### PR TITLE
refactor(jsonschema): support instillUIOrder, instillEditOnNodeFields, instillShortDescription

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/h2non/filetype v1.1.3
-	github.com/instill-ai/component v0.6.0-alpha.0.20231024173356-e8d5bc4dc2cf
+	github.com/instill-ai/component v0.6.0-alpha.0.20231025152234-6831f3393759
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231019202606-71607ddcd93f
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
-github.com/instill-ai/component v0.6.0-alpha.0.20231024173356-e8d5bc4dc2cf h1:1el2FKfENgR949rnIvR64gYbe5wDHgCfrol0mzN2Oe8=
-github.com/instill-ai/component v0.6.0-alpha.0.20231024173356-e8d5bc4dc2cf/go.mod h1:Iy0XA86lTQdAp60+YLJmyKKKZu/ONq+JfmbmjLvyA6E=
+github.com/instill-ai/component v0.6.0-alpha.0.20231025152234-6831f3393759 h1:go3JnA03QryYa9axlEIn3+6kYiNDWPylv8Jwsp/EHCc=
+github.com/instill-ai/component v0.6.0-alpha.0.20231025152234-6831f3393759/go.mod h1:Iy0XA86lTQdAp60+YLJmyKKKZu/ONq+JfmbmjLvyA6E=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231019202606-71607ddcd93f h1:hweU93u6qsg8GH/YSogOfa+wOZEnkilGsijcy1xKX7E=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231019202606-71607ddcd93f/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/pkg/airbyte/config/definitions.json
+++ b/pkg/airbyte/config/definitions.json
@@ -887,7 +887,7 @@
         "ql": 400,
         "sl": 200
       },
-      "dockerImageTag": "2.1.0",
+      "dockerImageTag": "2.1.6",
       "dockerRepository": "airbyte/destination-bigquery",
       "githubIssueLabel": "destination-bigquery",
       "license": "ELv2",
@@ -1178,6 +1178,58 @@
                   }
                 },
                 "title": "Chroma Default Embedding Function",
+                "type": "object"
+              },
+              {
+                "description": "Use a service that's compatible with the OpenAI API to embed text.",
+                "properties": {
+                  "api_key": {
+                    "credential_field": true,
+                    "default": "",
+                    "title": "API key",
+                    "type": "string"
+                  },
+                  "base_url": {
+                    "description": "The base URL for your OpenAI-compatible service",
+                    "examples": [
+                      "https://your-service-name.com"
+                    ],
+                    "title": "Base URL",
+                    "type": "string"
+                  },
+                  "dimensions": {
+                    "description": "The number of dimensions the embedding model is generating",
+                    "examples": [
+                      1536,
+                      384
+                    ],
+                    "title": "Embedding dimensions",
+                    "type": "integer"
+                  },
+                  "mode": {
+                    "const": "openai_compatible",
+                    "default": "openai_compatible",
+                    "enum": [
+                      "openai_compatible"
+                    ],
+                    "title": "Mode",
+                    "type": "string"
+                  },
+                  "model_name": {
+                    "default": "text-embedding-ada-002",
+                    "description": "The name of the model to use for embedding",
+                    "examples": [
+                      "text-embedding-ada-002"
+                    ],
+                    "title": "Model name",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "base_url",
+                  "dimensions"
+                ],
+                "title": "OpenAI-compatible",
                 "type": "object"
               }
             ],
@@ -1470,13 +1522,13 @@
         "ql": 100,
         "sl": 100
       },
-      "dockerImageTag": "0.0.3",
+      "dockerImageTag": "0.0.4",
       "dockerRepository": "airbyte/destination-chroma",
       "githubIssueLabel": "destination-chroma",
       "license": "MIT",
       "releaseStage": "alpha",
       "resourceRequirements": {},
-      "sourceType": "database",
+      "sourceType": "vectorstore",
       "spec": {
         "supported_destination_sync_modes": [
           "overwrite",
@@ -2528,12 +2580,25 @@
     "available_tasks": [
       "TASK_WRITE_DESTINATION"
     ],
+    "connectorBuildOptions": {
+      "baseImage": "docker.io/airbyte/python-connector-base:1.1.0@sha256:bd98f6505c6764b1b5f99d3aedc23dfc9e9af631a62533f60eb32b1d3dbab20c"
+    },
     "custom": false,
     "documentation_url": "https://docs.airbyte.com/integrations/destinations/duckdb",
     "icon": "duckdb.svg",
     "icon_url": "https://connectors.airbyte.com/files/metadata/airbyte/destination-duckdb/latest/icon.svg",
     "id": "airbyte-destination-duckdb",
     "public": true,
+    "releases": {
+      "breakingChanges": {
+        "0.3.0": {
+          "message": "This version uses the DuckDB 0.9.1 database driver, which is not backwards compatible with prior versions. MotherDuck users can upgrade their database by visiting https://app.motherduck.com/ and accepting the upgrade. For more information, see the connector migration guide.",
+          "migrationDocumentationUrl": "https://docs.airbyte.com/integrations/destinations/duckdb-migrations#0.3.0",
+          "upgradeDeadline": "2023-10-31"
+        }
+      },
+      "migrationDocumentationUrl": "https://docs.airbyte.com/integrations/destinations/duckdb-migrations"
+    },
     "spec": {
       "resource_specification": {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -2580,7 +2645,7 @@
         "ql": 100,
         "sl": 100
       },
-      "dockerImageTag": "0.2.1",
+      "dockerImageTag": "0.3.0",
       "dockerRepository": "airbyte/destination-duckdb",
       "githubIssueLabel": "destination-duckdb",
       "license": "MIT",
@@ -5818,6 +5883,9 @@
     "available_tasks": [
       "TASK_WRITE_DESTINATION"
     ],
+    "connectorBuildOptions": {
+      "baseImage": "docker.io/airbyte/python-connector-base:1.1.0@sha256:bd98f6505c6764b1b5f99d3aedc23dfc9e9af631a62533f60eb32b1d3dbab20c"
+    },
     "custom": false,
     "documentation_url": "https://docs.airbyte.com/integrations/destinations/milvus",
     "icon": "milvus.svg",
@@ -5989,6 +6057,58 @@
                   "deployment"
                 ],
                 "title": "Azure OpenAI",
+                "type": "object"
+              },
+              {
+                "description": "Use a service that's compatible with the OpenAI API to embed text.",
+                "properties": {
+                  "api_key": {
+                    "credential_field": true,
+                    "default": "",
+                    "title": "API key",
+                    "type": "string"
+                  },
+                  "base_url": {
+                    "description": "The base URL for your OpenAI-compatible service",
+                    "examples": [
+                      "https://your-service-name.com"
+                    ],
+                    "title": "Base URL",
+                    "type": "string"
+                  },
+                  "dimensions": {
+                    "description": "The number of dimensions the embedding model is generating",
+                    "examples": [
+                      1536,
+                      384
+                    ],
+                    "title": "Embedding dimensions",
+                    "type": "integer"
+                  },
+                  "mode": {
+                    "const": "openai_compatible",
+                    "default": "openai_compatible",
+                    "enum": [
+                      "openai_compatible"
+                    ],
+                    "title": "Mode",
+                    "type": "string"
+                  },
+                  "model_name": {
+                    "default": "text-embedding-ada-002",
+                    "description": "The name of the model to use for embedding",
+                    "examples": [
+                      "text-embedding-ada-002"
+                    ],
+                    "title": "Model name",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "base_url",
+                  "dimensions"
+                ],
+                "title": "OpenAI-compatible",
                 "type": "object"
               }
             ],
@@ -6307,7 +6427,7 @@
         "ql": 300,
         "sl": 200
       },
-      "dockerImageTag": "0.0.4",
+      "dockerImageTag": "0.0.6",
       "dockerRepository": "airbyte/destination-milvus",
       "githubIssueLabel": "destination-milvus",
       "license": "MIT",
@@ -6323,7 +6443,7 @@
           }
         ]
       },
-      "sourceType": "database",
+      "sourceType": "vectorstore",
       "spec": {
         "supported_destination_sync_modes": [
           "overwrite",
@@ -7695,6 +7815,9 @@
     "available_tasks": [
       "TASK_WRITE_DESTINATION"
     ],
+    "connectorBuildOptions": {
+      "baseImage": "docker.io/airbyte/python-connector-base:1.1.0@sha256:bd98f6505c6764b1b5f99d3aedc23dfc9e9af631a62533f60eb32b1d3dbab20c"
+    },
     "custom": false,
     "documentation_url": "https://docs.airbyte.com/integrations/destinations/pinecone",
     "icon": "pinecone.svg",
@@ -7828,6 +7951,58 @@
                   "deployment"
                 ],
                 "title": "Azure OpenAI",
+                "type": "object"
+              },
+              {
+                "description": "Use a service that's compatible with the OpenAI API to embed text.",
+                "properties": {
+                  "api_key": {
+                    "credential_field": true,
+                    "default": "",
+                    "title": "API key",
+                    "type": "string"
+                  },
+                  "base_url": {
+                    "description": "The base URL for your OpenAI-compatible service",
+                    "examples": [
+                      "https://your-service-name.com"
+                    ],
+                    "title": "Base URL",
+                    "type": "string"
+                  },
+                  "dimensions": {
+                    "description": "The number of dimensions the embedding model is generating",
+                    "examples": [
+                      1536,
+                      384
+                    ],
+                    "title": "Embedding dimensions",
+                    "type": "integer"
+                  },
+                  "mode": {
+                    "const": "openai_compatible",
+                    "default": "openai_compatible",
+                    "enum": [
+                      "openai_compatible"
+                    ],
+                    "title": "Mode",
+                    "type": "string"
+                  },
+                  "model_name": {
+                    "default": "text-embedding-ada-002",
+                    "description": "The name of the model to use for embedding",
+                    "examples": [
+                      "text-embedding-ada-002"
+                    ],
+                    "title": "Model name",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "base_url",
+                  "dimensions"
+                ],
+                "title": "OpenAI-compatible",
                 "type": "object"
               }
             ],
@@ -8057,7 +8232,7 @@
         "ql": 300,
         "sl": 200
       },
-      "dockerImageTag": "0.0.15",
+      "dockerImageTag": "0.0.17",
       "dockerRepository": "airbyte/destination-pinecone",
       "githubIssueLabel": "destination-pinecone",
       "license": "MIT",
@@ -8073,7 +8248,7 @@
           }
         ]
       },
-      "sourceType": "database",
+      "sourceType": "vectorstore",
       "spec": {
         "supported_destination_sync_modes": [
           "overwrite",
@@ -8991,6 +9166,58 @@
                 ],
                 "title": "Azure OpenAI",
                 "type": "object"
+              },
+              {
+                "description": "Use a service that's compatible with the OpenAI API to embed text.",
+                "properties": {
+                  "api_key": {
+                    "credential_field": true,
+                    "default": "",
+                    "title": "API key",
+                    "type": "string"
+                  },
+                  "base_url": {
+                    "description": "The base URL for your OpenAI-compatible service",
+                    "examples": [
+                      "https://your-service-name.com"
+                    ],
+                    "title": "Base URL",
+                    "type": "string"
+                  },
+                  "dimensions": {
+                    "description": "The number of dimensions the embedding model is generating",
+                    "examples": [
+                      1536,
+                      384
+                    ],
+                    "title": "Embedding dimensions",
+                    "type": "integer"
+                  },
+                  "mode": {
+                    "const": "openai_compatible",
+                    "default": "openai_compatible",
+                    "enum": [
+                      "openai_compatible"
+                    ],
+                    "title": "Mode",
+                    "type": "string"
+                  },
+                  "model_name": {
+                    "default": "text-embedding-ada-002",
+                    "description": "The name of the model to use for embedding",
+                    "examples": [
+                      "text-embedding-ada-002"
+                    ],
+                    "title": "Model name",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "base_url",
+                  "dimensions"
+                ],
+                "title": "OpenAI-compatible",
+                "type": "object"
               }
             ],
             "title": "Embedding",
@@ -9292,7 +9519,7 @@
         "ql": 100,
         "sl": 100
       },
-      "dockerImageTag": "0.0.4",
+      "dockerImageTag": "0.0.5",
       "dockerRepository": "airbyte/destination-qdrant",
       "githubIssueLabel": "destination-qdrant",
       "license": "MIT",
@@ -9308,7 +9535,7 @@
           }
         ]
       },
-      "sourceType": "database",
+      "sourceType": "vectorstore",
       "spec": {
         "supported_destination_sync_modes": [
           "overwrite",
@@ -12079,7 +12306,7 @@
         "ql": 400,
         "sl": 200
       },
-      "dockerImageTag": "3.2.0",
+      "dockerImageTag": "3.2.3",
       "dockerRepository": "airbyte/destination-snowflake",
       "githubIssueLabel": "destination-snowflake",
       "license": "ELv2",
@@ -13331,6 +13558,9 @@
     "available_tasks": [
       "TASK_WRITE_DESTINATION"
     ],
+    "connectorBuildOptions": {
+      "baseImage": "docker.io/airbyte/python-connector-base:1.1.0@sha256:bd98f6505c6764b1b5f99d3aedc23dfc9e9af631a62533f60eb32b1d3dbab20c"
+    },
     "custom": false,
     "documentation_url": "https://docs.airbyte.com/integrations/destinations/weaviate",
     "icon": "weaviate.svg",
@@ -13527,6 +13757,58 @@
                   }
                 },
                 "title": "Fake",
+                "type": "object"
+              },
+              {
+                "description": "Use a service that's compatible with the OpenAI API to embed text.",
+                "properties": {
+                  "api_key": {
+                    "credential_field": true,
+                    "default": "",
+                    "title": "API key",
+                    "type": "string"
+                  },
+                  "base_url": {
+                    "description": "The base URL for your OpenAI-compatible service",
+                    "examples": [
+                      "https://your-service-name.com"
+                    ],
+                    "title": "Base URL",
+                    "type": "string"
+                  },
+                  "dimensions": {
+                    "description": "The number of dimensions the embedding model is generating",
+                    "examples": [
+                      1536,
+                      384
+                    ],
+                    "title": "Embedding dimensions",
+                    "type": "integer"
+                  },
+                  "mode": {
+                    "const": "openai_compatible",
+                    "default": "openai_compatible",
+                    "enum": [
+                      "openai_compatible"
+                    ],
+                    "title": "Mode",
+                    "type": "string"
+                  },
+                  "model_name": {
+                    "default": "text-embedding-ada-002",
+                    "description": "The name of the model to use for embedding",
+                    "examples": [
+                      "text-embedding-ada-002"
+                    ],
+                    "title": "Model name",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "base_url",
+                  "dimensions"
+                ],
+                "title": "OpenAI-compatible",
                 "type": "object"
               }
             ],
@@ -13877,7 +14159,7 @@
         "ql": 300,
         "sl": 200
       },
-      "dockerImageTag": "0.2.1",
+      "dockerImageTag": "0.2.3",
       "dockerRepository": "airbyte/destination-weaviate",
       "githubIssueLabel": "destination-weaviate",
       "license": "MIT",
@@ -13893,7 +14175,7 @@
           }
         ]
       },
-      "sourceType": "database",
+      "sourceType": "vectorstore",
       "spec": {
         "supported_destination_sync_modes": [
           "overwrite",

--- a/pkg/airbyte/config/tasks.json
+++ b/pkg/airbyte/config/tasks.json
@@ -1,25 +1,38 @@
 {
   "TASK_WRITE_DESTINATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "data": {
           "additionalProperties": false,
+          "instillUIOrder": 0,
           "patternProperties": {
             "^[a-zA-Z_][a-zA-Z_0-9]*$": {
               "instillFormat": "*",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
+                "value",
                 "reference",
                 "template"
               ],
-              "type": "string"
+              "title": "Data"
             }
           },
+          "required": [],
+          "title": "Input",
           "type": "object"
         }
       },
+      "required": [
+        "data"
+      ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
+      "required": [],
+      "title": "Output",
       "type": "object"
     }
   }

--- a/pkg/bigquery/config/definitions.json
+++ b/pkg/bigquery/config/definitions.json
@@ -16,26 +16,26 @@
         "properties": {
           "dataset_id": {
             "description": "Fill in your BigQuery Dataset ID.",
-            "order": 2,
+            "instillUIOrder": 2,
             "title": "BigQuery Dataset ID",
             "type": "string"
           },
           "json_key": {
             "credential_field": true,
             "description": "Contents of the JSON key file with access to the bucket.",
-            "order": 0,
+            "instillUIOrder": 0,
             "title": "JSON Key File contents",
             "type": "string"
           },
           "project_id": {
             "description": "Fill in your BigQuery Project ID.",
-            "order": 1,
+            "instillUIOrder": 1,
             "title": "BigQuery Project ID",
             "type": "string"
           },
           "table_name": {
             "description": "Fill in your BigQuery Table Name.",
-            "order": 3,
+            "instillUIOrder": 3,
             "title": "BigQuery Table Name",
             "type": "string"
           }

--- a/pkg/bigquery/config/tasks.json
+++ b/pkg/bigquery/config/tasks.json
@@ -1,32 +1,49 @@
 {
   "TASK_INSERT": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "data": {
           "additionalProperties": false,
+          "instillUIOrder": 0,
           "patternProperties": {
             "^[a-zA-Z_][a-zA-Z_0-9]*$": {
               "instillFormat": "*",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
+                "value",
                 "reference",
                 "template"
               ],
-              "type": "string"
+              "title": "Data"
             }
           },
+          "required": [],
+          "title": "Data",
           "type": "object"
         }
       },
+      "required": [
+        "data"
+      ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "status": {
           "description": "Status of the upload operation",
           "instillFormat": "text",
+          "instillUIOrder": 0,
+          "title": "Status",
           "type": "string"
         }
       },
+      "required": [
+        "status"
+      ],
+      "title": "Output",
       "type": "object"
     }
   }

--- a/pkg/googlecloudstorage/config/definitions.json
+++ b/pkg/googlecloudstorage/config/definitions.json
@@ -17,12 +17,14 @@
           "bucket_name": {
             "credential_field": false,
             "description": "Name of the bucket to be used for object storage.",
+            "instillUIOrder": 0,
             "title": "Bucket Name",
             "type": "string"
           },
           "json_key": {
             "credential_field": true,
             "description": "Contents of the JSON key file with access to the bucket.",
+            "instillUIOrder": 1,
             "title": "JSON Key File contents",
             "type": "string"
           }

