### PR TITLE
chore: use `ConnectorResource_State` enum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/gofrs/uuid v4.4.0+incompatible
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230814104042-37ca0356defc
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/zap v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK8sZj0aUfI3TV1So=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230814104042-37ca0356defc h1:1akaOOUCsVU2yzFIb5KwVw5GRy7v+hyNmNmJD+2x+l8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230814104042-37ca0356defc/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa h1:QFj7GA+tLaxMCCIJfLMif2y0nPGDCU1+AJF08ORiRhQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230817132923-94c25875d8aa/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/base/connector.go
+++ b/pkg/base/connector.go
@@ -65,7 +65,7 @@ type IConnection interface {
 	// Execute
 	Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error)
 	// Test connection
-	Test() (connectorPB.Connector_State, error)
+	Test() (connectorPB.ConnectorResource_State, error)
 }
 
 type BaseConnection struct {


### PR DESCRIPTION
Because

- In proto, `Connector` has been renamed to `ConnectorResource`

This commit

- use `ConnectorResource_State` enum
