### PR TITLE
fix(openai): fix the message order in the chat completion request

### DIFF
--- a/pkg/openai/main.go
+++ b/pkg/openai/main.go
@@ -150,10 +150,10 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 			}
 
 			messages := []Message{}
-			messages = append(messages, Message{Role: "user", Content: inputStruct.Prompt})
 			if inputStruct.SystemMessage != nil {
 				messages = append(messages, Message{Role: "system", Content: *inputStruct.SystemMessage})
 			}
+			messages = append(messages, Message{Role: "user", Content: inputStruct.Prompt})
 
 			req := TextCompletionReq{
 				Messages:    messages,


### PR DESCRIPTION
Because

- we should put `system message` before `user message`, see [OpenAI API reference](https://platform.openai.com/docs/api-reference/chat/create?lang=curl)

This commit

- fix the message order for OpenAI chat completion request