--- a/pkg/googlecloudstorage/config/tasks.json
+++ b/pkg/googlecloudstorage/config/tasks.json
@@ -1,24 +1,29 @@
 {
   "TASK_UPLOAD": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "data": {
           "description": "The data to be saved in the object",
           "instillFormat": "text",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "value",
             "reference"
           ],
+          "title": "Data",
           "type": "string"
         },
         "object_name": {
           "description": "The name of the object to be created",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
+          "title": "Object Name",
           "type": "string"
         }
       },
@@ -26,14 +31,17 @@
         "object_name",
         "data"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "authenticated_url": {
           "description": "Only users granted permission can access the object with this link",
           "format": "uri",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "title": "Authenticated URL",
           "type": "string"
         },
@@ -41,28 +49,36 @@
           "description": "File path to this resource in Cloud Storage",
           "format": "uri",
           "instillFormat": "text",
-          "title": "gsutil URI",
+          "instillUIOrder": 1,
+          "title": "Gsutil URI",
           "type": "string"
         },
         "public_access": {
           "description": "Whether the object is publicly accessible",
           "instillFormat": "boolean",
-          "title": "Public access",
+          "instillUIOrder": 2,
+          "title": "Public Access",
           "type": "boolean"
         },
         "public_url": {
           "description": "Anyone with this link can access the object on the public Internet",
           "instillFormat": "text",
+          "instillUIOrder": 3,
           "title": "Public URL",
           "type": "string"
         },
         "status": {
           "description": "Status of the upload operation",
           "instillFormat": "text",
-          "title": "Upload status",
+          "instillUIOrder": 4,
+          "title": "Upload Status",
           "type": "string"
         }
       },
+      "required": [
+        "status"
+      ],
+      "title": "Output",
       "type": "object"
     }
   }

--- a/pkg/huggingface/config/definitions.json
+++ b/pkg/huggingface/config/definitions.json
@@ -2,7 +2,6 @@
   {
     "available_tasks": [
       "TASK_TEXT_GENERATION",
-      "TASK_TEXT_TO_IMAGE",
       "TASK_FILL_MASK",
       "TASK_SUMMARIZATION",
       "TASK_TEXT_CLASSIFICATION",
@@ -35,6 +34,7 @@
           "api_key": {
             "credential_field": true,
             "description": "Fill your Hugging face API token. To find your token, visit https://huggingface.co/settings/tokens.",
+            "instillUIOrder": 0,
             "title": "API Key",
             "type": "string"
           },
@@ -42,6 +42,7 @@
             "credential_field": false,
             "default": "https://api-inference.huggingface.co",
             "description": "Hostname for the endpoint. To use Inference API set to https://api-inference.huggingface.co, for Inference Endpoint set to your custom endpoint.",
+            "instillUIOrder": 1,
             "title": "Base URL",
             "type": "string"
           },
@@ -49,6 +50,7 @@
             "credential_field": false,
             "default": false,
             "description": "Fill true if you are using a custom Inference Endpoint and not the Inference API.",
+            "instillUIOrder": 2,
             "title": "Is Custom Endpoint",
             "type": "boolean"
           }

--- a/pkg/huggingface/config/seed/tasks.json
+++ b/pkg/huggingface/config/seed/tasks.json
@@ -4,89 +4,116 @@
       "instillFormat": "object",
       "properties": {
         "use_cache": {
+          "description": "There is a cache layer on the inference API to speedup requests we have already seen. Most models can use those results as is as models are deterministic (meaning the results will be the same anyway). However if you use a non deterministic model, you can set this parameter to prevent the caching mechanism from being used resulting in a real new query.",
           "instillFormat": "boolean",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference"
           ],
-          "type": "boolean"
-        },
-        "use_gpu": {
-          "instillFormat": "boolean",
-          "instillUpstreamTypes": [
-            "value",
-            "reference"
-          ],
+          "title": "Use Cache",
           "type": "boolean"
         },
         "wait_for_model": {
+          "description": "If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error as it will limit hanging in your application to known places.",
           "instillFormat": "boolean",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "value",
             "reference"
           ],
+          "title": "Wait For Model",
           "type": "boolean"
         }
       },
+      "required": [],
+      "title": "Options",
       "type": "object"
     },
     "string_input": {
       "instillFormat": "text",
+      "instillUIOrder": 0,
       "instillUpstreamTypes": [
         "value",
         "reference",
         "template"
       ],
+      "title": "String Input",
       "type": "string"
     }
   },
   "TASK_AUDIO_CLASSIFICATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "audio": {
           "instillFormat": "audio",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference"
           ],
+          "title": "Audio",
           "type": "string"
         }
       },
       "required": [
         "audio"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "classes": {
           "instillFormat": "object_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
             "properties": {
               "label": {
+                "description": "The label for the class (model specific)",
                 "instillFormat": "text",
+                "instillUIOrder": 0,
+                "title": "Label",
                 "type": "string"
               },
               "score": {
+                "description": "A float that represents how likely it is that the audio file belongs to this class.",
                 "instillFormat": "number",
+                "instillUIOrder": 1,
+                "title": "Score",
                 "type": "number"
               }
             },
+            "required": [
+              "label",
+              "score"
+            ],
             "type": "object"
           },
+          "title": "Classes",
           "type": "array"
         }
       },
+      "required": [
+        "classes"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_CONVERSATIONAL": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
+          "instillUIOrder": 0,
           "properties": {
             "generated_responses": {
+              "description": "A list of strings corresponding to the earlier replies from the model.",
               "instillFormat": "text_array",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
@@ -95,10 +122,13 @@
                 "instillFormat": "text",
                 "type": "string"
               },
+              "title": "Generated Responses",
               "type": "array"
             },
             "past_user_inputs": {
+              "description": "A list of strings corresponding to the earlier replies from the user. Should be of the same length of generated_responses.",
               "instillFormat": "text_array",
+              "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
@@ -107,145 +137,212 @@
                 "instillFormat": "text",
                 "type": "string"
               },
+              "title": "Past User Inputs",
               "type": "array"
             },
             "text": {
+              "description": "The last input from the user in the conversation.",
               "instillFormat": "text",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference",
                 "template"
               ],
+              "title": "Text",
               "type": "string"
             }
           },
           "required": [
             "text"
           ],
+          "title": "Inputs",
           "type": "object"
         },
         "options": {
-          "$ref": "#/$defs/options"
+          "$ref": "#/$defs/options",
+          "instillUIOrder": 2
         },
         "parameters": {
           "instillFormat": "object",
+          "instillUIOrder": 1,
           "properties": {
             "max_length": {
+              "description": "Integer to define the maximum length in tokens of the output summary.",
               "instillFormat": "integer",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Max Length",
               "type": "integer"
             },
             "max_time": {
+              "description": "The amount of time in seconds that the query should take maximum. Network can cause some overhead so it will be a soft limit.",
               "instillFormat": "number",
+              "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "maximum": 120.0,
+              "minimum": 0.0,
+              "title": "Max Time",
               "type": "number"
             },
             "min_length": {
+              "description": "Integer to define the minimum length in tokens of the output summary.",
               "instillFormat": "integer",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Min Length",
               "type": "integer"
             },
             "repetition_penalty": {
+              "description": "The more a token is used within generation the more it is penalized to not be picked in successive generation passes.",
               "instillFormat": "number",
+              "instillUIOrder": 3,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "maximum": 100.0,
+              "minimum": 0.0,
+              "title": "Repetition Penalty",
               "type": "number"
             },
             "temperature": {
+              "default": 1.0,
+              "description": "The temperature of the sampling operation. 1 means regular sampling, 0 means always take the highest score, 100.0 is getting closer to uniform probability.",
               "instillFormat": "number",
+              "instillUIOrder": 4,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "maximum": 100.0,
+              "minimum": 0.0,
+              "title": "Temperature",
               "type": "number"
             },
             "top_k": {
+              "description": "Integer to define the top tokens considered within the sample operation to create new text.",
               "instillFormat": "integer",
+              "instillUIOrder": 5,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Top K",
               "type": "integer"
             },
             "top_p": {
+              "description": "Float to define the tokens that are within the sample operation of text generation. Add tokens in the sample for more probable to least probable until the sum of the probabilities is greater than top_p.",
               "instillFormat": "number",
+              "instillUIOrder": 6,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Top P",
               "type": "number"
             }
           },
+          "required": [],
+          "title": "Parameters",
           "type": "object"
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "conversation": {
+          "description": "A facility dictionnary to send back for the next input (with the new user input addition).",
           "instillFormat": "object",
+          "instillUIOrder": 0,
           "properties": {
             "generated_responses": {
+              "description": "List of strings. The last outputs from the model in the conversation, after the model has run.",
               "instillFormat": "text_array",
+              "instillUIOrder": 0,
               "items": {
                 "instillFormat": "text",
                 "type": "string"
               },
+              "title": "Generated Responses",
               "type": "array"
             },
             "past_user_inputs": {
+              "description": "List of strings. The last inputs from the user in the conversation, after the model has run.",
               "instillFormat": "text_array",
+              "instillUIOrder": 1,
               "items": {
                 "instillFormat": "text",
                 "type": "string"
               },
+              "title": "Past User Inputs",
               "type": "array"
             }
           },
+          "required": [
+            "generated_responses",
+            "past_user_inputs"
+          ],
+          "title": "Conversation",
           "type": "object"
         },
         "generated_text": {
+          "description": "The answer of the bot",
           "instillFormat": "text",
+          "instillUIOrder": 1,
+          "title": "Generated Text",
           "type": "string"
         }
       },
+      "required": [
+        "generated_text"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_FEATURE_EXTRACTION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
-          "$ref": "#/$defs/string_input"
+          "$ref": "#/$defs/string_input",
+          "description": "a string or a list of strings to get the features from.",
+          "instillUIOrder": 0
         },
         "options": {
-          "$ref": "#/$defs/options"
+          "$ref": "#/$defs/options",
+          "instillUIOrder": 1
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "features": {
+          "description": "The numbers that are the representation features of the input.",
           "instillFormat": "number_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "number_array",
             "items": {
@@ -254,252 +351,373 @@
             },
             "type": "array"
           },
+          "title": "Features",
           "type": "array"
         }
       },
+      "required": [
+        "features"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_FILL_MASK": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
-          "$ref": "#/$defs/string_input"
+          "$ref": "#/$defs/string_input",
+          "description": "a string to be filled from, must contain the [MASK] token (check model card for exact name of the mask)",
+          "instillUIOrder": 0
         },
         "options": {
-          "$ref": "#/$defs/options"
+          "$ref": "#/$defs/options",
+          "instillUIOrder": 1
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "masks": {
           "instillFormat": "object_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
             "properties": {
               "score": {
+                "description": "The probability for this token.",
                 "instillFormat": "number",
+                "instillUIOrder": 0,
+                "title": "Score",
                 "type": "number"
               },
               "sequence": {
+                "description": "The actual sequence of tokens that ran against the model (may contain special tokens)",
                 "instillFormat": "text",
+                "instillUIOrder": 1,
+                "title": "Sequence",
                 "type": "string"
               },
               "token": {
+                "description": "The id of the token",
                 "instillFormat": "integer",
+                "instillUIOrder": 2,
+                "title": "Token",
                 "type": "integer"
               },
               "token_str": {
+                "description": "The string representation of the token",
                 "instillFormat": "text",
+                "instillUIOrder": 3,
+                "title": "Token Str",
                 "type": "string"
               }
             },
+            "required": [],
             "type": "object"
           },
+          "title": "Masks",
           "type": "array"
         }
       },
+      "required": [
+        "masks"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_IMAGE_CLASSIFICATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "image": {
           "instillFormat": "image",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference"
           ],
+          "title": "Image",
           "type": "string"
         }
       },
       "required": [
         "image"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "classes": {
           "instillFormat": "object_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
             "properties": {
               "label": {
+                "description": "The label for the class (model specific)",
                 "instillFormat": "text",
+                "instillUIOrder": 0,
+                "title": "Label",
                 "type": "string"
               },
               "score": {
+                "description": "A float that represents how likely it is that the image file belongs to this class.",
                 "instillFormat": "number",
+                "instillUIOrder": 0,
+                "title": "Score",
                 "type": "number"
               }
             },
+            "required": [
+              "label",
+              "score"
+            ],
             "type": "object"
           },
+          "title": "Classes",
           "type": "array"
         }
       },
+      "required": [
+        "classes"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_IMAGE_SEGMENTATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "image": {
           "instillFormat": "image",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference"
           ],
+          "title": "Image",
           "type": "string"
         }
       },
       "required": [
         "image"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "segments": {
           "instillFormat": "object_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
             "properties": {
               "label": {
+                "description": "The label for the class (model specific) of a segment.",
                 "instillFormat": "text",
+                "instillUIOrder": 0,
+                "title": "Label",
                 "type": "string"
               },
               "mask": {
+                "description": "A str (base64 str of a single channel black-and-white img) representing the mask of a segment.",
                 "instillFormat": "text",
+                "instillUIOrder": 1,
+                "title": "Mask",
                 "type": "string"
               },
               "score": {
+                "description": "A float that represents how likely it is that the segment belongs to the given class.",
                 "instillFormat": "number",
+                "instillUIOrder": 2,
+                "title": "Score",
                 "type": "number"
               }
             },
+            "required": [
+              "label",
+              "mask",
+              "score"
+            ],
             "type": "object"
           },
+          "title": "Segments",
           "type": "array"
         }
       },
+      "required": [
+        "segments"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_IMAGE_TO_TEXT": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "image": {
           "instillFormat": "image",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference"
           ],
+          "title": "Image",
           "type": "string"
         }
       },
       "required": [
         "image"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "text": {
           "instillFormat": "text",
+          "instillUIOrder": 0,
+          "title": "Text",
           "type": "string"
         }
       },
+      "required": [
+        "text"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_OBJECT_DETECTION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "image": {
           "instillFormat": "image",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference"
           ],
+          "title": "Image",
           "type": "string"
         }
       },
       "required": [
         "image"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "objects": {
           "instillFormat": "object_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
             "properties": {
               "box": {
+                "description": "A dict (with keys [xmin,ymin,xmax,ymax]) representing the bounding box of a detected object.",
                 "instillFormat": "object",
+                "instillUIOrder": 0,
                 "properties": {
                   "xmax": {
                     "instillFormat": "number",
+                    "instillUIOrder": 0,
+                    "title": "X Max",
                     "type": "number"
                   },
                   "xmin": {
                     "instillFormat": "number",
+                    "instillUIOrder": 1,
+                    "title": "X Min",
                     "type": "number"
                   },
                   "ymax": {
                     "instillFormat": "number",
+                    "instillUIOrder": 2,
+                    "title": "Y Max",
                     "type": "number"
                   },
                   "ymin": {
                     "instillFormat": "number",
+                    "instillUIOrder": 3,
+                    "title": "Y min",
                     "type": "number"
                   }
                 },
+                "title": "Box",
                 "type": "object"
               },
               "label": {
+                "description": "The label for the class (model specific) of a detected object.",
                 "instillFormat": "text",
+                "instillUIOrder": 1,
+                "title": "Label",
                 "type": "string"
               },
               "score": {
+                "description": "A float that represents how likely it is that the detected object belongs to the given class.",
                 "instillFormat": "number",
+                "instillUIOrder": 2,
+                "title": "Score",
                 "type": "number"
               }
             },
             "type": "object"
           },
+          "title": "Objects",
           "type": "array"
         }
       },
+      "required": [
+        "objects"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_QUESTION_ANSWERING": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
+          "instillUIOrder": 0,
           "properties": {
             "context": {
               "instillFormat": "text",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference",
                 "template"
               ],
+              "title": "Context",
               "type": "string"
             },
             "question": {
               "instillFormat": "text",
+              "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "value",
                 "reference",
                 "template"
               ],
+              "title": "Question",
               "type": "string"
             }
           },
@@ -507,46 +725,70 @@
             "question",
             "context"
           ],
+          "title": "Inputs",
           "type": "object"
         },
         "options": {
-          "$ref": "#/$defs/options"
+          "$ref": "#/$defs/options",
+          "instillUIOrder": 1
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "answer": {
+          "description": "A string that\u2019s the answer within the text.",
           "instillFormat": "text",
+          "instillUIOrder": 0,
+          "title": "Answer",
           "type": "string"
         },
-        "end": {
-          "instillFormat": "integer",
-          "type": "integer"
-        },
         "score": {
+          "description": "A float that represents how likely that the answer is correct",
           "instillFormat": "number",
+          "instillUIOrder": 2,
+          "title": "Score",
           "type": "number"
         },
         "start": {
+          "description": "The index (string wise) of the start of the answer within context.",
           "instillFormat": "integer",
+          "instillUIOrder": 3,
+          "title": "Start",
+          "type": "integer"
+        },
+        "stop": {
+          "description": "The index (string wise) of the stop of the answer within context.",
+          "instillFormat": "integer",
+          "instillUIOrder": 1,
+          "title": "Stop",
           "type": "integer"
         }
       },
+      "required": [
+        "answer"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_SENTENCE_SIMILARITY": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
+          "instillUIOrder": 0,
           "properties": {
             "sentences": {
+              "description": "A list of strings which will be compared against the source_sentence.",
               "instillFormat": "text_array",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
@@ -555,14 +797,18 @@
                 "instillFormat": "text",
                 "type": "string"
               },
+              "title": "Sentences",
               "type": "array"
             },
             "source_sentence": {
+              "description": "The string that you wish to compare the other strings with. This can be a phrase, sentence, or longer passage, depending on the model being used.",
               "instillFormat": "text",
+              "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Source Sentence",
               "type": "string"
             }
           },
@@ -570,165 +816,235 @@
             "source_sentence",
             "sentences"
           ],
+          "title": "Inputs",
           "type": "object"
         },
         "options": {
-          "$ref": "#/$defs/options"
+          "$ref": "#/$defs/options",
+          "instillUIOrder": 2
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "scores": {
+          "description": "The associated similarity score for each of the given strings",
           "instillFormat": "number_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "number",
             "type": "number"
           },
+          "title": "Scores",
           "type": "array"
         }
       },
+      "required": [
+        "scores"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_SPEECH_RECOGNITION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "audio": {
           "instillFormat": "audio",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference"
           ],
+          "title": "Audio",
           "type": "string"
         }
       },
       "required": [
         "audio"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "text": {
+          "description": "The string that was recognized within the audio file.",
           "instillFormat": "text",
+          "instillUIOrder": 0,
+          "title": "Text",
           "type": "string"
         }
       },
