### PR TITLE
chore: use `DataPayload` as input/output format for Execute()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/iancoleman/strcase v0.2.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230523000406-299e9451af13
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230615091607-d5e75c7bc0dd
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	go.uber.org/zap v1.24.0
 	google.golang.org/protobuf v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230523000406-299e9451af13 h1:qC0Xe0zCpmgq02vClxL4OS1ZLjDmFUn/KuJOtJxINmI=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230523000406-299e9451af13/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230615091607-d5e75c7bc0dd h1:Tu2JRlXKZpC5AfoZO23xf8AkDZxvxqr/Ve+Yw1GtKS8=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230615091607-d5e75c7bc0dd/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/Y25WS6cokEszi5g+S0QxI/d45PkRi7Nk=
 github.com/jackc/pgx/v5 v5.3.0 h1:/NQi8KHMpKWHInxXesC8yD4DhkXPrVhmnwYkjp9AmBA=

--- a/pkg/base/connector.go
+++ b/pkg/base/connector.go
@@ -55,7 +55,7 @@ type IConnection interface {
 
 	// Functions that need to be implenmented in connector implenmentation
 	// Execute
-	Execute(input interface{}) (interface{}, error)
+	Execute(input []*connectorPB.DataPayload) ([]*connectorPB.DataPayload, error)
 	// Test connection
 	Test() (connectorPB.Connector_State, error)
 }


### PR DESCRIPTION
Because

- we defined a unified format for interchange data in pipeline

This commit

- use `DataPayload` as input/output format for Execute()
