### PR TITLE
chore(instill): update ref schema url

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/h2non/filetype v1.1.3
-	github.com/instill-ai/component v0.6.1-alpha.0.20231101065727-0bcb5ecde330
+	github.com/instill-ai/component v0.6.1-alpha.0.20231102045107-dd7aa52dc2cd
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231019202606-71607ddcd93f
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
-github.com/instill-ai/component v0.6.1-alpha.0.20231101065727-0bcb5ecde330 h1:z5R7Kh0qwhBCZHcE5dlEB0YeDzjAUtbXnA6UWBP03xo=
-github.com/instill-ai/component v0.6.1-alpha.0.20231101065727-0bcb5ecde330/go.mod h1:crtctDOgLbxGzFXNhO8Sx3VNrjdup0F/LQlSmLixFzo=
+github.com/instill-ai/component v0.6.1-alpha.0.20231102045107-dd7aa52dc2cd h1:bEk1ejCb5AoGwN5Q3EI7yNO4ghOTWntaH29qPA+NCtc=
+github.com/instill-ai/component v0.6.1-alpha.0.20231102045107-dd7aa52dc2cd/go.mod h1:crtctDOgLbxGzFXNhO8Sx3VNrjdup0F/LQlSmLixFzo=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231019202606-71607ddcd93f h1:hweU93u6qsg8GH/YSogOfa+wOZEnkilGsijcy1xKX7E=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231019202606-71607ddcd93f/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/pkg/instill/config/tasks.json
+++ b/pkg/instill/config/tasks.json
@@ -59,7 +59,7 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/0bcb5ecde3302537078ece28f218eb2f8d95ef0a/shared_schema.json#/$defs/instill_types/classification",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/dd7aa52dc2cd5185733543ec0d9171b161cee149/schema.json#/$defs/instill_types/classification",
       "description": "Output",
       "instillUIOrder": 0,
       "title": "Output",
@@ -72,7 +72,7 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/0bcb5ecde3302537078ece28f218eb2f8d95ef0a/shared_schema.json#/$defs/instill_types/detection",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/dd7aa52dc2cd5185733543ec0d9171b161cee149/schema.json#/$defs/instill_types/detection",
       "description": "Output",
       "instillUIOrder": 0,
       "title": "Output",
@@ -85,7 +85,7 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/0bcb5ecde3302537078ece28f218eb2f8d95ef0a/shared_schema.json#/$defs/instill_types/instance_segmentation",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/dd7aa52dc2cd5185733543ec0d9171b161cee149/schema.json#/$defs/instill_types/instance_segmentation",
       "description": "Output",
       "instillUIOrder": 0,
       "title": "Output",
@@ -98,7 +98,7 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/0bcb5ecde3302537078ece28f218eb2f8d95ef0a/shared_schema.json#/$defs/instill_types/keypoint",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/dd7aa52dc2cd5185733543ec0d9171b161cee149/schema.json#/$defs/instill_types/keypoint",
       "description": "Output",
       "instillUIOrder": 0,
       "title": "Output",
@@ -111,7 +111,7 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/0bcb5ecde3302537078ece28f218eb2f8d95ef0a/shared_schema.json#/$defs/instill_types/ocr",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/dd7aa52dc2cd5185733543ec0d9171b161cee149/schema.json#/$defs/instill_types/ocr",
       "description": "Output",
       "instillUIOrder": 0,
       "title": "Output",
@@ -124,7 +124,7 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/0bcb5ecde3302537078ece28f218eb2f8d95ef0a/shared_schema.json#/$defs/instill_types/semantic_segmentation",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/dd7aa52dc2cd5185733543ec0d9171b161cee149/schema.json#/$defs/instill_types/semantic_segmentation",
       "description": "Output",
       "instillUIOrder": 0,
       "title": "Output",


### PR DESCRIPTION
Because

- `boundingBox` has been renamed to `bounding_box` to be consistent with gRPC naming convention

This commit

- fix the inconsistency
- rename file `shared_schema.json` to `schema.json`
- close instill-ai/community#470

⚠️  This PR needs to be updated to use `component` repo main branch after instill-ai/component#23 is merged