+      "required": [
+        "text"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_SUMMARIZATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
-          "$ref": "#/$defs/string_input"
+          "$ref": "#/$defs/string_input",
+          "instillUIOrder": 0
         },
         "options": {
-          "$ref": "#/$defs/options"
+          "$ref": "#/$defs/options",
+          "instillUIOrder": 2
         },
         "parameters": {
+          "instillUIOrder": 1,
           "properties": {
             "max_length": {
+              "description": "Integer to define the maximum length in tokens of the output summary.",
               "instillFormat": "integer",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Max Length",
               "type": "integer"
             },
             "max_time": {
               "instillFormat": "number",
+              "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "maximum": 120.0,
+              "minimum": 0.0,
+              "title": "Max Time",
               "type": "number"
             },
             "min_length": {
+              "description": "Integer to define the minimum length in tokens of the output summary.",
               "instillFormat": "integer",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Min Length",
               "type": "integer"
             },
             "repetition_penalty": {
+              "description": "The more a token is used within generation the more it is penalized to not be picked in successive generation passes.",
               "instillFormat": "number",
+              "instillUIOrder": 3,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "maximum": 100.0,
+              "minimum": 0.0,
+              "title": "Repetition Penalty",
               "type": "number"
             },
             "temperature": {
+              "default": 1.0,
+              "description": "The temperature of the sampling operation. 1 means regular sampling, 0 means always take the highest score, 100.0 is getting closer to uniform probability.",
               "instillFormat": "number",
+              "instillUIOrder": 4,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "maximum": 100.0,
+              "minimum": 0.0,
+              "title": "Temperature",
               "type": "number"
             },
             "top_k": {
+              "description": "Integer to define the top tokens considered within the sample operation to create new text.",
               "instillFormat": "integer",
+              "instillUIOrder": 5,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Top K",
               "type": "integer"
             },
             "top_p": {
+              "description": "Float to define the tokens that are within the sample operation of text generation. Add tokens in the sample for more probable to least probable until the sum of the probabilities is greater than top_p.",
               "instillFormat": "number",
+              "instillUIOrder": 6,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Top P",
               "type": "number"
             }
           },
+          "required": [],
+          "title": "Parameters",
           "type": "object"
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
-        "texts": {
-          "instillFormat": "text_array",
-          "items": {
-            "instillFormat": "text",
-            "type": "string"
-          },
-          "type": "array"
+        "summary_text": {
+          "description": "The string after summarization",
+          "instillFormat": "text",
+          "instillUIOrder": 0,
+          "title": "Summary Text",
+          "type": "string"
         }
       },
+      "required": [
+        "summary_text"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TABLE_QUESTION_ANSWERING": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
+          "instillUIOrder": 0,
           "properties": {
             "query": {
+              "description": "The query in plain text that you want to ask the table",
               "instillFormat": "text",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Query",
               "type": "string"
             },
             "table": {
+              "description": "A table of data represented as a dict of list where entries are headers and the lists are all the values, all lists must have the same size.",
               "instillFormat": "object",
+              "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "reference"
               ],
+              "required": [],
+              "title": "Table",
               "type": "object"
             }
           },
@@ -736,37 +1052,52 @@
             "query",
             "table"
           ],
+          "title": "Inputs",
           "type": "object"
         },
         "options": {
-          "$ref": "#/$defs/options"
+          "$ref": "#/$defs/options",
+          "instillUIOrder": 1
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "aggregator": {
+          "description": "The aggregator used to get the answer",
           "instillFormat": "text",
+          "instillUIOrder": 0,
+          "title": "Aggregator",
           "type": "string"
         },
         "answer": {
+          "description": "The plaintext answer",
           "instillFormat": "text",
+          "instillUIOrder": 1,
+          "title": "Answer",
           "type": "string"
         },
         "cells": {
+          "description": "a list of coordinates of the cells contents",
           "instillFormat": "text_array",
+          "instillUIOrder": 2,
           "items": {
             "instillFormat": "text",
             "type": "string"
           },
+          "title": "Cells",
           "type": "array"
         },
         "coordinates": {
+          "description": "a list of coordinates of the cells referenced in the answer",
           "instillFormat": "integer_array",
+          "instillUIOrder": 3,
           "items": {
             "instillFormat": "integer_array",
             "items": {
@@ -775,366 +1106,497 @@
             },
             "type": "array"
           },
+          "title": "Coordinates",
           "type": "array"
         }
       },
+      "required": [
+        "answer"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TEXT_CLASSIFICATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
-          "$ref": "#/$defs/string_input"
+          "$ref": "#/$defs/string_input",
+          "instillUIOrder": 0
         },
         "options": {
-          "$ref": "#/$defs/options"
+          "$ref": "#/$defs/options",
+          "instillUIOrder": 1
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "classes": {
           "instillFormat": "object_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
             "properties": {
               "label": {
+                "description": "The label for the class (model specific)",
                 "instillFormat": "text",
+                "instillUIOrder": 0,
+                "title": "Label",
                 "type": "string"
               },
               "score": {
+                "description": "A floats that represents how likely is that the text belongs the this class.",
                 "instillFormat": "text",
+                "instillUIOrder": 1,
+                "title": "Score",
                 "type": "number"
               }
             },
+            "required": [
+              "label",
+              "score"
+            ],
             "type": "object"
           },
+          "title": "Classes",
           "type": "array"
         }
       },
+      "required": [
+        "classes"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TEXT_GENERATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
-          "$ref": "#/$defs/string_input"
+          "$ref": "#/$defs/string_input",
+          "instillUIOrder": 0
         },
         "options": {
-          "$ref": "#/$defs/options"
+          "$ref": "#/$defs/options",
+          "instillUIOrder": 1
         },
         "parameters": {
+          "instillUIOrder": 1,
           "properties": {
             "do_sample": {
+              "description": "Whether or not to use sampling, use greedy decoding otherwise.",
               "instillFormat": "boolean",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Do Sample",
               "type": "boolean"
             },
             "max_new_tokens": {
+              "description": "The amount of new tokens to be generated, this does not include the input length it is a estimate of the size of generated text you want. Each new tokens slows down the request, so look for balance between response times and length of text generated.",
               "instillFormat": "integer",
+              "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Max New Tokens",
               "type": "integer"
             },
             "max_time": {
+              "description": "The amount of time in seconds that the query should take maximum. Network can cause some overhead so it will be a soft limit. Use that in combination with max_new_tokens for best results.",
               "instillFormat": "number",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Max Time",
               "type": "number"
             },
             "num_return_sequences": {
+              "description": "The number of proposition you want to be returned.",
               "instillFormat": "integer",
+              "instillUIOrder": 3,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Num Return Sequences",
               "type": "integer"
             },
             "repetition_penalty": {
+              "description": "The more a token is used within generation the more it is penalized to not be picked in successive generation passes.",
               "instillFormat": "number",
+              "instillUIOrder": 4,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Repetition Penalty",
               "type": "number"
             },
             "return_full_text": {
+              "description": "If set to False, the return results will not contain the original query making it easier for prompting.",
               "instillFormat": "boolean",
+              "instillUIOrder": 5,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Return Full Text",
               "type": "boolean"
             },
             "temperature": {
+              "description": "The temperature of the sampling operation. 1 means regular sampling, 0 means always take the highest score, 100.0 is getting closer to uniform probability.",
               "instillFormat": "number",
+              "instillUIOrder": 6,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Temperature",
               "type": "number"
             },
             "top_k": {
+              "description": "Integer to define the top tokens considered within the sample operation to create new text.",
               "instillFormat": "integer",
+              "instillUIOrder": 7,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Top K",
               "type": "integer"
             },
             "top_p": {
+              "description": "Float to define the tokens that are within the sample operation of text generation. Add tokens in the sample for more probable to least probable until the sum of the probabilities is greater than top_p.",
               "instillFormat": "number",
+              "instillUIOrder": 8,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Top P",
               "type": "number"
             }
           },
+          "required": [],
+          "title": "Parameters",
           "type": "object"
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
-        "classes": {
-          "instillFormat": "object_array",
-          "items": {
-            "instillFormat": "object",
-            "properties": {
-              "label": {
-                "instillFormat": "text",
-                "type": "string"
-              },
-              "score": {
-                "instillFormat": "number",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "type": "array"
+        "generated_text": {
+          "description": "The continuated string",
+          "instillFormat": "text",
+          "instillUIOrder": 1,
+          "title": "Generated Text",
+          "type": "string"
         }
       },
+      "required": [
+        "generated_text"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TEXT_TO_IMAGE": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
-          "$ref": "#/$defs/string_input"
+          "$ref": "#/$defs/string_input",
+          "instillUIOrder": 0
         },
         "options": {
-          "$ref": "#/$defs/options"
+          "$ref": "#/$defs/options",
+          "instillUIOrder": 2
         },
         "parameters": {
+          "instillUIOrder": 1,
           "properties": {
             "guidance_scale": {
               "instillFormat": "number",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Guidance Scale",
               "type": "number"
             },
             "height": {
               "instillFormat": "integer",
+              "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Height",
               "type": "integer"
             },
             "negative_prompt": {
               "instillFormat": "text",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference",
                 "template"
               ],
+              "title": "Negative Prompt",
               "type": "string"
             },
             "num_inference_steps": {
               "instillFormat": "integer",
+              "instillUIOrder": 3,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Num Inference Steps",
               "type": "integer"
             },
             "width": {
               "instillFormat": "integer",
+              "instillUIOrder": 4,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Width",
               "type": "integer"
             }
           },
+          "required": [],
+          "title": "Parameters",
           "type": "object"
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "image": {
           "instillFormat": "image",
+          "instillUIOrder": 0,
+          "title": "Image",
           "type": "string"
         }
       },
+      "required": [
+        "image"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TOKEN_CLASSIFICATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
-          "$ref": "#/$defs/string_input"
+          "$ref": "#/$defs/string_input",
+          "instillUIOrder": 0
         },
         "options": {
-          "$ref": "#/$defs/options"
+          "$ref": "#/$defs/options",
+          "instillUIOrder": 2
         },
         "parameters": {
+          "instillUIOrder": 1,
           "properties": {
             "aggregation_strategy": {
+              "description": "There are several aggregation strategies:\nnone: Every token gets classified without further aggregation.\nsimple: Entities are grouped according to the default schema (B-, I- tags get merged when the tag is similar).\nfirst: Same as the simple strategy except words cannot end up with different tags. Words will use the tag of the first token when there is ambiguity.\naverage: Same as the simple strategy except words cannot end up with different tags. Scores are averaged across tokens and then the maximum label is applied.\nmax: Same as the simple strategy except words cannot end up with different tags. Word entity will be the token with the maximum score.",
               "instillFormat": "text",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference",
                 "template"
               ],
+              "title": "Aggregation Strategy",
               "type": "string"
             }
           },
+          "required": [],
+          "title": "Parameters",
           "type": "object"
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "masks": {
           "instillFormat": "object_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
             "properties": {
               "end": {
+                "description": "The offset stringwise where the answer is located. Useful to disambiguate if word occurs multiple times.",
                 "instillFormat": "integer",
+                "instillUIOrder": 0,
+                "title": "End",
                 "type": "integer"
               },
               "entity_group": {
+                "description": "The type for the entity being recognized (model specific).",
                 "instillFormat": "text",
+                "instillUIOrder": 1,
+                "title": "Entity Group",
                 "type": "string"
               },
               "score": {
+                "description": "How likely the entity was recognized.",
                 "instillFormat": "number",
+                "instillUIOrder": 2,
+                "title": "Score",
                 "type": "number"
               },
               "start": {
+                "description": "The offset stringwise where the answer is located. Useful to disambiguate if word occurs multiple times.",
                 "instillFormat": "integer",
+                "instillUIOrder": 3,
+                "title": "Start",
                 "type": "integer"
               },
               "word": {
+                "description": "The string that was captured",
                 "instillFormat": "text",
+                "instillUIOrder": 4,
+                "title": "Word",
                 "type": "string"
               }
             },
+            "required": [],
             "type": "object"
           },
+          "title": "Masks",
           "type": "array"
         }
       },
+      "required": [
+        "masks"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TRANSLATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
-          "$ref": "#/$defs/string_input"
+          "$ref": "#/$defs/string_input",
+          "instillUIOrder": 0
         },
         "options": {
-          "$ref": "#/$defs/options"
+          "$ref": "#/$defs/options",
+          "instillUIOrder": 1
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
-        "texts": {
-          "instillFormat": "text_array",
-          "items": {
-            "instillFormat": "text",
-            "type": "string"
-          },
-          "type": "array"
+        "translation_text": {
+          "description": "The string after translation",
+          "instillFormat": "text",
+          "instillUIOrder": 0,
+          "title": "Translation Text",
+          "type": "sting"
         }
       },
+      "required": [
+        "translation_text"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_ZERO_SHOT_CLASSIFICATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
-          "$ref": "#/$defs/string_input"
+          "$ref": "#/$defs/string_input",
+          "instillUIOrder": 0
         },
         "options": {
-          "$ref": "#/$defs/options"
+          "$ref": "#/$defs/options",
+          "instillUIOrder": 2
         },
         "parameters": {
+          "instillUIOrder": 1,
           "properties": {
             "candidate_labels": {
+              "description": "a list of strings that are potential classes for inputs. (max 10 candidate_labels, for more, simply run multiple requests, results are going to be misleading if using too many candidate_labels anyway. If you want to keep the exact same, you can simply run multi_label=True and do the scaling on your end. )",
               "instillFormat": "text_array",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
               "items": {
+                "title": "candidate_label",
                 "type": "string"
               },
+              "title": "Candidate Labels",
               "type": "array"
             },
             "multi_label": {
+              "description": "Boolean that is set to True if classes can overlap",
               "instillFormat": "boolean_array",
+              "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Multi Label",
               "type": "boolean"
             }
           },
           "required": [
             "candidate_labels"
           ],
+          "title": "Parameters",
           "type": "object"
         }
       },
@@ -1142,19 +1604,46 @@
         "inputs",
         "parameters"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
-        "texts": {
+        "labels": {
+          "description": "The list of strings for labels that you sent (in order)",
           "instillFormat": "text_array",
+          "instillUIOrder": 1,
           "items": {
             "instillFormat": "text",
             "type": "string"
           },
+          "title": "Labels",
+          "type": "array"
+        },
+        "scores": {
+          "description": "a list of floats that correspond the the probability of label, in the same order as labels.",
+          "instillFormat": "number_array",
+          "instillUIOrder": 0,
+          "items": {
+            "instillFormat": "number",
+            "type": "number"
+          },
+          "title": "Scores",
+          "type": "array"
+        },
+        "sequence": {
+          "description": "The string sent as an input",
+          "instillFormat": "text",
+          "instillUIOrder": 1,
+          "title": "Texts",
           "type": "array"
         }
       },
+      "required": [
+        "texts"
+      ],
+      "title": "Output",
       "type": "object"
     }
   }

--- a/pkg/huggingface/config/tasks.json
+++ b/pkg/huggingface/config/tasks.json
@@ -4,89 +4,116 @@
       "instillFormat": "object",
       "properties": {
         "use_cache": {
+          "description": "There is a cache layer on the inference API to speedup requests we have already seen. Most models can use those results as is as models are deterministic (meaning the results will be the same anyway). However if you use a non deterministic model, you can set this parameter to prevent the caching mechanism from being used resulting in a real new query.",
           "instillFormat": "boolean",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference"
           ],
-          "type": "boolean"
-        },
-        "use_gpu": {
-          "instillFormat": "boolean",
-          "instillUpstreamTypes": [
-            "value",
-            "reference"
-          ],
+          "title": "Use Cache",
           "type": "boolean"
         },
         "wait_for_model": {
+          "description": "If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error as it will limit hanging in your application to known places.",
           "instillFormat": "boolean",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "value",
             "reference"
           ],
+          "title": "Wait For Model",
           "type": "boolean"
         }
       },
+      "required": [],
+      "title": "Options",
       "type": "object"
     },
     "string_input": {
       "instillFormat": "text",
+      "instillUIOrder": 0,
       "instillUpstreamTypes": [
         "value",
         "reference",
         "template"
       ],
+      "title": "String Input",
       "type": "string"
     }
   },
   "TASK_AUDIO_CLASSIFICATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "audio": {
           "instillFormat": "audio",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference"
           ],
+          "title": "Audio",
           "type": "string"
         }
       },
       "required": [
         "audio"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "classes": {
           "instillFormat": "object_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
             "properties": {
               "label": {
+                "description": "The label for the class (model specific)",
                 "instillFormat": "text",
+                "instillUIOrder": 0,
+                "title": "Label",
                 "type": "string"
               },
               "score": {
+                "description": "A float that represents how likely it is that the audio file belongs to this class.",
                 "instillFormat": "number",
+                "instillUIOrder": 1,
+                "title": "Score",
                 "type": "number"
               }
             },
+            "required": [
+              "label",
+              "score"
+            ],
             "type": "object"
           },
+          "title": "Classes",
           "type": "array"
         }
       },
+      "required": [
+        "classes"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_CONVERSATIONAL": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
+          "instillUIOrder": 0,
           "properties": {
             "generated_responses": {
+              "description": "A list of strings corresponding to the earlier replies from the model.",
               "instillFormat": "text_array",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
@@ -95,10 +122,13 @@
                 "instillFormat": "text",
                 "type": "string"
               },
+              "title": "Generated Responses",
               "type": "array"
             },
             "past_user_inputs": {
+              "description": "A list of strings corresponding to the earlier replies from the user. Should be of the same length of generated_responses.",
               "instillFormat": "text_array",
+              "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
@@ -107,205 +137,273 @@
                 "instillFormat": "text",
                 "type": "string"
               },
+              "title": "Past User Inputs",
               "type": "array"
             },
             "text": {
+              "description": "The last input from the user in the conversation.",
               "instillFormat": "text",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference",
                 "template"
               ],
+              "title": "Text",
               "type": "string"
             }
           },
           "required": [
             "text"
           ],
