### PR TITLE
refactor(component): refactor instillFormat xxx_array to array

### DIFF
--- a/pkg/huggingface/config/tasks.json
+++ b/pkg/huggingface/config/tasks.json
@@ -80,7 +80,7 @@
       "instillUIOrder": 0,
       "properties": {
         "classes": {
-          "instillFormat": "object_array",
+          "instillFormat": "array",
           "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
@@ -126,7 +126,7 @@
           "properties": {
             "generated_responses": {
               "description": "A list of strings corresponding to the earlier replies from the model.",
-              "instillFormat": "text_array",
+              "instillFormat": "array",
               "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
@@ -141,7 +141,7 @@
             },
             "past_user_inputs": {
               "description": "A list of strings corresponding to the earlier replies from the user. Should be of the same length of generated_responses.",
-              "instillFormat": "text_array",
+              "instillFormat": "array",
               "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "value",
@@ -291,7 +291,7 @@
           "properties": {
             "generated_responses": {
               "description": "List of strings. The last outputs from the model in the conversation, after the model has run.",
-              "instillFormat": "text_array",
+              "instillFormat": "array",
               "instillUIOrder": 0,
               "items": {
                 "instillFormat": "text",
@@ -302,7 +302,7 @@
             },
             "past_user_inputs": {
               "description": "List of strings. The last inputs from the user in the conversation, after the model has run.",
-              "instillFormat": "text_array",
+              "instillFormat": "array",
               "instillUIOrder": 1,
               "items": {
                 "instillFormat": "text",
@@ -362,7 +362,7 @@
       "instillUIOrder": 0,
       "properties": {
         "results": {
-          "instillFormat": "object_array",
+          "instillFormat": "array",
           "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
@@ -438,7 +438,7 @@
       "instillUIOrder": 0,
       "properties": {
         "classes": {
-          "instillFormat": "object_array",
+          "instillFormat": "array",
           "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
@@ -503,7 +503,7 @@
       "instillUIOrder": 0,
       "properties": {
         "segments": {
-          "instillFormat": "object_array",
+          "instillFormat": "array",
           "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
@@ -617,7 +617,7 @@
       "instillUIOrder": 0,
       "properties": {
         "objects": {
-          "instillFormat": "object_array",
+          "instillFormat": "array",
           "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
@@ -794,7 +794,7 @@
           "properties": {
             "sentences": {
               "description": "A list of strings which will be compared against the source_sentence.",
-              "instillFormat": "text_array",
+              "instillFormat": "array",
               "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
@@ -846,7 +846,7 @@
       "properties": {
         "scores": {
           "description": "The associated similarity score for each of the given strings",
-          "instillFormat": "number_array",
+          "instillFormat": "array",
           "instillUIOrder": 0,
           "items": {
             "instillFormat": "number",
@@ -1108,7 +1108,7 @@
         },
         "cells": {
           "description": "a list of coordinates of the cells contents",
-          "instillFormat": "text_array",
+          "instillFormat": "array",
           "instillUIOrder": 2,
           "items": {
             "instillFormat": "text",
@@ -1119,10 +1119,10 @@
         },
         "coordinates": {
           "description": "a list of coordinates of the cells referenced in the answer",
-          "instillFormat": "integer_array",
+          "instillFormat": "array",
           "instillUIOrder": 3,
           "items": {
-            "instillFormat": "integer_array",
+            "instillFormat": "array",
             "items": {
               "instillFormat": "integer",
               "type": "integer"
@@ -1167,7 +1167,7 @@
       "instillUIOrder": 0,
       "properties": {
         "results": {
-          "instillFormat": "object_array",
+          "instillFormat": "array",
           "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
@@ -1498,7 +1498,7 @@
       "instillUIOrder": 0,
       "properties": {
         "results": {
-          "instillFormat": "object_array",
+          "instillFormat": "array",
           "instillUIOrder": 0,
           "items": {
             "instillFormat": "object",
@@ -1615,7 +1615,7 @@
           "properties": {
             "candidate_labels": {
               "description": "a list of strings that are potential classes for inputs. (max 10 candidate_labels, for more, simply run multiple requests, results are going to be misleading if using too many candidate_labels anyway. If you want to keep the exact same, you can simply run multi_label=True and do the scaling on your end. )",
-              "instillFormat": "text_array",
+              "instillFormat": "array",
               "instillUIOrder": 0,
               "instillUpstreamTypes": [
                 "value",
@@ -1630,7 +1630,7 @@
             },
             "multi_label": {
               "description": "Boolean that is set to True if classes can overlap",
-              "instillFormat": "boolean_array",
+              "instillFormat": "array",
               "instillUIOrder": 1,
               "instillUpstreamTypes": [
                 "value",
@@ -1659,7 +1659,7 @@
       "properties": {
         "labels": {
           "description": "The list of strings for labels that you sent (in order)",
-          "instillFormat": "text_array",
+          "instillFormat": "array",
           "instillUIOrder": 1,
           "items": {
             "instillFormat": "text",
@@ -1670,7 +1670,7 @@
         },
         "scores": {
           "description": "a list of floats that correspond the the probability of label, in the same order as labels.",
-          "instillFormat": "number_array",
+          "instillFormat": "array",
           "instillUIOrder": 0,
           "items": {
             "instillFormat": "number",

--- a/pkg/instill/config/tasks.json
+++ b/pkg/instill/config/tasks.json
@@ -59,7 +59,7 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/6831f339375950f3f04429416124be96cbdd623a/shared_schema.json#/$defs/instill_types/classification",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/0bcb5ecde3302537078ece28f218eb2f8d95ef0a/shared_schema.json#/$defs/instill_types/classification",
       "description": "Output",
       "instillUIOrder": 0,
       "title": "Output",
@@ -72,7 +72,7 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/6831f339375950f3f04429416124be96cbdd623a/shared_schema.json#/$defs/instill_types/detection",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/0bcb5ecde3302537078ece28f218eb2f8d95ef0a/shared_schema.json#/$defs/instill_types/detection",
       "description": "Output",
       "instillUIOrder": 0,
       "title": "Output",
@@ -85,7 +85,7 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/6831f339375950f3f04429416124be96cbdd623a/shared_schema.json#/$defs/instill_types/instance_segmentation",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/0bcb5ecde3302537078ece28f218eb2f8d95ef0a/shared_schema.json#/$defs/instill_types/instance_segmentation",
       "description": "Output",
       "instillUIOrder": 0,
       "title": "Output",
@@ -98,7 +98,7 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/6831f339375950f3f04429416124be96cbdd623a/shared_schema.json#/$defs/instill_types/keypoint",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/0bcb5ecde3302537078ece28f218eb2f8d95ef0a/shared_schema.json#/$defs/instill_types/keypoint",
       "description": "Output",
       "instillUIOrder": 0,
       "title": "Output",
@@ -111,7 +111,7 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/6831f339375950f3f04429416124be96cbdd623a/shared_schema.json#/$defs/instill_types/ocr",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/0bcb5ecde3302537078ece28f218eb2f8d95ef0a/shared_schema.json#/$defs/instill_types/ocr",
       "description": "Output",
       "instillUIOrder": 0,
       "title": "Output",
@@ -124,7 +124,7 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/6831f339375950f3f04429416124be96cbdd623a/shared_schema.json#/$defs/instill_types/semantic_segmentation",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/0bcb5ecde3302537078ece28f218eb2f8d95ef0a/shared_schema.json#/$defs/instill_types/semantic_segmentation",
       "description": "Output",
       "instillUIOrder": 0,
       "title": "Output",
@@ -373,7 +373,7 @@
       "properties": {
         "images": {
           "description": "Images",
-          "instillFormat": "image_array",
+          "instillFormat": "array",
           "instillUIOrder": 0,
           "items": {
             "instillFormat": "image",

--- a/pkg/numbers/config/tasks.json
+++ b/pkg/numbers/config/tasks.json
@@ -152,7 +152,7 @@
         },
         "images": {
           "description": "The images you want to upload to blockchain.",
-          "instillFormat": "image_array",
+          "instillFormat": "array",
           "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference"
@@ -179,7 +179,7 @@
         "asset_urls": {
           "description": "Asset Urls",
           "instillEnableCopyButton": true,
-          "instillFormat": "text_array",
+          "instillFormat": "array",
           "instillUIOrder": 0,
           "items": {
             "instillEnableCopyButton": true,

--- a/pkg/openai/config/tasks.json
+++ b/pkg/openai/config/tasks.json
@@ -118,8 +118,8 @@
       "instillUIOrder": 0,
       "properties": {
         "embedding": {
-          "$ref": "https://raw.githubusercontent.com/instill-ai/component/70d06a013fa06f86130bf6e186d8e7839c38c448/shared_schema.json#/$defs/instill_types/embedding",
-          "instillFormat": "number_array",
+          "$ref": "https://raw.githubusercontent.com/instill-ai/component/0bcb5ecde3302537078ece28f218eb2f8d95ef0a/shared_schema.json#/$defs/instill_types/embedding",
+          "instillFormat": "array",
           "instillUIOrder": 0,
           "title": "Embedding"
         }
@@ -213,7 +213,7 @@
       "instillUIOrder": 0,
       "properties": {
         "texts": {
-          "instillFormat": "text_array",
+          "instillFormat": "array",
           "instillUIOrder": 0,
           "items": {
             "instillFormat": "text",

--- a/pkg/pinecone/config/tasks.json
+++ b/pkg/pinecone/config/tasks.json
@@ -63,7 +63,7 @@
         },
         "vector": {
           "description": "An array of dimensions for the query vector.",
-          "instillFormat": "number_array",
+          "instillFormat": "array",
           "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "reference"
@@ -90,7 +90,7 @@
       "properties": {
         "matches": {
           "description": "The matches returned for the query",
-          "instillFormat": "object_array",
+          "instillFormat": "array",
           "instillUIOrder": 1,
           "items": {
             "instillFormat": "object",
@@ -119,7 +119,7 @@
               },
               "values": {
                 "description": "Vector data values",
-                "instillFormat": "number_array",
+                "instillFormat": "array",
                 "instillUIOrder": 2,
                 "items": {
                   "description": "Each float value represents one dimension",
@@ -173,7 +173,7 @@
         },
         "values": {
           "description": "An array of dimensions for the vector to be saved",
-          "instillFormat": "number_array",
+          "instillFormat": "array",
           "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "reference"

--- a/pkg/stabilityai/config/tasks.json
+++ b/pkg/stabilityai/config/tasks.json
@@ -88,7 +88,7 @@
         },
         "prompts": {
           "description": "An array of prompts to use for generation.",
-          "instillFormat": "text_array",
+          "instillFormat": "array",
           "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference"
@@ -174,7 +174,7 @@
         },
         "weights": {
           "description": "An array of weights to use for generation.",
-          "instillFormat": "number_array",
+          "instillFormat": "array",
           "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "reference"
@@ -267,7 +267,7 @@
         },
         "prompts": {
           "description": "An array of prompts to use for generation.",
-          "instillFormat": "text_array",
+          "instillFormat": "array",
           "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference"
@@ -333,7 +333,7 @@
         },
         "weights": {
           "description": "An array of weights to use for generation.",
-          "instillFormat": "number_array",
+          "instillFormat": "array",
           "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "reference"
@@ -374,7 +374,7 @@
       "properties": {
         "images": {
           "description": "Generated images",
-          "instillFormat": "image_array",
+          "instillFormat": "array",
           "instillUIOrder": 0,
           "items": {
             "instillFormat": "image",
@@ -385,7 +385,7 @@
         },
         "seeds": {
           "description": "Seeds of generated images",
-          "instillFormat": "number_array",
+          "instillFormat": "array",
           "instillUIOrder": 1,
           "items": {
             "$ref": "stabilityai.json#/components/schemas/Image/properties/seed",


### PR DESCRIPTION
Because

- we should use `instillFormat: array` to simplify the json-schema structure

This commit

- refactor `instillFormat: xxx_array` to `array`