+          "title": "Inputs",
           "type": "object"
         },
         "options": {
           "instillFormat": "object",
+          "instillUIOrder": 2,
           "properties": {
             "use_cache": {
+              "description": "There is a cache layer on the inference API to speedup requests we have already seen. Most models can use those results as is as models are deterministic (meaning the results will be the same anyway). However if you use a non deterministic model, you can set this parameter to prevent the caching mechanism from being used resulting in a real new query.",
               "instillFormat": "boolean",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
-              "type": "boolean"
-            },
-            "use_gpu": {
-              "instillFormat": "boolean",
-              "instillUpstreamTypes": [
-                "value",
-                "reference"
-              ],
+              "title": "Use Cache",
               "type": "boolean"
             },
             "wait_for_model": {
+              "description": "If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error as it will limit hanging in your application to known places.",
               "instillFormat": "boolean",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Wait For Model",
               "type": "boolean"
             }
           },
+          "required": [],
+          "title": "Options",
           "type": "object"
         },
         "parameters": {
           "instillFormat": "object",
+          "instillUIOrder": 1,
           "properties": {
             "max_length": {
+              "description": "Integer to define the maximum length in tokens of the output summary.",
               "instillFormat": "integer",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Max Length",
               "type": "integer"
             },
             "max_time": {
+              "description": "The amount of time in seconds that the query should take maximum. Network can cause some overhead so it will be a soft limit.",
               "instillFormat": "number",
+              "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "maximum": 120.0,
+              "minimum": 0.0,
+              "title": "Max Time",
               "type": "number"
             },
             "min_length": {
+              "description": "Integer to define the minimum length in tokens of the output summary.",
               "instillFormat": "integer",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Min Length",
               "type": "integer"
             },
             "repetition_penalty": {
+              "description": "The more a token is used within generation the more it is penalized to not be picked in successive generation passes.",
               "instillFormat": "number",
+              "instillUIOrder": 3,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "maximum": 100.0,
+              "minimum": 0.0,
+              "title": "Repetition Penalty",
               "type": "number"
             },
             "temperature": {
+              "default": 1.0,
+              "description": "The temperature of the sampling operation. 1 means regular sampling, 0 means always take the highest score, 100.0 is getting closer to uniform probability.",
               "instillFormat": "number",
+              "instillUIOrder": 4,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "maximum": 100.0,
+              "minimum": 0.0,
+              "title": "Temperature",
               "type": "number"
             },
             "top_k": {
+              "description": "Integer to define the top tokens considered within the sample operation to create new text.",
               "instillFormat": "integer",
+              "instillUIOrder": 5,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Top K",
               "type": "integer"
             },
             "top_p": {
+              "description": "Float to define the tokens that are within the sample operation of text generation. Add tokens in the sample for more probable to least probable until the sum of the probabilities is greater than top_p.",
               "instillFormat": "number",
+              "instillUIOrder": 6,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Top P",
               "type": "number"
             }
           },
+          "required": [],
+          "title": "Parameters",
           "type": "object"
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "conversation": {
+          "description": "A facility dictionnary to send back for the next input (with the new user input addition).",
           "instillFormat": "object",
+          "instillUIOrder": 0,
           "properties": {
             "generated_responses": {
+              "description": "List of strings. The last outputs from the model in the conversation, after the model has run.",
               "instillFormat": "text_array",
+              "instillUIOrder": 0,
               "items": {
                 "instillFormat": "text",
                 "type": "string"
               },
+              "title": "Generated Responses",
               "type": "array"
             },
             "past_user_inputs": {
+              "description": "List of strings. The last inputs from the user in the conversation, after the model has run.",
               "instillFormat": "text_array",
+              "instillUIOrder": 1,
               "items": {
                 "instillFormat": "text",
                 "type": "string"
               },
+              "title": "Past User Inputs",
               "type": "array"
             }
           },
+          "required": [
+            "generated_responses",
+            "past_user_inputs"
+          ],
+          "title": "Conversation",
           "type": "object"
         },
         "generated_text": {
+          "description": "The answer of the bot",
           "instillFormat": "text",
+          "instillUIOrder": 1,
+          "title": "Generated Text",
           "type": "string"
         }
       },
+      "required": [
+        "generated_text"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_FEATURE_EXTRACTION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
+          "description": "a string or a list of strings to get the features from.",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
+          "title": "String Input",
           "type": "string"
         },
         "options": {
           "instillFormat": "object",
+          "instillUIOrder": 1,
           "properties": {
             "use_cache": {
+              "description": "There is a cache layer on the inference API to speedup requests we have already seen. Most models can use those results as is as models are deterministic (meaning the results will be the same anyway). However if you use a non deterministic model, you can set this parameter to prevent the caching mechanism from being used resulting in a real new query.",
               "instillFormat": "boolean",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
-              "type": "boolean"
-            },
-            "use_gpu": {
-              "instillFormat": "boolean",
-              "instillUpstreamTypes": [
-                "value",
-                "reference"
-              ],
+              "title": "Use Cache",
               "type": "boolean"
             },
             "wait_for_model": {
+              "description": "If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error as it will limit hanging in your application to known places.",
               "instillFormat": "boolean",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Wait For Model",
               "type": "boolean"
             }
           },
+          "required": [],
+          "title": "Options",
           "type": "object"
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "features": {
+          "description": "The numbers that are the representation features of the input.",
           "instillFormat": "number_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "number_array",
             "items": {
@@ -314,285 +412,407 @@
             },
             "type": "array"
           },
+          "title": "Features",
           "type": "array"
         }
       },
+      "required": [
+        "features"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_FILL_MASK": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
+          "description": "a string to be filled from, must contain the [MASK] token (check model card for exact name of the mask)",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
+          "title": "String Input",
           "type": "string"
         },
         "options": {
           "instillFormat": "object",
+          "instillUIOrder": 1,
           "properties": {
             "use_cache": {
+              "description": "There is a cache layer on the inference API to speedup requests we have already seen. Most models can use those results as is as models are deterministic (meaning the results will be the same anyway). However if you use a non deterministic model, you can set this parameter to prevent the caching mechanism from being used resulting in a real new query.",
               "instillFormat": "boolean",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
-              "type": "boolean"
-            },
-            "use_gpu": {
-              "instillFormat": "boolean",
-              "instillUpstreamTypes": [
-                "value",
-                "reference"
-              ],
+              "title": "Use Cache",
               "type": "boolean"
             },
             "wait_for_model": {
+              "description": "If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error as it will limit hanging in your application to known places.",
               "instillFormat": "boolean",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Wait For Model",
               "type": "boolean"
             }
           },
+          "required": [],
+          "title": "Options",
           "type": "object"
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "masks": {
           "instillFormat": "object_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
             "properties": {
               "score": {
+                "description": "The probability for this token.",
                 "instillFormat": "number",
+                "instillUIOrder": 0,
+                "title": "Score",
                 "type": "number"
               },
               "sequence": {
+                "description": "The actual sequence of tokens that ran against the model (may contain special tokens)",
                 "instillFormat": "text",
+                "instillUIOrder": 1,
+                "title": "Sequence",
                 "type": "string"
               },
               "token": {
+                "description": "The id of the token",
                 "instillFormat": "integer",
+                "instillUIOrder": 2,
+                "title": "Token",
                 "type": "integer"
               },
               "token_str": {
+                "description": "The string representation of the token",
                 "instillFormat": "text",
+                "instillUIOrder": 3,
+                "title": "Token Str",
                 "type": "string"
               }
             },
+            "required": [],
             "type": "object"
           },
+          "title": "Masks",
           "type": "array"
         }
       },
+      "required": [
+        "masks"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_IMAGE_CLASSIFICATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "image": {
           "instillFormat": "image",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference"
           ],
+          "title": "Image",
           "type": "string"
         }
       },
       "required": [
         "image"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "classes": {
           "instillFormat": "object_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
             "properties": {
               "label": {
+                "description": "The label for the class (model specific)",
                 "instillFormat": "text",
+                "instillUIOrder": 0,
+                "title": "Label",
                 "type": "string"
               },
               "score": {
+                "description": "A float that represents how likely it is that the image file belongs to this class.",
                 "instillFormat": "number",
+                "instillUIOrder": 0,
+                "title": "Score",
                 "type": "number"
               }
             },
+            "required": [
+              "label",
+              "score"
+            ],
             "type": "object"
           },
+          "title": "Classes",
           "type": "array"
         }
       },
+      "required": [
+        "classes"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_IMAGE_SEGMENTATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "image": {
           "instillFormat": "image",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference"
           ],
+          "title": "Image",
           "type": "string"
         }
       },
       "required": [
         "image"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "segments": {
           "instillFormat": "object_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
             "properties": {
               "label": {
+                "description": "The label for the class (model specific) of a segment.",
                 "instillFormat": "text",
+                "instillUIOrder": 0,
+                "title": "Label",
                 "type": "string"
               },
               "mask": {
+                "description": "A str (base64 str of a single channel black-and-white img) representing the mask of a segment.",
                 "instillFormat": "text",
+                "instillUIOrder": 1,
+                "title": "Mask",
                 "type": "string"
               },
               "score": {
+                "description": "A float that represents how likely it is that the segment belongs to the given class.",
                 "instillFormat": "number",
+                "instillUIOrder": 2,
+                "title": "Score",
                 "type": "number"
               }
             },
+            "required": [
+              "label",
+              "mask",
+              "score"
+            ],
             "type": "object"
           },
+          "title": "Segments",
           "type": "array"
         }
       },
+      "required": [
+        "segments"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_IMAGE_TO_TEXT": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "image": {
           "instillFormat": "image",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference"
           ],
+          "title": "Image",
           "type": "string"
         }
       },
       "required": [
         "image"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "text": {
           "instillFormat": "text",
+          "instillUIOrder": 0,
+          "title": "Text",
           "type": "string"
         }
       },
+      "required": [
+        "text"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_OBJECT_DETECTION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "image": {
           "instillFormat": "image",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference"
           ],
+          "title": "Image",
           "type": "string"
         }
       },
       "required": [
         "image"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "objects": {
           "instillFormat": "object_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
             "properties": {
               "box": {
+                "description": "A dict (with keys [xmin,ymin,xmax,ymax]) representing the bounding box of a detected object.",
                 "instillFormat": "object",
+                "instillUIOrder": 0,
                 "properties": {
                   "xmax": {
                     "instillFormat": "number",
+                    "instillUIOrder": 0,
+                    "title": "X Max",
                     "type": "number"
                   },
                   "xmin": {
                     "instillFormat": "number",
+                    "instillUIOrder": 1,
+                    "title": "X Min",
                     "type": "number"
                   },
                   "ymax": {
                     "instillFormat": "number",
+                    "instillUIOrder": 2,
+                    "title": "Y Max",
                     "type": "number"
                   },
                   "ymin": {
                     "instillFormat": "number",
+                    "instillUIOrder": 3,
+                    "title": "Y min",
                     "type": "number"
                   }
                 },
+                "title": "Box",
                 "type": "object"
               },
               "label": {
+                "description": "The label for the class (model specific) of a detected object.",
                 "instillFormat": "text",
+                "instillUIOrder": 1,
+                "title": "Label",
                 "type": "string"
               },
               "score": {
+                "description": "A float that represents how likely it is that the detected object belongs to the given class.",
                 "instillFormat": "number",
+                "instillUIOrder": 2,
+                "title": "Score",
                 "type": "number"
               }
             },
             "type": "object"
           },
+          "title": "Objects",
           "type": "array"
         }
       },
+      "required": [
+        "objects"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_QUESTION_ANSWERING": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
+          "instillUIOrder": 0,
           "properties": {
             "context": {
               "instillFormat": "text",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference",
                 "template"
               ],
+              "title": "Context",
               "type": "string"
             },
             "question": {
               "instillFormat": "text",
+              "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "value",
                 "reference",
                 "template"
               ],
+              "title": "Question",
               "type": "string"
             }
           },
@@ -600,73 +820,97 @@
             "question",
             "context"
           ],
+          "title": "Inputs",
           "type": "object"
         },
         "options": {
           "instillFormat": "object",
+          "instillUIOrder": 1,
           "properties": {
             "use_cache": {
+              "description": "There is a cache layer on the inference API to speedup requests we have already seen. Most models can use those results as is as models are deterministic (meaning the results will be the same anyway). However if you use a non deterministic model, you can set this parameter to prevent the caching mechanism from being used resulting in a real new query.",
               "instillFormat": "boolean",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
-              "type": "boolean"
-            },
-            "use_gpu": {
-              "instillFormat": "boolean",
-              "instillUpstreamTypes": [
-                "value",
-                "reference"
-              ],
+              "title": "Use Cache",
               "type": "boolean"
             },
             "wait_for_model": {
+              "description": "If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error as it will limit hanging in your application to known places.",
               "instillFormat": "boolean",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Wait For Model",
               "type": "boolean"
             }
           },
+          "required": [],
+          "title": "Options",
           "type": "object"
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "answer": {
+          "description": "A string that\u2019s the answer within the text.",
           "instillFormat": "text",
+          "instillUIOrder": 0,
+          "title": "Answer",
           "type": "string"
         },
-        "end": {
-          "instillFormat": "integer",
-          "type": "integer"
-        },
         "score": {
+          "description": "A float that represents how likely that the answer is correct",
           "instillFormat": "number",
+          "instillUIOrder": 2,
+          "title": "Score",
           "type": "number"
         },
         "start": {
+          "description": "The index (string wise) of the start of the answer within context.",
           "instillFormat": "integer",
+          "instillUIOrder": 3,
+          "title": "Start",
+          "type": "integer"
+        },
+        "stop": {
+          "description": "The index (string wise) of the stop of the answer within context.",
+          "instillFormat": "integer",
+          "instillUIOrder": 1,
+          "title": "Stop",
           "type": "integer"
         }
       },
+      "required": [
+        "answer"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_SENTENCE_SIMILARITY": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
+          "instillUIOrder": 0,
           "properties": {
             "sentences": {
+              "description": "A list of strings which will be compared against the source_sentence.",
               "instillFormat": "text_array",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
@@ -675,14 +919,18 @@
                 "instillFormat": "text",
                 "type": "string"
               },
+              "title": "Sentences",
               "type": "array"
             },
             "source_sentence": {
+              "description": "The string that you wish to compare the other strings with. This can be a phrase, sentence, or longer passage, depending on the model being used.",
               "instillFormat": "text",
+              "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Source Sentence",
               "type": "string"
             }
           },
@@ -690,225 +938,296 @@
             "source_sentence",
             "sentences"
           ],
+          "title": "Inputs",
           "type": "object"
         },
         "options": {
           "instillFormat": "object",
+          "instillUIOrder": 2,
           "properties": {
             "use_cache": {
+              "description": "There is a cache layer on the inference API to speedup requests we have already seen. Most models can use those results as is as models are deterministic (meaning the results will be the same anyway). However if you use a non deterministic model, you can set this parameter to prevent the caching mechanism from being used resulting in a real new query.",
               "instillFormat": "boolean",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
-              "type": "boolean"
-            },
-            "use_gpu": {
-              "instillFormat": "boolean",
-              "instillUpstreamTypes": [
-                "value",
-                "reference"
-              ],
+              "title": "Use Cache",
               "type": "boolean"
             },
             "wait_for_model": {
+              "description": "If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error as it will limit hanging in your application to known places.",
               "instillFormat": "boolean",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Wait For Model",
               "type": "boolean"
             }
           },
+          "required": [],
+          "title": "Options",
           "type": "object"
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "scores": {
+          "description": "The associated similarity score for each of the given strings",
           "instillFormat": "number_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "number",
             "type": "number"
           },
+          "title": "Scores",
           "type": "array"
         }
       },
+      "required": [
+        "scores"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_SPEECH_RECOGNITION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "audio": {
           "instillFormat": "audio",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference"
           ],
+          "title": "Audio",
           "type": "string"
         }
       },
       "required": [
         "audio"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "text": {
+          "description": "The string that was recognized within the audio file.",
           "instillFormat": "text",
+          "instillUIOrder": 0,
+          "title": "Text",
           "type": "string"
         }
       },
+      "required": [
+        "text"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_SUMMARIZATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
+          "title": "String Input",
           "type": "string"
         },
         "options": {
           "instillFormat": "object",
+          "instillUIOrder": 2,
           "properties": {
             "use_cache": {
+              "description": "There is a cache layer on the inference API to speedup requests we have already seen. Most models can use those results as is as models are deterministic (meaning the results will be the same anyway). However if you use a non deterministic model, you can set this parameter to prevent the caching mechanism from being used resulting in a real new query.",
               "instillFormat": "boolean",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
-              "type": "boolean"
-            },
-            "use_gpu": {
-              "instillFormat": "boolean",
-              "instillUpstreamTypes": [
-                "value",
-                "reference"
-              ],
+              "title": "Use Cache",
               "type": "boolean"
             },
             "wait_for_model": {
+              "description": "If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error as it will limit hanging in your application to known places.",
               "instillFormat": "boolean",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Wait For Model",
               "type": "boolean"
             }
           },
+          "required": [],
+          "title": "Options",
           "type": "object"
         },
         "parameters": {
+          "instillUIOrder": 1,
           "properties": {
             "max_length": {
+              "description": "Integer to define the maximum length in tokens of the output summary.",
               "instillFormat": "integer",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Max Length",
               "type": "integer"
             },
             "max_time": {
               "instillFormat": "number",
+              "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "maximum": 120.0,
+              "minimum": 0.0,
+              "title": "Max Time",
               "type": "number"
             },
             "min_length": {
+              "description": "Integer to define the minimum length in tokens of the output summary.",
               "instillFormat": "integer",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Min Length",
               "type": "integer"
             },
             "repetition_penalty": {
+              "description": "The more a token is used within generation the more it is penalized to not be picked in successive generation passes.",
               "instillFormat": "number",
+              "instillUIOrder": 3,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "maximum": 100.0,
+              "minimum": 0.0,
+              "title": "Repetition Penalty",
               "type": "number"
             },
             "temperature": {
+              "default": 1.0,
+              "description": "The temperature of the sampling operation. 1 means regular sampling, 0 means always take the highest score, 100.0 is getting closer to uniform probability.",
               "instillFormat": "number",
+              "instillUIOrder": 4,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "maximum": 100.0,
+              "minimum": 0.0,
+              "title": "Temperature",
               "type": "number"
             },
             "top_k": {
+              "description": "Integer to define the top tokens considered within the sample operation to create new text.",
               "instillFormat": "integer",
+              "instillUIOrder": 5,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Top K",
               "type": "integer"
             },
             "top_p": {
+              "description": "Float to define the tokens that are within the sample operation of text generation. Add tokens in the sample for more probable to least probable until the sum of the probabilities is greater than top_p.",
               "instillFormat": "number",
+              "instillUIOrder": 6,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Top P",
               "type": "number"
             }
           },
+          "required": [],
+          "title": "Parameters",
           "type": "object"
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
-        "texts": {
-          "instillFormat": "text_array",
-          "items": {
-            "instillFormat": "text",
-            "type": "string"
-          },
-          "type": "array"
+        "summary_text": {
+          "description": "The string after summarization",
+          "instillFormat": "text",
+          "instillUIOrder": 0,
+          "title": "Summary Text",
+          "type": "string"
         }
       },
+      "required": [
+        "summary_text"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TABLE_QUESTION_ANSWERING": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
+          "instillUIOrder": 0,
           "properties": {
             "query": {
+              "description": "The query in plain text that you want to ask the table",
               "instillFormat": "text",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Query",
               "type": "string"
             },
             "table": {
+              "description": "A table of data represented as a dict of list where entries are headers and the lists are all the values, all lists must have the same size.",
               "instillFormat": "object",
+              "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "reference"
               ],
+              "required": [],
+              "title": "Table",
               "type": "object"
             }
           },
@@ -916,64 +1235,79 @@
             "query",
             "table"
           ],
+          "title": "Inputs",
           "type": "object"
         },
         "options": {
           "instillFormat": "object",
+          "instillUIOrder": 1,
           "properties": {
             "use_cache": {
+              "description": "There is a cache layer on the inference API to speedup requests we have already seen. Most models can use those results as is as models are deterministic (meaning the results will be the same anyway). However if you use a non deterministic model, you can set this parameter to prevent the caching mechanism from being used resulting in a real new query.",
               "instillFormat": "boolean",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
-              "type": "boolean"
-            },
-            "use_gpu": {
-              "instillFormat": "boolean",
-              "instillUpstreamTypes": [
-                "value",
-                "reference"
-              ],
+              "title": "Use Cache",
               "type": "boolean"
             },
             "wait_for_model": {
+              "description": "If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error as it will limit hanging in your application to known places.",
               "instillFormat": "boolean",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Wait For Model",
               "type": "boolean"
             }
           },
+          "required": [],
+          "title": "Options",
           "type": "object"
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "aggregator": {
+          "description": "The aggregator used to get the answer",
           "instillFormat": "text",
+          "instillUIOrder": 0,
+          "title": "Aggregator",
           "type": "string"
         },
         "answer": {
+          "description": "The plaintext answer",
           "instillFormat": "text",
+          "instillUIOrder": 1,
+          "title": "Answer",
           "type": "string"
         },
         "cells": {
+          "description": "a list of coordinates of the cells contents",
           "instillFormat": "text_array",
+          "instillUIOrder": 2,
           "items": {
             "instillFormat": "text",
             "type": "string"
           },
+          "title": "Cells",
           "type": "array"
         },
         "coordinates": {
+          "description": "a list of coordinates of the cells referenced in the answer",
           "instillFormat": "integer_array",
+          "instillUIOrder": 3,
           "items": {
             "instillFormat": "integer_array",
             "items": {
@@ -982,564 +1316,701 @@
             },
             "type": "array"
           },
+          "title": "Coordinates",
           "type": "array"
         }
       },
+      "required": [
+        "answer"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TEXT_CLASSIFICATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
+          "title": "String Input",
           "type": "string"
         },
         "options": {
           "instillFormat": "object",
+          "instillUIOrder": 1,
           "properties": {
             "use_cache": {
+              "description": "There is a cache layer on the inference API to speedup requests we have already seen. Most models can use those results as is as models are deterministic (meaning the results will be the same anyway). However if you use a non deterministic model, you can set this parameter to prevent the caching mechanism from being used resulting in a real new query.",
               "instillFormat": "boolean",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
-              "type": "boolean"
-            },
-            "use_gpu": {
-              "instillFormat": "boolean",
-              "instillUpstreamTypes": [
-                "value",
-                "reference"
-              ],
+              "title": "Use Cache",
               "type": "boolean"
             },
             "wait_for_model": {
+              "description": "If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error as it will limit hanging in your application to known places.",
               "instillFormat": "boolean",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Wait For Model",
               "type": "boolean"
             }
           },
+          "required": [],
+          "title": "Options",
           "type": "object"
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "classes": {
           "instillFormat": "object_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
             "properties": {
               "label": {
+                "description": "The label for the class (model specific)",
                 "instillFormat": "text",
+                "instillUIOrder": 0,
+                "title": "Label",
                 "type": "string"
               },
               "score": {
+                "description": "A floats that represents how likely is that the text belongs the this class.",
                 "instillFormat": "text",
+                "instillUIOrder": 1,
+                "title": "Score",
                 "type": "number"
               }
             },
+            "required": [
+              "label",
+              "score"
+            ],
             "type": "object"
           },
+          "title": "Classes",
           "type": "array"
         }
       },
+      "required": [
+        "classes"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TEXT_GENERATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
+          "title": "String Input",
           "type": "string"
         },
         "options": {
           "instillFormat": "object",
+          "instillUIOrder": 1,
           "properties": {
             "use_cache": {
+              "description": "There is a cache layer on the inference API to speedup requests we have already seen. Most models can use those results as is as models are deterministic (meaning the results will be the same anyway). However if you use a non deterministic model, you can set this parameter to prevent the caching mechanism from being used resulting in a real new query.",
               "instillFormat": "boolean",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
-              "type": "boolean"
-            },
-            "use_gpu": {
-              "instillFormat": "boolean",
-              "instillUpstreamTypes": [
-                "value",
-                "reference"
-              ],
+              "title": "Use Cache",
               "type": "boolean"
             },
             "wait_for_model": {
+              "description": "If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error as it will limit hanging in your application to known places.",
               "instillFormat": "boolean",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Wait For Model",
               "type": "boolean"
             }
           },
+          "required": [],
+          "title": "Options",
           "type": "object"
         },
         "parameters": {
+          "instillUIOrder": 1,
           "properties": {
             "do_sample": {
+              "description": "Whether or not to use sampling, use greedy decoding otherwise.",
               "instillFormat": "boolean",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Do Sample",
               "type": "boolean"
             },
             "max_new_tokens": {
+              "description": "The amount of new tokens to be generated, this does not include the input length it is a estimate of the size of generated text you want. Each new tokens slows down the request, so look for balance between response times and length of text generated.",
               "instillFormat": "integer",
+              "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Max New Tokens",
               "type": "integer"
             },
             "max_time": {
+              "description": "The amount of time in seconds that the query should take maximum. Network can cause some overhead so it will be a soft limit. Use that in combination with max_new_tokens for best results.",
               "instillFormat": "number",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Max Time",
               "type": "number"
             },
             "num_return_sequences": {
+              "description": "The number of proposition you want to be returned.",
               "instillFormat": "integer",
+              "instillUIOrder": 3,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Num Return Sequences",
               "type": "integer"
             },
             "repetition_penalty": {
+              "description": "The more a token is used within generation the more it is penalized to not be picked in successive generation passes.",
               "instillFormat": "number",
+              "instillUIOrder": 4,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Repetition Penalty",
               "type": "number"
             },
             "return_full_text": {
+              "description": "If set to False, the return results will not contain the original query making it easier for prompting.",
               "instillFormat": "boolean",
+              "instillUIOrder": 5,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Return Full Text",
               "type": "boolean"
             },
             "temperature": {
+              "description": "The temperature of the sampling operation. 1 means regular sampling, 0 means always take the highest score, 100.0 is getting closer to uniform probability.",
               "instillFormat": "number",
+              "instillUIOrder": 6,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Temperature",
               "type": "number"
             },
             "top_k": {
+              "description": "Integer to define the top tokens considered within the sample operation to create new text.",
               "instillFormat": "integer",
+              "instillUIOrder": 7,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Top K",
               "type": "integer"
             },
             "top_p": {
+              "description": "Float to define the tokens that are within the sample operation of text generation. Add tokens in the sample for more probable to least probable until the sum of the probabilities is greater than top_p.",
               "instillFormat": "number",
+              "instillUIOrder": 8,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Top P",
               "type": "number"
             }
           },
+          "required": [],
+          "title": "Parameters",
           "type": "object"
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
-        "classes": {
-          "instillFormat": "object_array",
-          "items": {
-            "instillFormat": "object",
-            "properties": {
-              "label": {
-                "instillFormat": "text",
-                "type": "string"
-              },
-              "score": {
-                "instillFormat": "number",
-                "type": "number"
-              }
-            },
-            "type": "object"
-          },
-          "type": "array"
+        "generated_text": {
+          "description": "The continuated string",
+          "instillFormat": "text",
+          "instillUIOrder": 1,
+          "title": "Generated Text",
+          "type": "string"
         }
       },
+      "required": [
+        "generated_text"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TEXT_TO_IMAGE": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
+          "title": "String Input",
           "type": "string"
         },
         "options": {
           "instillFormat": "object",
+          "instillUIOrder": 2,
           "properties": {
             "use_cache": {
+              "description": "There is a cache layer on the inference API to speedup requests we have already seen. Most models can use those results as is as models are deterministic (meaning the results will be the same anyway). However if you use a non deterministic model, you can set this parameter to prevent the caching mechanism from being used resulting in a real new query.",
               "instillFormat": "boolean",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
-              "type": "boolean"
-            },
-            "use_gpu": {
-              "instillFormat": "boolean",
-              "instillUpstreamTypes": [
-                "value",
-                "reference"
-              ],
+              "title": "Use Cache",
               "type": "boolean"
             },
             "wait_for_model": {
+              "description": "If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error as it will limit hanging in your application to known places.",
               "instillFormat": "boolean",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Wait For Model",
               "type": "boolean"
             }
           },
+          "required": [],
+          "title": "Options",
           "type": "object"
         },
         "parameters": {
+          "instillUIOrder": 1,
           "properties": {
             "guidance_scale": {
               "instillFormat": "number",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Guidance Scale",
               "type": "number"
             },
             "height": {
               "instillFormat": "integer",
+              "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Height",
               "type": "integer"
             },
             "negative_prompt": {
               "instillFormat": "text",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference",
                 "template"
               ],
+              "title": "Negative Prompt",
               "type": "string"
             },
             "num_inference_steps": {
               "instillFormat": "integer",
+              "instillUIOrder": 3,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Num Inference Steps",
               "type": "integer"
             },
             "width": {
               "instillFormat": "integer",
+              "instillUIOrder": 4,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Width",
               "type": "integer"
             }
           },
+          "required": [],
+          "title": "Parameters",
           "type": "object"
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "image": {
           "instillFormat": "image",
+          "instillUIOrder": 0,
+          "title": "Image",
           "type": "string"
         }
       },
+      "required": [
+        "image"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TOKEN_CLASSIFICATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
+          "title": "String Input",
           "type": "string"
         },
         "options": {
           "instillFormat": "object",
+          "instillUIOrder": 2,
           "properties": {
             "use_cache": {
+              "description": "There is a cache layer on the inference API to speedup requests we have already seen. Most models can use those results as is as models are deterministic (meaning the results will be the same anyway). However if you use a non deterministic model, you can set this parameter to prevent the caching mechanism from being used resulting in a real new query.",
               "instillFormat": "boolean",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
-              "type": "boolean"
-            },
-            "use_gpu": {
-              "instillFormat": "boolean",
-              "instillUpstreamTypes": [
-                "value",
-                "reference"
-              ],
+              "title": "Use Cache",
               "type": "boolean"
             },
             "wait_for_model": {
+              "description": "If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error as it will limit hanging in your application to known places.",
               "instillFormat": "boolean",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Wait For Model",
               "type": "boolean"
             }
           },
+          "required": [],
+          "title": "Options",
           "type": "object"
         },
         "parameters": {
+          "instillUIOrder": 1,
           "properties": {
             "aggregation_strategy": {
+              "description": "There are several aggregation strategies:\nnone: Every token gets classified without further aggregation.\nsimple: Entities are grouped according to the default schema (B-, I- tags get merged when the tag is similar).\nfirst: Same as the simple strategy except words cannot end up with different tags. Words will use the tag of the first token when there is ambiguity.\naverage: Same as the simple strategy except words cannot end up with different tags. Scores are averaged across tokens and then the maximum label is applied.\nmax: Same as the simple strategy except words cannot end up with different tags. Word entity will be the token with the maximum score.",
               "instillFormat": "text",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference",
                 "template"
               ],
+              "title": "Aggregation Strategy",
               "type": "string"
             }
           },
+          "required": [],
+          "title": "Parameters",
           "type": "object"
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "masks": {
           "instillFormat": "object_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
             "properties": {
               "end": {
+                "description": "The offset stringwise where the answer is located. Useful to disambiguate if word occurs multiple times.",
                 "instillFormat": "integer",
+                "instillUIOrder": 0,
+                "title": "End",
                 "type": "integer"
               },
               "entity_group": {
+                "description": "The type for the entity being recognized (model specific).",
                 "instillFormat": "text",
+                "instillUIOrder": 1,
+                "title": "Entity Group",
                 "type": "string"
               },
               "score": {
+                "description": "How likely the entity was recognized.",
                 "instillFormat": "number",
+                "instillUIOrder": 2,
+                "title": "Score",
                 "type": "number"
               },
               "start": {
+                "description": "The offset stringwise where the answer is located. Useful to disambiguate if word occurs multiple times.",
                 "instillFormat": "integer",
+                "instillUIOrder": 3,
+                "title": "Start",
                 "type": "integer"
               },
               "word": {
+                "description": "The string that was captured",
                 "instillFormat": "text",
+                "instillUIOrder": 4,
+                "title": "Word",
                 "type": "string"
               }
             },
+            "required": [],
             "type": "object"
           },
+          "title": "Masks",
           "type": "array"
         }
       },
+      "required": [
+        "masks"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TRANSLATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
+          "title": "String Input",
           "type": "string"
         },
         "options": {
           "instillFormat": "object",
+          "instillUIOrder": 1,
           "properties": {
             "use_cache": {
+              "description": "There is a cache layer on the inference API to speedup requests we have already seen. Most models can use those results as is as models are deterministic (meaning the results will be the same anyway). However if you use a non deterministic model, you can set this parameter to prevent the caching mechanism from being used resulting in a real new query.",
               "instillFormat": "boolean",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
-              "type": "boolean"
-            },
-            "use_gpu": {
-              "instillFormat": "boolean",
-              "instillUpstreamTypes": [
-                "value",
-                "reference"
-              ],
+              "title": "Use Cache",
               "type": "boolean"
             },
             "wait_for_model": {
+              "description": "If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error as it will limit hanging in your application to known places.",
               "instillFormat": "boolean",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Wait For Model",
               "type": "boolean"
             }
           },
+          "required": [],
+          "title": "Options",
           "type": "object"
         }
       },
       "required": [
         "inputs"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
-        "texts": {
-          "instillFormat": "text_array",
-          "items": {
-            "instillFormat": "text",
-            "type": "string"
-          },
-          "type": "array"
+        "translation_text": {
+          "description": "The string after translation",
+          "instillFormat": "text",
+          "instillUIOrder": 0,
+          "title": "Translation Text",
+          "type": "sting"
         }
       },
+      "required": [
+        "translation_text"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_ZERO_SHOT_CLASSIFICATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "inputs": {
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
+          "title": "String Input",
           "type": "string"
         },
         "options": {
           "instillFormat": "object",
+          "instillUIOrder": 2,
           "properties": {
             "use_cache": {
+              "description": "There is a cache layer on the inference API to speedup requests we have already seen. Most models can use those results as is as models are deterministic (meaning the results will be the same anyway). However if you use a non deterministic model, you can set this parameter to prevent the caching mechanism from being used resulting in a real new query.",
               "instillFormat": "boolean",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
-              "type": "boolean"
-            },
-            "use_gpu": {
-              "instillFormat": "boolean",
-              "instillUpstreamTypes": [
-                "value",
-                "reference"
-              ],
+              "title": "Use Cache",
               "type": "boolean"
             },
             "wait_for_model": {
+              "description": "If the model is not ready, wait for it instead of receiving 503. It limits the number of requests required to get your inference done. It is advised to only set this flag to true after receiving a 503 error as it will limit hanging in your application to known places.",
               "instillFormat": "boolean",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Wait For Model",
               "type": "boolean"
             }
           },
+          "required": [],
+          "title": "Options",
           "type": "object"
         },
         "parameters": {
+          "instillUIOrder": 1,
           "properties": {
             "candidate_labels": {
+              "description": "a list of strings that are potential classes for inputs. (max 10 candidate_labels, for more, simply run multiple requests, results are going to be misleading if using too many candidate_labels anyway. If you want to keep the exact same, you can simply run multi_label=True and do the scaling on your end. )",
               "instillFormat": "text_array",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
               "items": {
+                "title": "candidate_label",
                 "type": "string"
               },
+              "title": "Candidate Labels",
               "type": "array"
             },
             "multi_label": {
+              "description": "Boolean that is set to True if classes can overlap",
               "instillFormat": "boolean_array",
+              "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "value",
                 "reference"
               ],
+              "title": "Multi Label",
               "type": "boolean"
             }
           },
           "required": [
             "candidate_labels"
           ],
+          "title": "Parameters",
           "type": "object"
         }
       },
@@ -1547,19 +2018,46 @@
         "inputs",
         "parameters"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
-        "texts": {
+        "labels": {
+          "description": "The list of strings for labels that you sent (in order)",
           "instillFormat": "text_array",
+          "instillUIOrder": 1,
           "items": {
             "instillFormat": "text",
             "type": "string"
           },
+          "title": "Labels",
+          "type": "array"
+        },
+        "scores": {
+          "description": "a list of floats that correspond the the probability of label, in the same order as labels.",
+          "instillFormat": "number_array",
+          "instillUIOrder": 0,
+          "items": {
+            "instillFormat": "number",
+            "type": "number"
+          },
+          "title": "Scores",
+          "type": "array"
+        },
+        "sequence": {
+          "description": "The string sent as an input",
+          "instillFormat": "text",
+          "instillUIOrder": 1,
+          "title": "Texts",
           "type": "array"
         }
       },
+      "required": [
+        "texts"
+      ],
+      "title": "Output",
       "type": "object"
     }
   }

--- a/pkg/huggingface/structs.go
+++ b/pkg/huggingface/structs.go
@@ -286,7 +286,7 @@ type QuestionAnsweringResponse struct {
 	Start int `json:"start,omitempty"`
 
 	// The string index of the stop of the answer within Context.
-	End int `json:"end,omitempty"`
+	Stop int `json:"stop,omitempty"`
 }
 
 // Request structure for table question answering model

--- a/pkg/instill/config/definitions.json
+++ b/pkg/instill/config/definitions.json
@@ -24,12 +24,14 @@
           "api_token": {
             "credential_field": true,
             "description": "To access models on Instill Cloud, enter your Instill Cloud API Token. You can find your tokens by visiting your Instill Cloud's Settings > API Tokens page. Leave this field empty to access models on your local Instill Model.",
+            "instillUIOrder": 0,
             "title": "API Token",
             "type": "string"
           },
           "server_url": {
             "default": "https://api-model.instill.tech",
             "description": "Base URL for the Instill Model API. To access models on Instill Cloud, use the base URL `https://api.instill.tech`. To access models on your local Instill Model, use the base URL `http://api-gateway:8080`.",
+            "instillUIOrder": 1,
             "title": "Server URL",
             "type": "string"
           }

--- a/pkg/instill/config/seed/tasks.json
+++ b/pkg/instill/config/seed/tasks.json
@@ -1,9 +1,18 @@
 {
   "$defs": {
     "common": {
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "image_base64",
+        "model_namespace",
+        "model_id"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "image_base64": {
+          "description": "Image base64",
           "instillFormat": "image",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -13,17 +22,19 @@
         "model_id": {
           "description": "ID of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
-          "title": "Model Id",
+          "title": "Model ID",
           "type": "string"
         },
         "model_namespace": {
           "description": "Namespace of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -38,6 +49,7 @@
         "model_namespace",
         "model_id"
       ],
+      "title": "Input",
       "type": "object"
     }
   },
@@ -47,7 +59,10 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/classification",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/6831f339375950f3f04429416124be96cbdd623a/shared_schema.json#/$defs/instill_types/classification",
+      "description": "Output",
+      "instillUIOrder": 0,
+      "title": "Output",
       "type": "object"
     }
   },
@@ -57,7 +72,10 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/detection",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/6831f339375950f3f04429416124be96cbdd623a/shared_schema.json#/$defs/instill_types/detection",
+      "description": "Output",
+      "instillUIOrder": 0,
+      "title": "Output",
       "type": "object"
     }
   },
@@ -67,7 +85,10 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/instance_segmentation",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/6831f339375950f3f04429416124be96cbdd623a/shared_schema.json#/$defs/instill_types/instance_segmentation",
+      "description": "Output",
+      "instillUIOrder": 0,
+      "title": "Output",
       "type": "object"
     }
   },
@@ -77,7 +98,10 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/keypoint",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/6831f339375950f3f04429416124be96cbdd623a/shared_schema.json#/$defs/instill_types/keypoint",
+      "description": "Output",
+      "instillUIOrder": 0,
+      "title": "Output",
       "type": "object"
     }
   },
@@ -87,7 +111,10 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/ocr",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/6831f339375950f3f04429416124be96cbdd623a/shared_schema.json#/$defs/instill_types/ocr",
+      "description": "Output",
+      "instillUIOrder": 0,
+      "title": "Output",
       "type": "object"
     }
   },
@@ -97,15 +124,27 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/semantic_segmentation",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/6831f339375950f3f04429416124be96cbdd623a/shared_schema.json#/$defs/instill_types/semantic_segmentation",
+      "description": "Output",
+      "instillUIOrder": 0,
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TEXT_GENERATION": {
     "input": {
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "prompt",
+        "model_namespace",
+        "model_id"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "bad_words_list": {
+          "description": "Bad words list",
           "instillFormat": "text",
+          "instillUIOrder": 4,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -117,17 +156,19 @@
         "model_id": {
           "description": "ID of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
-          "title": "Model Id",
+          "title": "Model ID",
           "type": "string"
         },
         "model_namespace": {
           "description": "Namespace of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -137,7 +178,9 @@
           "type": "string"
         },
         "output_len": {
+          "description": "Output length",
           "instillFormat": "integer",
+          "instillUIOrder": 6,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -146,7 +189,9 @@
           "type": "integer"
         },
         "prompt": {
+          "description": "Prompt",
           "instillFormat": "text",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -156,7 +201,9 @@
           "type": "string"
         },
         "seed": {
+          "description": "Seed",
           "instillFormat": "integer",
+          "instillUIOrder": 3,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -165,7 +212,9 @@
           "type": "integer"
         },
         "stop_words_list": {
+          "description": "Stop words list",
           "instillFormat": "text",
+          "instillUIOrder": 6,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -175,7 +224,9 @@
           "type": "string"
         },
         "top_k": {
+          "description": "Top K",
           "instillFormat": "integer",
+          "instillUIOrder": 5,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -189,23 +240,45 @@
         "model_namespace",
         "model_id"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "description": "Output",
+      "instillEditOnNodeFields": [
+        "text"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "text": {
+          "description": "Text",
           "instillFormat": "text",
+          "instillUIOrder": 0,
+          "title": "Text",
           "type": "string"
         }
       },
+      "required": [
+        "text"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TEXT_TO_IMAGE": {
     "input": {
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "prompt",
+        "model_namespace",
+        "model_id"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "cfg_scale": {
+          "description": "CFG Scale",
           "instillFormat": "number",
+          "instillUIOrder": 3,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -216,17 +289,19 @@
         "model_id": {
           "description": "ID of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
-          "title": "Model Id",
+          "title": "Model ID",
           "type": "string"
         },
         "model_namespace": {
           "description": "Namespace of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -236,7 +311,9 @@
           "type": "string"
         },
         "prompt": {
+          "description": "Prompt",
           "instillFormat": "text",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -246,7 +323,9 @@
           "type": "string"
         },
         "samples": {
+          "description": "Samples",
           "instillFormat": "integer",
+          "instillUIOrder": 4,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -255,7 +334,9 @@
           "type": "integer"
         },
         "seed": {
+          "description": "Seed",
           "instillFormat": "integer",
+          "instillUIOrder": 5,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -264,7 +345,9 @@
           "type": "integer"
         },
         "steps": {
+          "description": "Steps",
           "instillFormat": "integer",
+          "instillUIOrder": 6,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -278,19 +361,32 @@
         "model_namespace",
         "model_id"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "description": "Output",
+      "instillEditOnNodeFields": [
+        "images"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "images": {
+          "description": "Images",
           "instillFormat": "image_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "image",
             "type": "string"
           },
+          "title": "Images",
           "type": "array"
         }
       },
+      "required": [
+        "images"
+      ],
+      "title": "Output",
       "type": "object"
     }
   }

--- a/pkg/instill/config/tasks.json
+++ b/pkg/instill/config/tasks.json
@@ -1,9 +1,18 @@
 {
   "$defs": {
     "common": {
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "image_base64",
+        "model_namespace",
+        "model_id"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "image_base64": {
+          "description": "Image base64",
           "instillFormat": "image",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -13,17 +22,19 @@
         "model_id": {
           "description": "ID of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
-          "title": "Model Id",
+          "title": "Model ID",
           "type": "string"
         },
         "model_namespace": {
           "description": "Namespace of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -38,14 +49,24 @@
         "model_namespace",
         "model_id"
       ],
+      "title": "Input",
       "type": "object"
     }
   },
   "TASK_CLASSIFICATION": {
     "input": {
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "image_base64",
+        "model_namespace",
+        "model_id"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "image_base64": {
+          "description": "Image base64",
           "instillFormat": "image",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -55,17 +76,19 @@
         "model_id": {
           "description": "ID of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
-          "title": "Model Id",
+          "title": "Model ID",
           "type": "string"
         },
         "model_namespace": {
           "description": "Namespace of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -80,20 +103,27 @@
         "model_namespace",
         "model_id"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
       "additionalProperties": false,
+      "description": "Output",
       "instillFormat": "object",
+      "instillUIOrder": 0,
       "properties": {
         "category": {
           "description": "The predicted category of the input.",
           "instillFormat": "text",
+          "instillUIOrder": 0,
+          "title": "Category",
           "type": "string"
         },
         "score": {
           "description": "The confidence score of the predicted category of the input.",
           "instillFormat": "number",
+          "instillUIOrder": 1,
+          "title": "Score",
           "type": "number"
         }
       },
@@ -101,14 +131,24 @@
         "category",
         "score"
       ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_DETECTION": {
     "input": {
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "image_base64",
+        "model_namespace",
+        "model_id"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "image_base64": {
+          "description": "Image base64",
           "instillFormat": "image",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -118,17 +158,19 @@
         "model_id": {
           "description": "ID of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
-          "title": "Model Id",
+          "title": "Model ID",
           "type": "string"
         },
         "model_namespace": {
           "description": "Namespace of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -143,15 +185,19 @@
         "model_namespace",
         "model_id"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
       "additionalProperties": false,
+      "description": "Output",
       "instillFormat": "object",
+      "instillUIOrder": 0,
       "properties": {
         "objects": {
           "description": "A list of detected objects.",
           "instillFormat": "object_array",
+          "instillUIOrder": 0,
           "items": {
             "additionalProperties": false,
             "instillFormat": "object",
@@ -160,25 +206,34 @@
                 "additionalProperties": false,
                 "description": "The detected bounding box in (left, top, width, height) format.",
                 "instillFormat": "object",
+                "instillUIOrder": 1,
                 "properties": {
                   "height": {
                     "description": "Bounding box height value",
                     "instillFormat": "number",
+                    "instillUIOrder": 3,
+                    "title": "Height",
                     "type": "number"
                   },
                   "left": {
                     "description": "Bounding box left x-axis value",
                     "instillFormat": "number",
+                    "instillUIOrder": 0,
+                    "title": "Left",
                     "type": "number"
                   },
                   "top": {
                     "description": "Bounding box top y-axis value",
                     "instillFormat": "number",
+                    "instillUIOrder": 1,
+                    "title": "Top",
                     "type": "number"
                   },
                   "width": {
                     "description": "Bounding box width value",
                     "instillFormat": "number",
+                    "instillUIOrder": 2,
+                    "title": "Width",
                     "type": "number"
                   }
                 },
@@ -188,16 +243,21 @@
                   "width",
                   "height"
                 ],
+                "title": "Bounding box",
                 "type": "object"
               },
               "category": {
                 "description": "The predicted category of the bounding box.",
                 "instillFormat": "text",
+                "instillUIOrder": 2,
+                "title": "Category",
                 "type": "string"
               },
               "score": {
                 "description": "The confidence score of the predicted category of the bounding box.",
                 "instillFormat": "number",
+                "instillUIOrder": 3,
+                "title": "Score",
                 "type": "number"
               }
             },
@@ -206,22 +266,34 @@
               "category",
               "score"
             ],
+            "title": "Object",
             "type": "object"
           },
+          "title": "Objects",
           "type": "array"
         }
       },
       "required": [
         "objects"
       ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_INSTANCE_SEGMENTATION": {
     "input": {
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "image_base64",
+        "model_namespace",
+        "model_id"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "image_base64": {
+          "description": "Image base64",
           "instillFormat": "image",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -231,17 +303,19 @@
         "model_id": {
           "description": "ID of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
-          "title": "Model Id",
+          "title": "Model ID",
           "type": "string"
         },
         "model_namespace": {
           "description": "Namespace of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -256,15 +330,19 @@
         "model_namespace",
         "model_id"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
       "additionalProperties": false,
+      "description": "Output",
       "instillFormat": "object",
+      "instillUIOrder": 0,
       "properties": {
         "objects": {
           "description": "A list of detected instance bounding boxes.",
           "instillFormat": "object_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
             "properties": {
@@ -272,25 +350,34 @@
                 "additionalProperties": false,
                 "description": "The detected bounding box in (left, top, width, height) format.",
                 "instillFormat": "object",
+                "instillUIOrder": 1,
                 "properties": {
                   "height": {
                     "description": "Bounding box height value",
                     "instillFormat": "number",
+                    "instillUIOrder": 3,
+                    "title": "Height",
                     "type": "number"
                   },
                   "left": {
                     "description": "Bounding box left x-axis value",
                     "instillFormat": "number",
+                    "instillUIOrder": 0,
+                    "title": "Left",
                     "type": "number"
                   },
                   "top": {
                     "description": "Bounding box top y-axis value",
                     "instillFormat": "number",
+                    "instillUIOrder": 1,
+                    "title": "Top",
                     "type": "number"
                   },
                   "width": {
                     "description": "Bounding box width value",
                     "instillFormat": "number",
+                    "instillUIOrder": 2,
+                    "title": "Width",
                     "type": "number"
                   }
                 },
@@ -300,21 +387,28 @@
                   "width",
                   "height"
                 ],
+                "title": "Bounding Box",
                 "type": "object"
               },
               "category": {
                 "description": "The predicted category of the bounding box.",
                 "instillFormat": "text",
+                "instillUIOrder": 2,
+                "title": "Category",
                 "type": "string"
               },
               "rle": {
                 "description": "Run Length Encoding (RLE) of instance mask within the bounding box.",
                 "instillFormat": "text",
+                "instillUIOrder": 0,
+                "title": "RLE",
                 "type": "string"
               },
               "score": {
                 "description": "The confidence score of the predicted instance object.",
                 "instillFormat": "number",
+                "instillUIOrder": 3,
+                "title": "Score",
                 "type": "number"
               }
             },
@@ -324,22 +418,34 @@
               "category",
               "score"
             ],
+            "title": "Object",
             "type": "object"
           },
+          "title": "Objects",
           "type": "array"
         }
       },
       "required": [
         "objects"
       ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_KEYPOINT": {
     "input": {
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "image_base64",
+        "model_namespace",
+        "model_id"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "image_base64": {
+          "description": "Image base64",
           "instillFormat": "image",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -349,17 +455,19 @@
         "model_id": {
           "description": "ID of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
-          "title": "Model Id",
+          "title": "Model ID",
           "type": "string"
         },
         "model_namespace": {
           "description": "Namespace of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -374,15 +482,19 @@
         "model_namespace",
         "model_id"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
       "additionalProperties": false,
+      "description": "Output",
       "instillFormat": "object",
+      "instillUIOrder": 0,
       "properties": {
         "objects": {
           "description": "A list of keypoint objects, a keypoint object includes all the pre-defined keypoints of a detected object.",
           "instillFormat": "object_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
             "properties": {
@@ -390,25 +502,34 @@
                 "additionalProperties": false,
                 "description": "The detected bounding box in (left, top, width, height) format.",
                 "instillFormat": "object",
+                "instillUIOrder": 2,
                 "properties": {
                   "height": {
                     "description": "Bounding box height value",
                     "instillFormat": "number",
+                    "instillUIOrder": 3,
+                    "title": "Height",
                     "type": "number"
                   },
                   "left": {
                     "description": "Bounding box left x-axis value",
                     "instillFormat": "number",
+                    "instillUIOrder": 0,
+                    "title": "Left",
                     "type": "number"
                   },
                   "top": {
                     "description": "Bounding box top y-axis value",
                     "instillFormat": "number",
+                    "instillUIOrder": 1,
+                    "title": "Top",
                     "type": "number"
                   },
                   "width": {
                     "description": "Bounding box width value",
                     "instillFormat": "number",
+                    "instillUIOrder": 2,
+                    "title": "Width",
                     "type": "number"
                   }
                 },
@@ -418,26 +539,32 @@
                   "width",
                   "height"
                 ],
+                "title": "Bounding Box",
                 "type": "object"
               },
               "keypoints": {
                 "description": "A keypoint group is composed of a list of pre-defined keypoints of a detected object.",
+                "instillUIOrder": 0,
                 "items": {
                   "instillFormat": "object",
+                  "instillUIOrder": 0,
                   "properties": {
                     "v": {
                       "description": "visibility score of the keypoint.",
                       "instillFormat": "number",
+                      "instillUIOrder": 2,
                       "type": "number"
                     },
                     "x": {
                       "description": "x coordinate of the keypoint.",
                       "instillFormat": "number",
+                      "instillUIOrder": 0,
                       "type": "number"
                     },
                     "y": {
                       "description": "y coordinate of the keypoint.",
                       "instillFormat": "number",
+                      "instillUIOrder": 1,
                       "type": "number"
                     }
                   },
@@ -446,13 +573,17 @@
                     "y",
                     "v"
                   ],
+                  "title": "Object",
                   "type": "object"
                 },
+                "title": "Keypoints",
                 "type": "object_array"
               },
               "score": {
                 "description": "The confidence score of the predicted object.",
                 "instillFormat": "number",
+                "instillUIOrder": 1,
+                "title": "Score",
                 "type": "number"
               }
             },
@@ -461,22 +592,34 @@
               "score",
               "bounding_box"
             ],
+            "title": "Object",
             "type": "object"
           },
+          "title": "Objects",
           "type": "array"
         }
       },
       "required": [
         "objects"
       ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_OCR": {
     "input": {
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "image_base64",
+        "model_namespace",
+        "model_id"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "image_base64": {
+          "description": "Image base64",
           "instillFormat": "image",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -486,17 +629,19 @@
         "model_id": {
           "description": "ID of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
-          "title": "Model Id",
+          "title": "Model ID",
           "type": "string"
         },
         "model_namespace": {
           "description": "Namespace of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -511,15 +656,19 @@
         "model_namespace",
         "model_id"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
       "additionalProperties": false,
+      "description": "Output",
       "instillFormat": "object",
+      "instillUIOrder": 0,
       "properties": {
         "objects": {
           "description": "A list of detected bounding boxes.",
           "instillFormat": "object_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
             "properties": {
@@ -527,25 +676,34 @@
                 "additionalProperties": false,
                 "description": "The detected bounding box in (left, top, width, height) format.",
                 "instillFormat": "object",
+                "instillUIOrder": 0,
                 "properties": {
                   "height": {
                     "description": "Bounding box height value",
                     "instillFormat": "number",
+                    "instillUIOrder": 3,
+                    "title": "Height",
                     "type": "number"
                   },
                   "left": {
                     "description": "Bounding box left x-axis value",
                     "instillFormat": "number",
+                    "instillUIOrder": 0,
+                    "title": "Left",
                     "type": "number"
                   },
                   "top": {
                     "description": "Bounding box top y-axis value",
                     "instillFormat": "number",
+                    "instillUIOrder": 1,
+                    "title": "Top",
                     "type": "number"
                   },
                   "width": {
                     "description": "Bounding box width value",
                     "instillFormat": "number",
+                    "instillUIOrder": 2,
+                    "title": "Width",
                     "type": "number"
                   }
                 },
@@ -555,16 +713,21 @@
                   "width",
                   "height"
                 ],
+                "title": "Bounding Box",
                 "type": "object"
               },
               "score": {
                 "description": "The confidence score of the predicted object.",
                 "instillFormat": "number",
+                "instillUIOrder": 2,
+                "title": "Score",
                 "type": "number"
               },
               "text": {
                 "description": "Text string recognised per bounding box.",
                 "instillFormat": "text",
+                "instillUIOrder": 1,
+                "title": "Text",
                 "type": "string"
               }
             },
@@ -573,22 +736,34 @@
               "text",
               "score"
             ],
+            "title": "Object",
             "type": "object"
           },
+          "title": "Objects",
           "type": "array"
         }
       },
       "required": [
         "objects"
       ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_SEMANTIC_SEGMENTATION": {
     "input": {
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "image_base64",
+        "model_namespace",
+        "model_id"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "image_base64": {
+          "description": "Image base64",
           "instillFormat": "image",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -598,17 +773,19 @@
         "model_id": {
           "description": "ID of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
-          "title": "Model Id",
+          "title": "Model ID",
           "type": "string"
         },
         "model_namespace": {
           "description": "Namespace of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -623,26 +800,34 @@
         "model_namespace",
         "model_id"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
       "additionalProperties": false,
+      "description": "Output",
       "instillFormat": "object",
+      "instillUIOrder": 0,
       "properties": {
         "stuffs": {
           "description": "A list of RLE binary masks.",
           "instillFormat": "object_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
             "properties": {
               "category": {
                 "description": "Category text string corresponding to each stuff mask.",
                 "instillFormat": "text",
+                "instillUIOrder": 1,
+                "title": "Category",
                 "type": "string"
               },
               "rle": {
                 "description": "Run Length Encoding (RLE) of each stuff mask within the image.",
                 "instillFormat": "text",
+                "instillUIOrder": 0,
+                "title": "RLE",
                 "type": "string"
               }
             },
@@ -650,22 +835,34 @@
               "rle",
               "category"
             ],
+            "title": "Object",
             "type": "object"
           },
+          "title": "Stuffs",
           "type": "array"
         }
       },
       "required": [
         "stuffs"
       ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TEXT_GENERATION": {
     "input": {
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "prompt",
+        "model_namespace",
+        "model_id"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "bad_words_list": {
+          "description": "Bad words list",
           "instillFormat": "text",
+          "instillUIOrder": 4,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -677,17 +874,19 @@
         "model_id": {
           "description": "ID of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
-          "title": "Model Id",
+          "title": "Model ID",
           "type": "string"
         },
         "model_namespace": {
           "description": "Namespace of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -697,7 +896,9 @@
           "type": "string"
         },
         "output_len": {
+          "description": "Output length",
           "instillFormat": "integer",
+          "instillUIOrder": 6,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -706,7 +907,9 @@
           "type": "integer"
         },
         "prompt": {
+          "description": "Prompt",
           "instillFormat": "text",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -716,7 +919,9 @@
           "type": "string"
         },
         "seed": {
+          "description": "Seed",
           "instillFormat": "integer",
+          "instillUIOrder": 3,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -725,7 +930,9 @@
           "type": "integer"
         },
         "stop_words_list": {
+          "description": "Stop words list",
           "instillFormat": "text",
+          "instillUIOrder": 6,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -735,7 +942,9 @@
           "type": "string"
         },
         "top_k": {
+          "description": "Top K",
           "instillFormat": "integer",
+          "instillUIOrder": 5,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -749,23 +958,45 @@
         "model_namespace",
         "model_id"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "description": "Output",
+      "instillEditOnNodeFields": [
+        "text"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "text": {
+          "description": "Text",
           "instillFormat": "text",
+          "instillUIOrder": 0,
+          "title": "Text",
           "type": "string"
         }
       },
+      "required": [
+        "text"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TEXT_TO_IMAGE": {
     "input": {
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "prompt",
+        "model_namespace",
+        "model_id"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "cfg_scale": {
+          "description": "CFG Scale",
           "instillFormat": "number",
+          "instillUIOrder": 3,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -776,17 +1007,19 @@
         "model_id": {
           "description": "ID of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
-          "title": "Model Id",
+          "title": "Model ID",
           "type": "string"
         },
         "model_namespace": {
           "description": "Namespace of the Instill Model model to be used.",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -796,7 +1029,9 @@
           "type": "string"
         },
         "prompt": {
+          "description": "Prompt",
           "instillFormat": "text",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -806,7 +1041,9 @@
           "type": "string"
         },
         "samples": {
+          "description": "Samples",
           "instillFormat": "integer",
+          "instillUIOrder": 4,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -815,7 +1052,9 @@
           "type": "integer"
         },
         "seed": {
+          "description": "Seed",
           "instillFormat": "integer",
+          "instillUIOrder": 5,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -824,7 +1063,9 @@
           "type": "integer"
         },
         "steps": {
+          "description": "Steps",
           "instillFormat": "integer",
+          "instillUIOrder": 6,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -838,19 +1079,32 @@
         "model_namespace",
         "model_id"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "description": "Output",
+      "instillEditOnNodeFields": [
+        "images"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "images": {
+          "description": "Images",
           "instillFormat": "image_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "image",
             "type": "string"
           },
+          "title": "Images",
           "type": "array"
         }
       },
+      "required": [
+        "images"
+      ],
+      "title": "Output",
       "type": "object"
     }
   }

--- a/pkg/numbers/config/definitions.json
+++ b/pkg/numbers/config/definitions.json
@@ -17,6 +17,7 @@
           "capture_token": {
             "credential_field": true,
             "description": "Fill your Capture token in the Capture App. To access your tokens, you need a Capture App account and you can sign in with email or wallet to acquire the Capture Token.",
+            "instillUIOrder": 0,
             "title": "Capture token",
             "type": "string"
           }

--- a/pkg/numbers/config/tasks.json
+++ b/pkg/numbers/config/tasks.json
@@ -1,10 +1,13 @@
 {
   "TASK_COMMIT": {
     "input": {
+      "description": "Input",
+      "instillUIOrder": 0,
       "properties": {
         "abstract": {
           "description": "A summary or abstract of the asset.",
           "instillFormat": "text",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -16,6 +19,7 @@
         "asset_creator": {
           "description": "Name of the asset creator.",
           "instillFormat": "text",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -25,10 +29,13 @@
           "type": "string"
         },
         "custom": {
+          "description": "Custom",
+          "instillUIOrder": 3,
           "properties": {
             "creator_wallet": {
               "description": "The Wallet address of the asset creator.",
               "instillFormat": "text",
+              "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
                 "reference",
@@ -48,6 +55,7 @@
                 "algorithmicMedia"
               ],
               "instillFormat": "text",
+              "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "value",
                 "reference",
@@ -59,6 +67,7 @@
             "generated_by": {
               "description": "The AI model used to generate the content.",
               "instillFormat": "text",
+              "instillUIOrder": 2,
               "instillUpstreamTypes": [
                 "value",
                 "reference",
@@ -71,6 +80,7 @@
               "default": "https://console.instill.tech",
               "description": "URL of the service that is used to generate the content.",
               "instillFormat": "text",
+              "instillUIOrder": 3,
               "instillUpstreamTypes": [
                 "value",
                 "reference",
@@ -80,11 +90,14 @@
               "type": "string"
             },
             "license": {
+              "description": "License",
+              "instillUIOrder": 4,
               "properties": {
                 "document": {
                   "description": "URL of the license file.",
                   "instillEnableCopyButton": true,
                   "instillFormat": "text",
+                  "instillUIOrder": 0,
                   "instillUpstreamTypes": [
                     "value",
                     "reference",
@@ -96,6 +109,7 @@
                 "name": {
                   "description": "License of the asset file.",
                   "instillFormat": "text",
+                  "instillUIOrder": 1,
                   "instillUpstreamTypes": [
                     "value",
                     "reference",
@@ -105,6 +119,7 @@
                   "type": "string"
                 }
               },
+              "required": [],
               "title": "License",
               "type": "object"
             },
@@ -121,6 +136,7 @@
                 "aiTrainingWithAuthorship"
               ],
               "instillFormat": "text",
+              "instillUIOrder": 5,
               "instillUpstreamTypes": [
                 "value",
                 "reference",
@@ -130,12 +146,14 @@
               "type": "string"
             }
           },
+          "required": [],
           "title": "Custom",
           "type": "object"
         },
         "images": {
           "description": "The images you want to upload to blockchain.",
           "instillFormat": "image_array",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -151,14 +169,18 @@
       "required": [
         "images"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "description": "Output",
+      "instillUIOrder": 0,
       "properties": {
         "asset_urls": {
           "description": "Asset Urls",
           "instillEnableCopyButton": true,
           "instillFormat": "text_array",
+          "instillUIOrder": 0,
           "items": {
             "instillEnableCopyButton": true,
             "instillFormat": "text",
@@ -171,6 +193,7 @@
       "required": [
         "asset_urls"
       ],
+      "title": "Output",
       "type": "object"
     }
   }

--- a/pkg/openai/config/definitions.json
+++ b/pkg/openai/config/definitions.json
@@ -19,11 +19,13 @@
           "api_key": {
             "credential_field": true,
             "description": "Fill your OpenAI API key. To find your keys, visit your OpenAI's API Keys page.",
+            "instillUIOrder": 0,
             "title": "API Key",
             "type": "string"
           },
           "organization": {
             "description": "Specify which organization is used for the requests. Usage will count against the specified organization's subscription quota.",
+            "instillUIOrder": 1,
             "title": "Organization",
             "type": "string"
           }

--- a/pkg/openai/config/seed/tasks.json
+++ b/pkg/openai/config/seed/tasks.json
@@ -1,10 +1,12 @@
 {
   "TASK_SPEECH_RECOGNITION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "audio": {
           "$ref": "openai.json#/components/schemas/CreateTranscriptionRequest/properties/file",
           "instillFormat": "audio",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -13,6 +15,7 @@
         "language": {
           "$ref": "openai.json#/components/schemas/CreateTranscriptionRequest/properties/language",
           "instillFormat": "text",
+          "instillUIOrder": 3,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -23,6 +26,7 @@
         "model": {
           "$ref": "openai.json#/components/schemas/CreateTranscriptionRequest/properties/model",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -33,6 +37,7 @@
         "prompt": {
           "$ref": "openai.json#/components/schemas/CreateTranscriptionRequest/properties/prompt",
           "instillFormat": "text",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -43,6 +48,7 @@
         "temperature": {
           "$ref": "openai.json#/components/schemas/CreateTranscriptionRequest/properties/temperature",
           "instillFormat": "number",
+          "instillUIOrder": 4,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -54,24 +60,34 @@
         "audio",
         "model"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "text": {
           "$ref": "openai.json#/components/schemas/CreateTranscriptionResponse/properties/text",
-          "instillFormat": "text"
+          "instillFormat": "text",
+          "instillUIOrder": 0,
+          "title": "Text"
         }
       },
+      "required": [
+        "text"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TEXT_EMBEDDINGS": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "model": {
           "$ref": "openai.json#/components/schemas/CreateEmbeddingRequest/properties/model",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -81,6 +97,7 @@
         },
         "text": {
           "instillFormat": "text",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -94,24 +111,34 @@
         "text",
         "model"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "embedding": {
           "$ref": "https://raw.githubusercontent.com/instill-ai/component/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/embedding",
-          "instillFormat": "number_array"
+          "instillFormat": "number_array",
+          "instillUIOrder": 0,
+          "title": "Embedding"
         }
       },
+      "required": [
+        "embedding"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TEXT_GENERATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "max_tokens": {
           "$ref": "openai.json#/components/schemas/CreateChatCompletionRequest/properties/max_tokens",
           "instillFormat": "integer",
+          "instillUIOrder": 5,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -121,6 +148,7 @@
         "model": {
           "$ref": "openai.json#/components/schemas/CreateChatCompletionRequest/properties/model",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -131,6 +159,7 @@
         "n": {
           "$ref": "openai.json#/components/schemas/CreateChatCompletionRequest/properties/n",
           "instillFormat": "integer",
+          "instillUIOrder": 4,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -139,6 +168,7 @@
         },
         "prompt": {
           "instillFormat": "text",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -151,6 +181,7 @@
           "default": "You are a helpful assistant.",
           "description": "The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model\u2019s behavior is using a generic message as \"You are a helpful assistant.\"",
           "instillFormat": "text",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -163,6 +194,7 @@
         "temperature": {
           "$ref": "openai.json#/components/schemas/CreateChatCompletionRequest/properties/temperature",
           "instillFormat": "number",
+          "instillUIOrder": 3,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -174,19 +206,27 @@
         "model",
         "prompt"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "texts": {
           "instillFormat": "text_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "text",
             "type": "string"
           },
+          "title": "Texts",
           "type": "array"
         }
       },
+      "required": [
+        "texts"
+      ],
+      "title": "Output",
       "type": "object"
     }
   }

--- a/pkg/openai/config/tasks.json
+++ b/pkg/openai/config/tasks.json
@@ -1,11 +1,13 @@
 {
   "TASK_SPEECH_RECOGNITION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "audio": {
           "description": "The audio file object (not file name) to transcribe, in one of these formats: mp3, mp4, mpeg, mpga, m4a, wav, or webm.\n",
           "format": "binary",
           "instillFormat": "audio",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -16,6 +18,7 @@
         "language": {
           "description": "The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format will improve accuracy and latency.\n",
           "instillFormat": "text",
+          "instillUIOrder": 3,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -31,6 +34,7 @@
           ],
           "example": "whisper-1",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -43,6 +47,7 @@
         "prompt": {
           "description": "An optional text to guide the model's style or continue a previous audio segment. The [prompt](https://platform.openai.com/docs/guides/speech-to-text/prompting) should match the audio language.\n",
           "instillFormat": "text",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -55,6 +60,7 @@
           "default": 0,
           "description": "The sampling temperature, between 0 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. If set to 0, the model will use [log probability](https://en.wikipedia.org/wiki/Log_probability) to automatically increase the temperature until certain thresholds are hit.\n",
           "instillFormat": "number",
+          "instillUIOrder": 4,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -67,20 +73,29 @@
         "audio",
         "model"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "text": {
           "instillFormat": "text",
+          "instillUIOrder": 0,
+          "title": "Text",
           "type": "string"
         }
       },
+      "required": [
+        "text"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TEXT_EMBEDDINGS": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "model": {
           "description": "ID of the model to use. You can use the [List models](https://platform.openai.com/docs/api-reference/models/list) API to see all of your available models, or see our [Model overview](https://platform.openai.com/docs/models/overview) for descriptions of them.\n",
@@ -89,6 +104,7 @@
           ],
           "example": "text-embedding-ada-002",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -100,6 +116,7 @@
         },
         "text": {
           "instillFormat": "text",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -113,29 +130,39 @@
         "text",
         "model"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "embedding": {
           "instillFormat": "number_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "number",
             "type": "number"
           },
+          "title": "Embedding",
           "type": "array"
         }
       },
+      "required": [
+        "embedding"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TEXT_GENERATION": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "max_tokens": {
           "default": "inf",
           "description": "The maximum number of [tokens](/tokenizer) to generate in the chat completion.\n\nThe total length of input tokens and generated tokens is limited by the model's context length. [Example Python code](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb) for counting tokens.\n",
           "instillFormat": "integer",
+          "instillUIOrder": 5,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -160,6 +187,7 @@
           ],
           "example": "gpt-3.5-turbo",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -174,6 +202,7 @@
           "description": "How many chat completion choices to generate for each input message.",
           "example": 1,
           "instillFormat": "integer",
+          "instillUIOrder": 4,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -186,6 +215,7 @@
         },
         "prompt": {
           "instillFormat": "text",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -198,6 +228,7 @@
           "default": "You are a helpful assistant.",
           "description": "The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model\u2019s behavior is using a generic message as \"You are a helpful assistant.\"",
           "instillFormat": "text",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -212,6 +243,7 @@
           "description": "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.\n\nWe generally recommend altering this or `top_p` but not both.\n",
           "example": 1,
           "instillFormat": "number",
+          "instillUIOrder": 3,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -227,19 +259,27 @@
         "model",
         "prompt"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "texts": {
           "instillFormat": "text_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "text",
             "type": "string"
           },
+          "title": "Texts",
           "type": "array"
         }
       },
+      "required": [
+        "texts"
+      ],
+      "title": "Output",
       "type": "object"
     }
   }

--- a/pkg/pinecone/config/definitions.json
+++ b/pkg/pinecone/config/definitions.json
@@ -18,12 +18,14 @@
           "api_key": {
             "credential_field": true,
             "description": "Fill your Pinecone AI API key. You can create a api key in [Pinecone Console](https://app.pinecone.io/)",
+            "instillUIOrder": 0,
             "title": "API Key",
             "type": "string"
           },
           "url": {
             "credential_field": false,
             "description": "Fill in your Pinecone base URL. It is in the form [https://index_name-project_id.svc.environment.pinecone.io]",
+            "instillUIOrder": 1,
             "title": "Pinecone Base URL",
             "type": "string"
           }

--- a/pkg/pinecone/config/tasks.json
+++ b/pkg/pinecone/config/tasks.json
@@ -1,58 +1,70 @@
 {
   "TASK_QUERY": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "id": {
           "description": "The unique ID of the vector to be used as a query vector",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference",
             "template"
           ],
+          "title": "ID",
           "type": "string"
         },
         "include_metadata": {
           "default": false,
           "description": "Indicates whether metadata is included in the response as well as the ids",
           "instillFormat": "boolean",
+          "instillUIOrder": 4,
           "instillUpstreamTypes": [
             "value",
             "reference"
           ],
+          "title": "Include Metadata",
           "type": "boolean"
         },
         "include_values": {
           "default": false,
           "description": "Indicates whether vector values are included in the response",
           "instillFormat": "boolean",
+          "instillUIOrder": 3,
           "instillUpstreamTypes": [
             "value",
             "reference"
           ],
+          "title": "Include Values",
           "type": "boolean"
         },
         "namespace": {
           "description": "The namespace to query",
           "instillFormat": "text",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
+          "title": "Namespace",
           "type": "string"
         },
         "top_k": {
           "description": "The number of results to return for each query",
           "instillFormat": "integer",
+          "instillUIOrder": 5,
           "instillUpstreamTypes": [
             "value",
             "reference"
           ],
+          "title": "Top K",
           "type": "integer"
         },
         "vector": {
           "description": "An array of dimensions for the query vector.",
           "instillFormat": "number_array",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -62,76 +74,102 @@
             "type": "number"
           },
           "minItems": 1,
+          "title": "Vector",
           "type": "array"
         }
       },
       "required": [
-        "top_k"
+        "top_k",
+        "vector"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "matches": {
           "description": "The matches returned for the query",
           "instillFormat": "object_array",
+          "instillUIOrder": 1,
           "items": {
             "instillFormat": "object",
             "properties": {
               "id": {
                 "description": "The id of the matched vector",
                 "instillFormat": "text",
+                "instillUIOrder": 0,
+                "title": "ID",
                 "type": "string"
               },
               "metadata": {
                 "description": "Metadata",
                 "instillFormat": "object",
+                "instillUIOrder": 3,
+                "title": "Metadata",
                 "type": "object"
               },
               "score": {
                 "description": "A measure of similarity between this vector and the query vector. The higher the score, the more they are similar.",
                 "instillFormat": "number",
+                "instillUIOrder": 1,
+                "title": "Score",
                 "type": "number"
               },
               "values": {
                 "description": "Vector data values",
                 "instillFormat": "number_array",
+                "instillUIOrder": 2,
                 "items": {
                   "description": "Each float value represents one dimension",
                   "type": "number"
                 },
+                "title": "Values",
                 "type": "array"
               }
             },
+            "title": "Match",
             "type": "object"
           },
+          "title": "Matches",
           "type": "array"
         },
         "namespace": {
           "description": "The namespace of the query",
           "instillFormat": "text",
+          "instillUIOrder": 0,
+          "title": "Namespace",
           "type": "string"
         }
       },
+      "required": [
+        "namespace",
+        "matches"
+      ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_UPSERT": {
     "input": {
+      "instillUIOrder": 0,
       "properties": {
         "id": {
           "description": "This is the vector's unique id",
           "instillFormat": "text",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "value",
             "reference",
             "template"
           ],
+          "title": "ID",
           "type": "string"
         },
         "values": {
           "description": "An array of dimensions for the vector to be saved",
           "instillFormat": "number_array",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -141,6 +179,7 @@
             "type": "number"
           },
           "minItems": 1,
+          "title": "Values",
           "type": "array"
         }
       },
@@ -148,16 +187,24 @@
         "id",
         "values"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
+      "instillUIOrder": 0,
       "properties": {
         "upserted_count": {
           "description": "Number of records modified or added",
           "instillFormat": "integer",
+          "instillUIOrder": 0,
+          "title": "Upserted Count",
           "type": "integer"
         }
       },
+      "required": [
+        "upserted_count"
+      ],
+      "title": "Output",
       "type": "object"
     }
   }

--- a/pkg/stabilityai/config/definitions.json
+++ b/pkg/stabilityai/config/definitions.json
@@ -18,6 +18,7 @@
           "api_key": {
             "credential_field": true,
             "description": "Fill your Stability AI API key. To find your keys, visit - https://platform.stability.ai/account/keys",
+            "instillUIOrder": 0,
             "title": "API Key",
             "type": "string"
           }

--- a/pkg/stabilityai/config/seed/tasks.json
+++ b/pkg/stabilityai/config/seed/tasks.json
@@ -2,10 +2,16 @@
   "TASK_IMAGE_TO_IMAGE": {
     "input": {
       "additionalProperties": false,
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "prompts"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "cfg_scale": {
           "$ref": "stabilityai.json#/components/schemas/CfgScale",
           "instillFormat": "number",
+          "instillUIOrder": 6,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -14,7 +20,9 @@
         },
         "clip_guidance_preset": {
           "$ref": "stabilityai.json#/components/schemas/ClipGuidancePreset",
+          "description": "Clip guidance preset",
           "instillFormat": "text",
+          "instillUIOrder": 3,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -39,6 +47,7 @@
             "stable-inpainting-512-v2-0"
           ],
           "instillFormat": "text",
+          "instillUIOrder": 4,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -50,6 +59,7 @@
         "image_strength": {
           "$ref": "stabilityai.json#/components/schemas/InitImageStrength",
           "instillFormat": "number",
+          "instillUIOrder": 5,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -59,6 +69,7 @@
         "init_image": {
           "$ref": "stabilityai.json#/components/schemas/InitImage",
           "instillFormat": "image",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -67,6 +78,7 @@
         "init_image_mode": {
           "$ref": "stabilityai.json#/components/schemas/InitImageMode",
           "instillFormat": "text",
+          "instillUIOrder": 7,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -77,6 +89,7 @@
         "prompts": {
           "description": "An array of prompts to use for generation.",
           "instillFormat": "text_array",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -90,6 +103,7 @@
         "sampler": {
           "$ref": "stabilityai.json#/components/schemas/Sampler",
           "instillFormat": "text",
+          "instillUIOrder": 8,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -100,6 +114,7 @@
         "samples": {
           "$ref": "stabilityai.json#/components/schemas/Samples",
           "instillFormat": "integer",
+          "instillUIOrder": 9,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -109,6 +124,7 @@
         "seed": {
           "$ref": "stabilityai.json#/components/schemas/Seed",
           "instillFormat": "number",
+          "instillUIOrder": 10,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -118,6 +134,7 @@
         "step_schedule_end": {
           "$ref": "stabilityai.json#/components/schemas/StepScheduleEnd",
           "instillFormat": "number",
+          "instillUIOrder": 11,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -127,6 +144,7 @@
         "step_schedule_start": {
           "$ref": "stabilityai.json#/components/schemas/StepScheduleStart",
           "instillFormat": "number",
+          "instillUIOrder": 12,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -136,6 +154,7 @@
         "steps": {
           "$ref": "stabilityai.json#/components/schemas/Steps",
           "instillFormat": "integer",
+          "instillUIOrder": 13,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -145,6 +164,7 @@
         "style_preset": {
           "$ref": "stabilityai.json#/components/schemas/StylePreset",
           "instillFormat": "text",
+          "instillUIOrder": 14,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -155,6 +175,7 @@
         "weights": {
           "description": "An array of weights to use for generation.",
           "instillFormat": "number_array",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -170,20 +191,26 @@
       "required": [
         "prompts"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
-      "$ref": "#/TASK_TEXT_TO_IMAGE/output",
-      "instillFormat": "image"
+      "$ref": "#/TASK_TEXT_TO_IMAGE/output"
     }
   },
   "TASK_TEXT_TO_IMAGE": {
     "input": {
       "additionalProperties": false,
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "prompts"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "cfg_scale": {
           "$ref": "stabilityai.json#/components/schemas/CfgScale",
           "instillFormat": "number",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -192,7 +219,9 @@
         },
         "clip_guidance_preset": {
           "$ref": "stabilityai.json#/components/schemas/ClipGuidancePreset",
+          "description": "Clip guidance preset",
           "instillFormat": "text",
+          "instillUIOrder": 3,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -217,6 +246,7 @@
             "stable-inpainting-512-v2-0"
           ],
           "instillFormat": "text",
+          "instillUIOrder": 4,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -228,6 +258,7 @@
         "height": {
           "$ref": "stabilityai.json#/components/schemas/DiffuseImageHeight",
           "instillFormat": "integer",
+          "instillUIOrder": 5,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -237,6 +268,7 @@
         "prompts": {
           "description": "An array of prompts to use for generation.",
           "instillFormat": "text_array",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -250,6 +282,7 @@
         "sampler": {
           "$ref": "stabilityai.json#/components/schemas/Sampler",
           "instillFormat": "text",
+          "instillUIOrder": 6,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -260,6 +293,7 @@
         "samples": {
           "$ref": "stabilityai.json#/components/schemas/Samples",
           "instillFormat": "integer",
+          "instillUIOrder": 7,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -269,6 +303,7 @@
         "seed": {
           "$ref": "stabilityai.json#/components/schemas/Seed",
           "instillFormat": "number",
+          "instillUIOrder": 8,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -278,6 +313,7 @@
         "steps": {
           "$ref": "stabilityai.json#/components/schemas/Steps",
           "instillFormat": "integer",
+          "instillUIOrder": 9,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -287,6 +323,7 @@
         "style_preset": {
           "$ref": "stabilityai.json#/components/schemas/StylePreset",
           "instillFormat": "text",
+          "instillUIOrder": 10,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -297,6 +334,7 @@
         "weights": {
           "description": "An array of weights to use for generation.",
           "instillFormat": "number_array",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -311,6 +349,7 @@
         "width": {
           "$ref": "stabilityai.json#/components/schemas/DiffuseImageWidth",
           "instillFormat": "integer",
+          "instillUIOrder": 11,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -321,13 +360,22 @@
       "required": [
         "prompts"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
       "additionalProperties": false,
+      "description": "Output",
+      "instillEditOnNodeFields": [
+        "images",
+        "seeds"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "images": {
+          "description": "Generated images",
           "instillFormat": "image_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "image",
             "type": "string"
@@ -336,7 +384,9 @@
           "type": "array"
         },
         "seeds": {
+          "description": "Seeds of generated images",
           "instillFormat": "number_array",
+          "instillUIOrder": 1,
           "items": {
             "$ref": "stabilityai.json#/components/schemas/Image/properties/seed",
             "instillFormat": "number"
@@ -349,6 +399,7 @@
         "images",
         "seeds"
       ],
+      "title": "Output",
       "type": "object"
     }
   }

--- a/pkg/stabilityai/config/tasks.json
+++ b/pkg/stabilityai/config/tasks.json
@@ -2,12 +2,18 @@
   "TASK_IMAGE_TO_IMAGE": {
     "input": {
       "additionalProperties": false,
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "prompts"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "cfg_scale": {
           "default": 7,
           "description": "How strictly the diffusion process adheres to the prompt text (higher values keep your image closer to your prompt)",
           "example": 7,
           "instillFormat": "number",
+          "instillUIOrder": 6,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -19,6 +25,7 @@
         },
         "clip_guidance_preset": {
           "default": "NONE",
+          "description": "Clip guidance preset",
           "enum": [
             "FAST_BLUE",
             "FAST_GREEN",
@@ -30,6 +37,7 @@
           ],
           "example": "FAST_BLUE",
           "instillFormat": "text",
+          "instillUIOrder": 3,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -55,6 +63,7 @@
             "stable-inpainting-512-v2-0"
           ],
           "instillFormat": "text",
+          "instillUIOrder": 4,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -69,6 +78,7 @@
           "example": 0.4,
           "format": "float",
           "instillFormat": "number",
+          "instillUIOrder": 5,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -83,6 +93,7 @@
           "example": "<image binary>",
           "format": "binary",
           "instillFormat": "image",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -98,6 +109,7 @@
             "STEP_SCHEDULE"
           ],
           "instillFormat": "text",
+          "instillUIOrder": 7,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -109,6 +121,7 @@
         "prompts": {
           "description": "An array of prompts to use for generation.",
           "instillFormat": "text_array",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -138,6 +151,7 @@
           ],
           "example": "K_DPM_2_ANCESTRAL",
           "instillFormat": "text",
+          "instillUIOrder": 8,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -151,6 +165,7 @@
           "description": "Number of images to generate",
           "example": 1,
           "instillFormat": "integer",
+          "instillUIOrder": 9,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -166,6 +181,7 @@
           "description": "Random noise seed (omit this option or use `0` for a random seed)",
           "example": 0,
           "instillFormat": "number",
+          "instillUIOrder": 10,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -180,6 +196,7 @@
           "description": "Skips a proportion of the end of the diffusion steps, allowing the init_image to influence the final generated image.  Lower values will result in more influence from the init_image, while higher values will result in more influence from the diffusion steps.",
           "example": 0.01,
           "instillFormat": "number",
+          "instillUIOrder": 11,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -194,6 +211,7 @@
           "description": "Skips a proportion of the start of the diffusion steps, allowing the init_image to influence the final generated image.  Lower values will result in more influence from the init_image, while higher values will result in more influence from the diffusion steps.  (e.g. a value of `0` would simply return you the init_image, where a value of `1` would return you a completely different image.)",
           "example": 0.4,
           "instillFormat": "number",
+          "instillUIOrder": 12,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -208,6 +226,7 @@
           "description": "Number of diffusion steps to run",
           "example": 75,
           "instillFormat": "integer",
+          "instillUIOrder": 13,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -240,6 +259,7 @@
             "tile-texture"
           ],
           "instillFormat": "text",
+          "instillUIOrder": 14,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -251,6 +271,7 @@
         "weights": {
           "description": "An array of weights to use for generation.",
           "instillFormat": "number_array",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -269,14 +290,22 @@
       "required": [
         "prompts"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
       "additionalProperties": false,
-      "instillFormat": "image",
+      "description": "Output",
+      "instillEditOnNodeFields": [
+        "images",
+        "seeds"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "images": {
+          "description": "Generated images",
           "instillFormat": "image_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "image",
             "type": "string"
@@ -285,7 +314,9 @@
           "type": "array"
         },
         "seeds": {
+          "description": "Seeds of generated images",
           "instillFormat": "number_array",
+          "instillUIOrder": 1,
           "items": {
             "description": "The seed associated with this image",
             "example": 1229191277,
@@ -300,18 +331,25 @@
         "images",
         "seeds"
       ],
+      "title": "Output",
       "type": "object"
     }
   },
   "TASK_TEXT_TO_IMAGE": {
     "input": {
       "additionalProperties": false,
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "prompts"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "cfg_scale": {
           "default": 7,
           "description": "How strictly the diffusion process adheres to the prompt text (higher values keep your image closer to your prompt)",
           "example": 7,
           "instillFormat": "number",
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -323,6 +361,7 @@
         },
         "clip_guidance_preset": {
           "default": "NONE",
+          "description": "Clip guidance preset",
           "enum": [
             "FAST_BLUE",
             "FAST_GREEN",
@@ -334,6 +373,7 @@
           ],
           "example": "FAST_BLUE",
           "instillFormat": "text",
+          "instillUIOrder": 3,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -359,6 +399,7 @@
             "stable-inpainting-512-v2-0"
           ],
           "instillFormat": "text",
+          "instillUIOrder": 4,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -372,6 +413,7 @@
           "description": "Height of the image in pixels.  Must be in increments of 64 and pass the following validation:\n- For 512 engines: 262,144 \u2264 `height * width` \u2264 1,048,576\n- For 768 engines: 589,824 \u2264 `height * width` \u2264 1,048,576\n- For SDXL Beta: can be as low as 128 and as high as 896 as long as `width` is not greater than 512. If `width` is greater than 512 then this can be _at most_ 512.\n- For SDXL v0.9: valid dimensions are 1024x1024, 1152x896, 1216x832, 1344x768, 1536x640, 640x1536, 768x1344, 832x1216, or 896x1152\n- For SDXL v1.0: valid dimensions are the same as SDXL v0.9",
           "example": 512,
           "instillFormat": "integer",
+          "instillUIOrder": 5,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -385,6 +427,7 @@
         "prompts": {
           "description": "An array of prompts to use for generation.",
           "instillFormat": "text_array",
+          "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -414,6 +457,7 @@
           ],
           "example": "K_DPM_2_ANCESTRAL",
           "instillFormat": "text",
+          "instillUIOrder": 6,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -427,6 +471,7 @@
           "description": "Number of images to generate",
           "example": 1,
           "instillFormat": "integer",
+          "instillUIOrder": 7,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -442,6 +487,7 @@
           "description": "Random noise seed (omit this option or use `0` for a random seed)",
           "example": 0,
           "instillFormat": "number",
+          "instillUIOrder": 8,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -457,6 +503,7 @@
           "description": "Number of diffusion steps to run",
           "example": 75,
           "instillFormat": "integer",
+          "instillUIOrder": 9,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -489,6 +536,7 @@
             "tile-texture"
           ],
           "instillFormat": "text",
+          "instillUIOrder": 10,
           "instillUpstreamTypes": [
             "value",
             "reference",
@@ -500,6 +548,7 @@
         "weights": {
           "description": "An array of weights to use for generation.",
           "instillFormat": "number_array",
+          "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -519,6 +568,7 @@
           "description": "Width of the image in pixels.  Must be in increments of 64 and pass the following validation:\n- For 512 engines: 262,144 \u2264 `height * width` \u2264 1,048,576\n- For 768 engines: 589,824 \u2264 `height * width` \u2264 1,048,576\n- For SDXL Beta: can be as low as 128 and as high as 896 as long as `height` is not greater than 512. If `height` is greater than 512 then this can be _at most_ 512.\n- For SDXL v0.9: valid dimensions are 1024x1024, 1152x896, 1216x832, 1344x768, 1536x640, 640x1536, 768x1344, 832x1216, or 896x1152\n- For SDXL v1.0: valid dimensions are the same as SDXL v0.9",
           "example": 512,
           "instillFormat": "integer",
+          "instillUIOrder": 11,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -533,13 +583,22 @@
       "required": [
         "prompts"
       ],
+      "title": "Input",
       "type": "object"
     },
     "output": {
       "additionalProperties": false,
+      "description": "Output",
+      "instillEditOnNodeFields": [
+        "images",
+        "seeds"
+      ],
+      "instillUIOrder": 0,
       "properties": {
         "images": {
+          "description": "Generated images",
           "instillFormat": "image_array",
+          "instillUIOrder": 0,
           "items": {
             "instillFormat": "image",
             "type": "string"
@@ -548,7 +607,9 @@
           "type": "array"
         },
         "seeds": {
+          "description": "Seeds of generated images",
           "instillFormat": "number_array",
+          "instillUIOrder": 1,
           "items": {
             "description": "The seed associated with this image",
             "example": 1229191277,
@@ -563,6 +624,7 @@
         "images",
         "seeds"
       ],
+      "title": "Output",
       "type": "object"
     }
   }


### PR DESCRIPTION
Because

- we need some extra annotation in json-schema for auto-form and smart hint on Console.

This commit

- support `instillUIOrder` for UI ordering
- support `instillEditOnNodeFields` for auto-form
- support `instillShortDescription` for short description


