### PR TITLE
feat(ai-openai): support OpenAI gpt-4-turbo and dall-e-3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,11 @@ require (
 	github.com/PuerkitoBio/goquery v1.5.1
 	github.com/allegro/bigcache v1.2.1
 	github.com/docker/docker v24.0.7+incompatible
+	github.com/gabriel-vasile/mimetype v1.4.3
 	github.com/ghodss/yaml v1.0.0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/h2non/filetype v1.1.3
-	github.com/instill-ai/component v0.6.1-alpha.0.20231108090255-582dc5f90db9
+	github.com/instill-ai/component v0.6.1-alpha.0.20231108162809-21ba1d24cef4
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231019202606-71607ddcd93f
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/stretchr/testify v1.8.4
@@ -37,7 +38,6 @@ require (
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/goccy/go-json v0.9.11 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
-github.com/instill-ai/component v0.6.1-alpha.0.20231108090255-582dc5f90db9 h1:iaMeJzG/kkykvAnR9T2OlEkZX+iijdThk6l3khXqR0E=
-github.com/instill-ai/component v0.6.1-alpha.0.20231108090255-582dc5f90db9/go.mod h1:JDVDbZby6njJS2ioy2ptD3RhC4CuKWJKsWBg0PtQWK4=
+github.com/instill-ai/component v0.6.1-alpha.0.20231108162809-21ba1d24cef4 h1:hMjRL2SiXg3/GJ/viBnKwQW/Ig/Ot03Cv2/NmFb8YW4=
+github.com/instill-ai/component v0.6.1-alpha.0.20231108162809-21ba1d24cef4/go.mod h1:JDVDbZby6njJS2ioy2ptD3RhC4CuKWJKsWBg0PtQWK4=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231019202606-71607ddcd93f h1:hweU93u6qsg8GH/YSogOfa+wOZEnkilGsijcy1xKX7E=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231019202606-71607ddcd93f/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/pkg/googlecloudstorage/upload.go
+++ b/pkg/googlecloudstorage/upload.go
@@ -7,11 +7,13 @@ import (
 
 	"cloud.google.com/go/iam"
 	"cloud.google.com/go/storage"
+
+	"github.com/instill-ai/component/pkg/base"
 )
 
 func uploadToGCS(client *storage.Client, bucketName, objectName, data string) error {
 	wc := client.Bucket(bucketName).Object(objectName).NewWriter(context.Background())
-	b, _ := base64.StdEncoding.DecodeString(data)
+	b, _ := base64.StdEncoding.DecodeString(base.TrimBase64Mime(data))
 	if _, err := io.WriteString(wc, string(b)); err != nil {
 		return err
 	}

--- a/pkg/huggingface/main.go
+++ b/pkg/huggingface/main.go
@@ -438,7 +438,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 			if err != nil {
 				return nil, err
 			}
-			b, err := base64.StdEncoding.DecodeString(inputStruct.Image)
+			b, err := base64.StdEncoding.DecodeString(base.TrimBase64Mime(inputStruct.Image))
 			if err != nil {
 				return nil, err
 			}
@@ -472,7 +472,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 			if err != nil {
 				return nil, err
 			}
-			b, err := base64.StdEncoding.DecodeString(inputStruct.Image)
+			b, err := base64.StdEncoding.DecodeString(base.TrimBase64Mime(inputStruct.Image))
 			if err != nil {
 				return nil, err
 			}
@@ -507,7 +507,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 			if err != nil {
 				return nil, err
 			}
-			b, err := base64.StdEncoding.DecodeString(inputStruct.Image)
+			b, err := base64.StdEncoding.DecodeString(base.TrimBase64Mime(inputStruct.Image))
 			if err != nil {
 				return nil, err
 			}
@@ -549,7 +549,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 			if err != nil {
 				return nil, err
 			}
-			b, err := base64.StdEncoding.DecodeString(inputStruct.Image)
+			b, err := base64.StdEncoding.DecodeString(base.TrimBase64Mime(inputStruct.Image))
 			if err != nil {
 				return nil, err
 			}
@@ -577,7 +577,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 			if err != nil {
 				return nil, err
 			}
-			b, err := base64.StdEncoding.DecodeString(inputStruct.Audio)
+			b, err := base64.StdEncoding.DecodeString(base.TrimBase64Mime(inputStruct.Audio))
 			if err != nil {
 				return nil, err
 			}
@@ -597,7 +597,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 			if err != nil {
 				return nil, err
 			}
-			b, err := base64.StdEncoding.DecodeString(inputStruct.Audio)
+			b, err := base64.StdEncoding.DecodeString(base.TrimBase64Mime(inputStruct.Audio))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/numbers/main.go
+++ b/pkg/numbers/main.go
@@ -271,7 +271,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 		}
 
 		for _, image := range inputStruct.Images {
-			imageBytes, err := b64.StdEncoding.DecodeString(image)
+			imageBytes, err := b64.StdEncoding.DecodeString(base.TrimBase64Mime(image))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/openai/config/definitions.json
+++ b/pkg/openai/config/definitions.json
@@ -3,7 +3,8 @@
     "available_tasks": [
       "TASK_TEXT_GENERATION",
       "TASK_TEXT_EMBEDDINGS",
-      "TASK_SPEECH_RECOGNITION"
+      "TASK_SPEECH_RECOGNITION",
+      "TASK_TEXT_TO_IMAGE"
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/vdp/ai-connectors/openai",

--- a/pkg/openai/config/openai.json
+++ b/pkg/openai/config/openai.json
@@ -1,12 +1,230 @@
 {
   "components": {
     "schemas": {
+      "AssistantFileObject": {
+        "description": "A list of [Files](/docs/api-reference/files) attached to an `assistant`.",
+        "properties": {
+          "assistant_id": {
+            "description": "The assistant ID that the file is attached to.",
+            "type": "string"
+          },
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) for when the assistant file was created.",
+            "type": "integer"
+          },
+          "id": {
+            "description": "The identifier, which can be referenced in API endpoints.",
+            "type": "string"
+          },
+          "object": {
+            "description": "The object type, which is always `assistant.file`.",
+            "enum": [
+              "assistant.file"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "created_at",
+          "assistant_id"
+        ],
+        "title": "Assistant files",
+        "type": "object",
+        "x-oaiMeta": {
+          "beta": true,
+          "example": "{\n  \"id\": \"file-wB6RM6wHdA49HfS2DJ9fEyrH\",\n  \"object\": \"assistant.file\",\n  \"created_at\": 1699055364,\n  \"assistant_id\": \"asst_FBOFvAOHhwEWMghbMGseaPGQ\"\n}\n",
+          "name": "The assistant file object"
+        }
+      },
+      "AssistantObject": {
+        "description": "Represents an `assistant` that can call the model and use tools.",
+        "properties": {
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) for when the assistant was created.",
+            "type": "integer"
+          },
+          "description": {
+            "description": "The description of the assistant. The maximum length is 512 characters.\n",
+            "maxLength": 512,
+            "nullable": true,
+            "type": "string"
+          },
+          "file_ids": {
+            "default": [],
+            "description": "A list of [file](/docs/api-reference/files) IDs attached to this assistant. There can be a maximum of 20 files attached to the assistant. Files are ordered by their creation date in ascending order.\n",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 20,
+            "type": "array"
+          },
+          "id": {
+            "description": "The identifier, which can be referenced in API endpoints.",
+            "type": "string"
+          },
+          "instructions": {
+            "description": "The system instructions that the assistant uses. The maximum length is 32768 characters.\n",
+            "maxLength": 32768,
+            "nullable": true,
+            "type": "string"
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "nullable": true,
+            "type": "object",
+            "x-oaiTypeLabel": "map"
+          },
+          "model": {
+            "description": "ID of the model to use. You can use the [List models](/docs/api-reference/models/list) API to see all of your available models, or see our [Model overview](/docs/models/overview) for descriptions of them.\n",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the assistant. The maximum length is 256 characters.\n",
+            "maxLength": 256,
+            "nullable": true,
+            "type": "string"
+          },
+          "object": {
+            "description": "The object type, which is always `assistant`.",
+            "enum": [
+              "assistant"
+            ],
+            "type": "string"
+          },
+          "tools": {
+            "default": [],
+            "description": "A list of tool enabled on the assistant. There can be a maximum of 128 tools per assistant. Tools can be of types `code_interpreter`, `retrieval`, or `function`.\n",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AssistantToolsCode"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsRetrieval"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsFunction"
+                }
+              ],
+              "x-oaiExpandable": true
+            },
+            "maxItems": 128,
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "created_at",
+          "name",
+          "description",
+          "model",
+          "instructions",
+          "tools",
+          "file_ids",
+          "metadata"
+        ],
+        "title": "Assistant",
+        "type": "object",
+        "x-oaiMeta": {
+          "beta": true,
+          "example": "{\n  \"id\": \"asst_abc123\",\n  \"object\": \"assistant\",\n  \"created_at\": 1698984975,\n  \"name\": \"Math Tutor\",\n  \"description\": null,\n  \"model\": \"gpt-4\",\n  \"instructions\": \"You are a personal math tutor. When asked a question, write and run Python code to answer the question.\",\n  \"tools\": [\n    {\n      \"type\": \"code_interpreter\"\n    }\n  ],\n  \"file_ids\": [],\n  \"metadata\": {}\n}\n",
+          "name": "The assistant object"
+        }
+      },
+      "AssistantToolsCode": {
+        "properties": {
+          "type": {
+            "description": "The type of tool being defined: `code_interpreter`",
+            "enum": [
+              "code_interpreter"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "Code interpreter tool",
+        "type": "object"
+      },
+      "AssistantToolsFunction": {
+        "properties": {
+          "function": {
+            "description": "The function definition.",
+            "properties": {
+              "description": {
+                "description": "A description of what the function does, used by the model to choose when and how to call the function.",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64.",
+                "type": "string"
+              },
+              "parameters": {
+                "$ref": "#/components/schemas/ChatCompletionFunctionParameters"
+              }
+            },
+            "required": [
+              "name",
+              "parameters",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": {
+            "description": "The type of tool being defined: `function`",
+            "enum": [
+              "function"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "function"
+        ],
+        "title": "Function tool",
+        "type": "object"
+      },
+      "AssistantToolsRetrieval": {
+        "properties": {
+          "type": {
+            "description": "The type of tool being defined: `retrieval`",
+            "enum": [
+              "retrieval"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "Retrieval tool",
+        "type": "object"
+      },
+      "ChatCompletionFunctionCallOption": {
+        "description": "Specifying a particular function via `{\"name\": \"my_function\"}` forces the model to call that function.\n",
+        "properties": {
+          "name": {
+            "description": "The name of the function to call.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
       "ChatCompletionFunctionParameters": {
         "additionalProperties": true,
-        "description": "The parameters the functions accepts, described as a JSON Schema object. See the [guide](https://platform.openai.com/docs/guides/gpt/function-calling) for examples, and the [JSON Schema reference](https://json-schema.org/understanding-json-schema/) for documentation about the format.\n\nTo describe a function that accepts no parameters, provide the value `{\"type\": \"object\", \"properties\": {}}`.",
+        "description": "The parameters the functions accepts, described as a JSON Schema object. See the [guide](/docs/guides/gpt/function-calling) for examples, and the [JSON Schema reference](https://json-schema.org/understanding-json-schema/) for documentation about the format.\n\nTo describe a function that accepts no parameters, provide the value `{\"type\": \"object\", \"properties\": {}}`.",
         "type": "object"
       },
       "ChatCompletionFunctions": {
+        "deprecated": true,
         "properties": {
           "description": {
             "description": "A description of what the function does, used by the model to choose when and how to call the function.",
@@ -26,15 +244,10 @@
         ],
         "type": "object"
       },
-      "ChatCompletionRequestMessage": {
+      "ChatCompletionMessageToolCall": {
         "properties": {
-          "content": {
-            "description": "The contents of the message. `content` is required for all messages, and may be null for assistant messages with function calls.",
-            "nullable": true,
-            "type": "string"
-          },
-          "function_call": {
-            "description": "The name and arguments of a function that should be called, as generated by the model.",
+          "function": {
+            "description": "The function that the model called.",
             "properties": {
               "arguments": {
                 "description": "The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function.",
@@ -51,19 +264,378 @@
             ],
             "type": "object"
           },
-          "name": {
-            "description": "The name of the author of this message. `name` is required if role is `function`, and it should be the name of the function whose response is in the `content`. May contain a-z, A-Z, 0-9, and underscores, with a maximum length of 64 characters.",
+          "id": {
+            "description": "The ID of the tool call.",
             "type": "string"
           },
-          "role": {
-            "description": "The role of the messages author. One of `system`, `user`, `assistant`, or `function`.",
+          "type": {
+            "description": "The type of the tool. Currently, only `function` is supported.",
             "enum": [
-              "system",
-              "user",
-              "assistant",
               "function"
             ],
             "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "function"
+        ],
+        "type": "object"
+      },
+      "ChatCompletionMessageToolCallChunk": {
+        "properties": {
+          "function": {
+            "properties": {
+              "arguments": {
+                "description": "The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function.",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the function to call.",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "id": {
+            "description": "The ID of the tool call.",
+            "type": "string"
+          },
+          "index": {
+            "type": "integer"
+          },
+          "type": {
+            "description": "The type of the tool. Currently, only `function` is supported.",
+            "enum": [
+              "function"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "index"
+        ],
+        "type": "object"
+      },
+      "ChatCompletionMessageToolCalls": {
+        "description": "The tool calls generated by the model, such as function calls.",
+        "items": {
+          "$ref": "#/components/schemas/ChatCompletionMessageToolCall"
+        },
+        "type": "array"
+      },
+      "ChatCompletionNamedToolChoice": {
+        "description": "Specifies a tool the model should use. Use to force the model to call a specific function.",
+        "properties": {
+          "function": {
+            "properties": {
+              "name": {
+                "description": "The name of the function to call.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": {
+            "description": "The type of the tool. Currently, only `function` is supported.",
+            "enum": [
+              "function"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ChatCompletionRequestAssistantMessage": {
+        "properties": {
+          "content": {
+            "description": "The contents of the assistant message.\n",
+            "nullable": true,
+            "type": "string"
+          },
+          "function_call": {
+            "deprecated": true,
+            "description": "Deprecated and replaced by `tool_calls`. The name and arguments of a function that should be called, as generated by the model.",
+            "properties": {
+              "arguments": {
+                "description": "The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function.",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the function to call.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "arguments",
+              "name"
+            ],
+            "type": "object"
+          },
+          "role": {
+            "description": "The role of the messages author, in this case `assistant`.",
+            "enum": [
+              "assistant"
+            ],
+            "type": "string"
+          },
+          "tool_calls": {
+            "$ref": "#/components/schemas/ChatCompletionMessageToolCalls"
+          }
+        },
+        "required": [
+          "content",
+          "role"
+        ],
+        "title": "Assistant message",
+        "type": "object"
+      },
+      "ChatCompletionRequestFunctionMessage": {
+        "deprecated": true,
+        "properties": {
+          "content": {
+            "description": "The return value from the function call, to return to the model.",
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the function to call.",
+            "type": "string"
+          },
+          "role": {
+            "description": "The role of the messages author, in this case `function`.",
+            "enum": [
+              "function"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "role",
+          "name",
+          "content"
+        ],
+        "title": "Function message",
+        "type": "object"
+      },
+      "ChatCompletionRequestMessage": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ChatCompletionRequestSystemMessage"
+          },
+          {
+            "$ref": "#/components/schemas/ChatCompletionRequestUserMessage"
+          },
+          {
+            "$ref": "#/components/schemas/ChatCompletionRequestAssistantMessage"
+          },
+          {
+            "$ref": "#/components/schemas/ChatCompletionRequestToolMessage"
+          },
+          {
+            "$ref": "#/components/schemas/ChatCompletionRequestFunctionMessage"
+          }
+        ],
+        "x-oaiExpandable": true
+      },
+      "ChatCompletionRequestMessageContentPart": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ChatCompletionRequestMessageContentPartText"
+          },
+          {
+            "$ref": "#/components/schemas/ChatCompletionRequestMessageContentPartImage"
+          }
+        ],
+        "x-oaiExpandable": true
+      },
+      "ChatCompletionRequestMessageContentPartImage": {
+        "properties": {
+          "image_url": {
+            "properties": {
+              "detail": {
+                "default": "auto",
+                "description": "Specifies the detail level of the image.",
+                "enum": [
+                  "auto",
+                  "low",
+                  "high"
+                ],
+                "type": "string"
+              },
+              "url": {
+                "description": "Either a URL of the image or the base64 encoded image data.",
+                "format": "uri",
+                "type": "string"
+              }
+            },
+            "required": [
+              "url"
+            ],
+            "type": "object"
+          },
+          "type": {
+            "description": "The type of the content part.",
+            "enum": [
+              "image_url"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "image_url"
+        ],
+        "title": "Image content part",
+        "type": "object"
+      },
+      "ChatCompletionRequestMessageContentPartText": {
+        "properties": {
+          "text": {
+            "description": "The text content.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of the content part.",
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "title": "Text content part",
+        "type": "object"
+      },
+      "ChatCompletionRequestSystemMessage": {
+        "properties": {
+          "content": {
+            "description": "The contents of the system message.",
+            "nullable": true,
+            "type": "string"
+          },
+          "role": {
+            "description": "The role of the messages author, in this case `system`.",
+            "enum": [
+              "system"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "content",
+          "role"
+        ],
+        "title": "System message",
+        "type": "object"
+      },
+      "ChatCompletionRequestToolMessage": {
+        "properties": {
+          "content": {
+            "description": "The contents of the tool message.",
+            "nullable": true,
+            "type": "string"
+          },
+          "role": {
+            "description": "The role of the messages author, in this case `tool`.",
+            "enum": [
+              "tool"
+            ],
+            "type": "string"
+          },
+          "tool_call_id": {
+            "description": "Tool call that this message is responding to.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "role",
+          "content",
+          "tool_call_id"
+        ],
+        "title": "Tool message",
+        "type": "object"
+      },
+      "ChatCompletionRequestUserMessage": {
+        "properties": {
+          "content": {
+            "description": "The contents of the user message.\n",
+            "nullable": true,
+            "oneOf": [
+              {
+                "description": "The text contents of the message.",
+                "title": "Text content",
+                "type": "string"
+              },
+              {
+                "description": "An array of content parts with a defined type, each can be of type `text` or `image_url` when passing in images. You can pass multiple images by adding multiple `image_url` content parts. Image input is only supported when using the `gpt-4-visual-preview` model.",
+                "items": {
+                  "$ref": "#/components/schemas/ChatCompletionRequestMessageContentPart"
+                },
+                "minItems": 1,
+                "title": "Array of content parts",
+                "type": "array"
+              }
+            ]
+          },
+          "role": {
+            "description": "The role of the messages author, in this case `user`.",
+            "enum": [
+              "user"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "content",
+          "role"
+        ],
+        "title": "User message",
+        "type": "object"
+      },
+      "ChatCompletionResponseMessage": {
+        "description": "A chat completion message generated by the model.",
+        "properties": {
+          "content": {
+            "description": "The contents of the message.",
+            "nullable": true,
+            "type": "string"
+          },
+          "function_call": {
+            "deprecated": true,
+            "description": "Deprecated and replaced by `tool_calls`. The name and arguments of a function that should be called, as generated by the model.",
+            "properties": {
+              "arguments": {
+                "description": "The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function.",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the function to call.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "arguments"
+            ],
+            "type": "object"
+          },
+          "role": {
+            "description": "The role of the author of this message.",
+            "enum": [
+              "assistant"
+            ],
+            "type": "string"
+          },
+          "tool_calls": {
+            "$ref": "#/components/schemas/ChatCompletionMessageToolCalls"
           }
         },
         "required": [
@@ -72,44 +644,19 @@
         ],
         "type": "object"
       },
-      "ChatCompletionResponseMessage": {
-        "properties": {
-          "content": {
-            "description": "The contents of the message.",
-            "nullable": true,
-            "type": "string"
-          },
-          "function_call": {
-            "description": "The name and arguments of a function that should be called, as generated by the model.",
-            "properties": {
-              "arguments": {
-                "description": "The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function.",
-                "type": "string"
-              },
-              "name": {
-                "description": "The name of the function to call.",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "role": {
-            "description": "The role of the author of this message.",
-            "enum": [
-              "system",
-              "user",
-              "assistant",
-              "function"
-            ],
-            "type": "string"
-          }
-        },
-        "required": [
-          "role"
+      "ChatCompletionRole": {
+        "description": "The role of the author of a message",
+        "enum": [
+          "system",
+          "user",
+          "assistant",
+          "tool",
+          "function"
         ],
-        "type": "object"
+        "type": "string"
       },
       "ChatCompletionStreamResponseDelta": {
+        "description": "A chat completion delta generated by streamed model responses.",
         "properties": {
           "content": {
             "description": "The contents of the chunk message.",
@@ -117,7 +664,8 @@
             "type": "string"
           },
           "function_call": {
-            "description": "The name and arguments of a function that should be called, as generated by the model.",
+            "deprecated": true,
+            "description": "Deprecated and replaced by `tool_calls`. The name and arguments of a function that should be called, as generated by the model.",
             "properties": {
               "arguments": {
                 "description": "The arguments to call the function with, as generated by the model in JSON format. Note that the model does not always generate valid JSON, and may hallucinate parameters not defined by your function schema. Validate the arguments in your code before calling your function.",
@@ -136,27 +684,278 @@
               "system",
               "user",
               "assistant",
+              "tool"
+            ],
+            "type": "string"
+          },
+          "tool_calls": {
+            "items": {
+              "$ref": "#/components/schemas/ChatCompletionMessageToolCallChunk"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ChatCompletionTool": {
+        "properties": {
+          "function": {
+            "properties": {
+              "description": {
+                "description": "A description of what the function does, used by the model to choose when and how to call the function.",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 64.",
+                "type": "string"
+              },
+              "parameters": {
+                "$ref": "#/components/schemas/ChatCompletionFunctionParameters"
+              }
+            },
+            "required": [
+              "name",
+              "parameters"
+            ],
+            "type": "object"
+          },
+          "type": {
+            "description": "The type of the tool. Currently, only `function` is supported.",
+            "enum": [
               "function"
             ],
             "type": "string"
           }
         },
+        "required": [
+          "type",
+          "function"
+        ],
         "type": "object"
+      },
+      "ChatCompletionToolChoiceOption": {
+        "description": "Controls which (if any) function is called by the model.\n`none` means the model will not call a function and instead generates a message.\n`auto` means the model can pick between generating a message or calling a function.\nSpecifying a particular function via `{\"type: \"function\", \"function\": {\"name\": \"my_function\"}}` forces the model to call that function.\n\n`none` is the default when no functions are present. `auto` is the default if functions are present.\n",
+        "oneOf": [
+          {
+            "description": "`none` means the model will not call a function and instead generates a message. `auto` means the model can pick between generating a message or calling a function.\n",
+            "enum": [
+              "none",
+              "auto"
+            ],
+            "type": "string"
+          },
+          {
+            "$ref": "#/components/schemas/ChatCompletionNamedToolChoice"
+          }
+        ],
+        "x-oaiExpandable": true
+      },
+      "CompletionUsage": {
+        "description": "Usage statistics for the completion request.",
+        "properties": {
+          "completion_tokens": {
+            "description": "Number of tokens in the generated completion.",
+            "type": "integer"
+          },
+          "prompt_tokens": {
+            "description": "Number of tokens in the prompt.",
+            "type": "integer"
+          },
+          "total_tokens": {
+            "description": "Total number of tokens used in the request (prompt + completion).",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "prompt_tokens",
+          "completion_tokens",
+          "total_tokens"
+        ],
+        "type": "object"
+      },
+      "CreateAssistantFileRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "file_id": {
+            "description": "A [File](/docs/api-reference/files) ID (with `purpose=\"assistants\"`) that the assistant should use. Useful for tools like `retrieval` and `code_interpreter` that can access files.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_id"
+        ],
+        "type": "object"
+      },
+      "CreateAssistantRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "description": "The description of the assistant. The maximum length is 512 characters.\n",
+            "maxLength": 512,
+            "nullable": true,
+            "type": "string"
+          },
+          "file_ids": {
+            "default": [],
+            "description": "A list of [file](/docs/api-reference/files) IDs attached to this assistant. There can be a maximum of 20 files attached to the assistant. Files are ordered by their creation date in ascending order.\n",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 20,
+            "type": "array"
+          },
+          "instructions": {
+            "description": "The system instructions that the assistant uses. The maximum length is 32768 characters.\n",
+            "maxLength": 32768,
+            "nullable": true,
+            "type": "string"
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "nullable": true,
+            "type": "object",
+            "x-oaiTypeLabel": "map"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              }
+            ],
+            "description": "ID of the model to use. You can use the [List models](/docs/api-reference/models/list) API to see all of your available models, or see our [Model overview](/docs/models/overview) for descriptions of them.\n"
+          },
+          "name": {
+            "description": "The name of the assistant. The maximum length is 256 characters.\n",
+            "maxLength": 256,
+            "nullable": true,
+            "type": "string"
+          },
+          "tools": {
+            "default": [],
+            "description": "A list of tool enabled on the assistant. There can be a maximum of 128 tools per assistant. Tools can be of types `code_interpreter`, `retrieval`, or `function`.\n",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AssistantToolsCode"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsRetrieval"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsFunction"
+                }
+              ],
+              "x-oaiExpandable": true
+            },
+            "maxItems": 128,
+            "type": "array"
+          }
+        },
+        "required": [
+          "model"
+        ],
+        "type": "object"
+      },
+      "CreateChatCompletionFunctionResponse": {
+        "description": "Represents a chat completion response returned by model, based on the provided input.",
+        "properties": {
+          "choices": {
+            "description": "A list of chat completion choices. Can be more than one if `n` is greater than 1.",
+            "items": {
+              "properties": {
+                "finish_reason": {
+                  "description": "The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence, `length` if the maximum number of tokens specified in the request was reached, `content_filter` if content was omitted due to a flag from our content filters, or `function_call` if the model called a function.\n",
+                  "enum": [
+                    "stop",
+                    "length",
+                    "function_call",
+                    "content_filter"
+                  ],
+                  "type": "string"
+                },
+                "index": {
+                  "description": "The index of the choice in the list of choices.",
+                  "type": "integer"
+                },
+                "message": {
+                  "$ref": "#/components/schemas/ChatCompletionResponseMessage"
+                }
+              },
+              "required": [
+                "finish_reason",
+                "index",
+                "message"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "created": {
+            "description": "The Unix timestamp (in seconds) of when the chat completion was created.",
+            "type": "integer"
+          },
+          "id": {
+            "description": "A unique identifier for the chat completion.",
+            "type": "string"
+          },
+          "model": {
+            "description": "The model used for the chat completion.",
+            "type": "string"
+          },
+          "object": {
+            "description": "The object type, which is always `chat.completion`.",
+            "enum": [
+              "chat.completion"
+            ],
+            "type": "string"
+          },
+          "system_fingerprint": {
+            "description": "This fingerprint represents the backend configuration that the model runs with.\n\nCan be used in conjunction with the `seed` request parameter to understand when backend changes have been made that might impact determinism.\n",
+            "type": "string"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/CompletionUsage"
+          }
+        },
+        "required": [
+          "choices",
+          "created",
+          "id",
+          "model",
+          "object"
+        ],
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"choices\": [\n    {\n      \"finish_reason\": \"function_call\",\n      \"index\": 0,\n      \"message\": {\n        \"content\": null,\n        \"function_call\": {\n          \"arguments\": \"{\\n  \\\"location\\\": \\\"Boston, MA\\\"\\n}\",\n          \"name\": \"get_current_weather\"\n        },\n        \"role\": \"assistant\"\n      }\n    }\n  ],\n  \"created\": 1694028367,\n  \"model\": \"gpt-3.5-turbo-0613\",\n  \"system_fingerprint\": \"fp_44709d6fcb\",\n  \"object\": \"chat.completion\",\n  \"usage\": {\n    \"completion_tokens\": 18,\n    \"prompt_tokens\": 82,\n    \"total_tokens\": 100\n  }\n}\n",
+          "group": "chat",
+          "name": "The chat completion object"
+        }
+      },
+      "CreateChatCompletionImageResponse": {
+        "description": "Represents a streamed chunk of a chat completion response returned by model, based on the provided input.",
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"id\": \"chatcmpl-123\",\n  \"object\": \"chat.completion\",\n  \"created\": 1677652288,\n  \"model\": \"gpt-3.5-turbo-0613\",\n  \"system_fingerprint\": \"fp_44709d6fcb\",\n  \"choices\": [{\n    \"index\": 0,\n    \"message\": {\n      \"role\": \"assistant\",\n      \"content\": \"\\n\\nHello there, how may I assist you today?\",\n    },\n    \"finish_reason\": \"stop\"\n  }],\n  \"usage\": {\n    \"prompt_tokens\": 9,\n    \"completion_tokens\": 12,\n    \"total_tokens\": 21\n  }\n}\n",
+          "group": "chat",
+          "name": "The chat completion chunk object"
+        }
       },
       "CreateChatCompletionRequest": {
         "properties": {
           "frequency_penalty": {
             "default": 0,
-            "description": "Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.\n\n[See more information about frequency and presence penalties.](https://platform.openai.com/docs/api-reference/parameter-details)\n",
+            "description": "Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.\n\n[See more information about frequency and presence penalties.](/docs/guides/gpt/parameter-details)\n",
             "maximum": 2,
             "minimum": -2,
             "nullable": true,
             "type": "number"
           },
           "function_call": {
-            "description": "Controls how the model responds to function calls. \"none\" means the model does not call a function, and responds to the end-user. \"auto\" means the model can pick between an end-user or calling a function.  Specifying a particular function via `{\"name\":\\ \"my_function\"}` forces the model to call that function. \"none\" is the default when no functions are present. \"auto\" is the default if functions are present.",
+            "deprecated": true,
+            "description": "Deprecated in favor of `tool_choice`.\n\nControls which (if any) function is called by the model.\n`none` means the model will not call a function and instead generates a message.\n`auto` means the model can pick between generating a message or calling a function.\nSpecifying a particular function via `{\"name\": \"my_function\"}` forces the model to call that function.\n\n`none` is the default when no functions are present. `auto`` is the default if functions are present.\n",
             "oneOf": [
               {
+                "description": "`none` means the model will not call a function and instead generates a message. `auto` means the model can pick between generating a message or calling a function.\n",
                 "enum": [
                   "none",
                   "auto"
@@ -164,24 +963,18 @@
                 "type": "string"
               },
               {
-                "properties": {
-                  "name": {
-                    "description": "The name of the function to call.",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "name"
-                ],
-                "type": "object"
+                "$ref": "#/components/schemas/ChatCompletionFunctionCallOption"
               }
-            ]
+            ],
+            "x-oaiExpandable": true
           },
           "functions": {
-            "description": "A list of functions the model may generate JSON inputs for.",
+            "deprecated": true,
+            "description": "Deprecated in favor of `tools`.\n\nA list of functions the model may generate JSON inputs for.\n",
             "items": {
               "$ref": "#/components/schemas/ChatCompletionFunctions"
             },
+            "maxItems": 128,
             "minItems": 1,
             "type": "array"
           },
@@ -190,18 +983,19 @@
               "type": "integer"
             },
             "default": null,
-            "description": "Modify the likelihood of specified tokens appearing in the completion.\n\nAccepts a json object that maps tokens (specified by their token ID in the tokenizer) to an associated bias value from -100 to 100. Mathematically, the bias is added to the logits generated by the model prior to sampling. The exact effect will vary per model, but values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.\n",
+            "description": "Modify the likelihood of specified tokens appearing in the completion.\n\nAccepts a JSON object that maps tokens (specified by their token ID in the tokenizer) to an associated bias value from -100 to 100. Mathematically, the bias is added to the logits generated by the model prior to sampling. The exact effect will vary per model, but values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.\n",
             "nullable": true,
             "type": "object",
             "x-oaiTypeLabel": "map"
           },
           "max_tokens": {
             "default": "inf",
-            "description": "The maximum number of <a href=\"https://platform.openai.com/tokenizer\">tokens</a> to generate in the chat completion.\n\nThe total length of input tokens and generated tokens is limited by the model's context length. <a href=\"https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb\">Example Python code</a> for counting tokens.\n",
+            "description": "The maximum number of [tokens](/tokenizer) to generate in the chat completion.\n\nThe total length of input tokens and generated tokens is limited by the model's context length. [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken) for counting tokens.\n",
+            "nullable": true,
             "type": "integer"
           },
           "messages": {
-            "description": "A list of messages comprising the conversation so far. [Example Python code](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_format_inputs_to_ChatGPT_models.ipynb).",
+            "description": "A list of messages comprising the conversation so far. [Example Python code](https://cookbook.openai.com/examples/how_to_format_inputs_to_chatgpt_models).",
             "items": {
               "$ref": "#/components/schemas/ChatCompletionRequestMessage"
             },
@@ -209,8 +1003,10 @@
             "type": "array"
           },
           "model": {
-            "description": "ID of the model to use. See the <a href=\"https://platform.openai.com/docs/models/model-endpoint-compatibility\">model endpoint compatibility</a> table for details on which models work with the Chat API.",
+            "description": "ID of the model to use. See the [model endpoint compatibility](/docs/models/model-endpoint-compatibility) table for details on which models work with the Chat API.",
             "enum": [
+              "gpt-4-1106-preview",
+              "gpt-4-vision-preview",
               "gpt-4",
               "gpt-4-0314",
               "gpt-4-0613",
@@ -238,11 +1034,37 @@
           },
           "presence_penalty": {
             "default": 0,
-            "description": "Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.\n\n[See more information about frequency and presence penalties.](https://platform.openai.com/docs/api-reference/parameter-details)\n",
+            "description": "Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.\n\n[See more information about frequency and presence penalties.](/docs/guides/gpt/parameter-details)\n",
             "maximum": 2,
             "minimum": -2,
             "nullable": true,
             "type": "number"
+          },
+          "response_format": {
+            "description": "An object specifying the format that the model must output. Used to enable JSON mode.",
+            "properties": {
+              "type": {
+                "default": "text",
+                "description": "Setting to `json_object` enables JSON mode. This guarantees that the message the model generates is valid JSON. \n\nNote that your system prompt must still instruct the model to produce JSON, and to help ensure you don't forget, the API will throw an error if the string `JSON` does not appear in your system message. Also note that the message content may be partial (i.e. cut off) if `finish_reason=\"length\"`, which indicates the generation exceeded `max_tokens` or the conversation exceeded the max context length. \n\nMust be one of `text` or `json_object`.\n",
+                "enum": [
+                  "text",
+                  "json_object"
+                ],
+                "example": "json_object",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "seed": {
+            "description": "This feature is in Beta. \nIf specified, our system will make a best effort to sample deterministically, such that repeated requests with the same `seed` and parameters should return the same result.\nDeterminism is not guaranteed, and you should refer to the `system_fingerprint` response parameter to monitor changes in the backend.\n",
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "nullable": true,
+            "type": "integer",
+            "x-oaiMeta": {
+              "beta": true
+            }
           },
           "stop": {
             "default": null,
@@ -264,7 +1086,7 @@
           },
           "stream": {
             "default": false,
-            "description": "If set, partial message deltas will be sent, like in ChatGPT. Tokens will be sent as data-only [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format) as they become available, with the stream terminated by a `data: [DONE]` message. [Example Python code](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_stream_completions.ipynb).\n",
+            "description": "If set, partial message deltas will be sent, like in ChatGPT. Tokens will be sent as data-only [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format) as they become available, with the stream terminated by a `data: [DONE]` message. [Example Python code](https://cookbook.openai.com/examples/how_to_stream_completions).\n",
             "nullable": true,
             "type": "boolean"
           },
@@ -277,6 +1099,16 @@
             "nullable": true,
             "type": "number"
           },
+          "tool_choice": {
+            "$ref": "#/components/schemas/ChatCompletionToolChoiceOption"
+          },
+          "tools": {
+            "description": "A list of tools the model may call. Currently, only functions are supported as a tool. Use this to provide a list of functions the model may generate JSON inputs for.\n",
+            "items": {
+              "$ref": "#/components/schemas/ChatCompletionTool"
+            },
+            "type": "array"
+          },
           "top_p": {
             "default": 1,
             "description": "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.\n\nWe generally recommend altering this or `temperature` but not both.\n",
@@ -287,7 +1119,7 @@
             "type": "number"
           },
           "user": {
-            "description": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).\n",
+            "description": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](/docs/guides/safety-best-practices/end-user-ids).\n",
             "example": "user-1234",
             "type": "string"
           }
@@ -299,19 +1131,25 @@
         "type": "object"
       },
       "CreateChatCompletionResponse": {
+        "description": "Represents a chat completion response returned by model, based on the provided input.",
         "properties": {
           "choices": {
+            "description": "A list of chat completion choices. Can be more than one if `n` is greater than 1.",
             "items": {
               "properties": {
                 "finish_reason": {
+                  "description": "The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,\n`length` if the maximum number of tokens specified in the request was reached,\n`content_filter` if content was omitted due to a flag from our content filters,\n`tool_calls` if the model called a tool, or `function_call` (deprecated) if the model called a function.\n",
                   "enum": [
                     "stop",
                     "length",
+                    "tool_calls",
+                    "content_filter",
                     "function_call"
                   ],
                   "type": "string"
                 },
                 "index": {
+                  "description": "The index of the choice in the list of choices.",
                   "type": "integer"
                 },
                 "message": {
@@ -319,106 +1157,128 @@
                 }
               },
               "required": [
+                "finish_reason",
                 "index",
-                "message",
-                "finish_reason"
+                "message"
               ],
               "type": "object"
             },
             "type": "array"
           },
           "created": {
+            "description": "The Unix timestamp (in seconds) of when the chat completion was created.",
             "type": "integer"
           },
           "id": {
+            "description": "A unique identifier for the chat completion.",
             "type": "string"
           },
           "model": {
+            "description": "The model used for the chat completion.",
             "type": "string"
           },
           "object": {
+            "description": "The object type, which is always `chat.completion`.",
+            "enum": [
+              "chat.completion"
+            ],
+            "type": "string"
+          },
+          "system_fingerprint": {
+            "description": "This fingerprint represents the backend configuration that the model runs with.\n\nCan be used in conjunction with the `seed` request parameter to understand when backend changes have been made that might impact determinism.\n",
             "type": "string"
           },
           "usage": {
-            "properties": {
-              "completion_tokens": {
-                "type": "integer"
-              },
-              "prompt_tokens": {
-                "type": "integer"
-              },
-              "total_tokens": {
-                "type": "integer"
-              }
-            },
-            "required": [
-              "prompt_tokens",
-              "completion_tokens",
-              "total_tokens"
-            ],
-            "type": "object"
+            "$ref": "#/components/schemas/CompletionUsage"
           }
         },
         "required": [
-          "id",
-          "object",
+          "choices",
           "created",
+          "id",
           "model",
-          "choices"
+          "object"
         ],
-        "type": "object"
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"id\": \"chatcmpl-123\",\n  \"object\": \"chat.completion\",\n  \"created\": 1677652288,\n  \"model\": \"gpt-3.5-turbo-0613\",\n  \"system_fingerprint\": \"fp_44709d6fcb\",\n  \"choices\": [{\n    \"index\": 0,\n    \"message\": {\n      \"role\": \"assistant\",\n      \"content\": \"\\n\\nHello there, how may I assist you today?\",\n    },\n    \"finish_reason\": \"stop\"\n  }],\n  \"usage\": {\n    \"prompt_tokens\": 9,\n    \"completion_tokens\": 12,\n    \"total_tokens\": 21\n  }\n}\n",
+          "group": "chat",
+          "name": "The chat completion object"
+        }
       },
       "CreateChatCompletionStreamResponse": {
+        "description": "Represents a streamed chunk of a chat completion response returned by model, based on the provided input.",
         "properties": {
           "choices": {
+            "description": "A list of chat completion choices. Can be more than one if `n` is greater than 1.",
             "items": {
               "properties": {
                 "delta": {
                   "$ref": "#/components/schemas/ChatCompletionStreamResponseDelta"
                 },
                 "finish_reason": {
+                  "description": "The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,\n`length` if the maximum number of tokens specified in the request was reached,\n`content_filter` if content was omitted due to a flag from our content filters,\n`tool_calls` if the model called a tool, or `function_call` (deprecated) if the model called a function.\n",
                   "enum": [
                     "stop",
                     "length",
+                    "tool_calls",
+                    "content_filter",
                     "function_call"
                   ],
                   "nullable": true,
                   "type": "string"
                 },
                 "index": {
+                  "description": "The index of the choice in the list of choices.",
                   "type": "integer"
                 }
               },
               "required": [
-                "index",
                 "delta",
-                "finish_reason"
+                "finish_reason",
+                "index"
               ],
               "type": "object"
             },
             "type": "array"
           },
           "created": {
+            "description": "The Unix timestamp (in seconds) of when the chat completion was created. Each chunk has the same timestamp.",
             "type": "integer"
           },
           "id": {
+            "description": "A unique identifier for the chat completion. Each chunk has the same ID.",
             "type": "string"
           },
           "model": {
+            "description": "The model to generate the completion.",
             "type": "string"
           },
           "object": {
+            "description": "The object type, which is always `chat.completion.chunk`.",
+            "enum": [
+              "chat.completion.chunk"
+            ],
+            "type": "string"
+          },
+          "system_fingerprint": {
+            "description": "This fingerprint represents the backend configuration that the model runs with.\n\nCan be used in conjunction with the `seed` request parameter to understand when backend changes have been made that might impact determinism.\n",
             "type": "string"
           }
         },
         "required": [
-          "id",
-          "object",
+          "choices",
           "created",
+          "id",
           "model",
-          "choices"
+          "object"
         ],
-        "type": "object"
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"created\":1694268190,\"model\":\"gpt-3.5-turbo-0613\", \"system_fingerprint\": \"fp_44709d6fcb\", \"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"},\"finish_reason\":null}]}\n\n{\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"created\":1694268190,\"model\":\"gpt-3.5-turbo-0613\", \"system_fingerprint\": \"fp_44709d6fcb\", \"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n{\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"created\":1694268190,\"model\":\"gpt-3.5-turbo-0613\", \"system_fingerprint\": \"fp_44709d6fcb\", \"choices\":[{\"index\":0,\"delta\":{\"content\":\"!\"},\"finish_reason\":null}]}\n\n....\n\n{\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"created\":1694268190,\"model\":\"gpt-3.5-turbo-0613\", \"system_fingerprint\": \"fp_44709d6fcb\", \"choices\":[{\"index\":0,\"delta\":{\"content\":\" today\"},\"finish_reason\":null}]}\n\n{\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"created\":1694268190,\"model\":\"gpt-3.5-turbo-0613\", \"system_fingerprint\": \"fp_44709d6fcb\", \"choices\":[{\"index\":0,\"delta\":{\"content\":\"?\"},\"finish_reason\":null}]}\n\n{\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"created\":1694268190,\"model\":\"gpt-3.5-turbo-0613\", \"system_fingerprint\": \"fp_44709d6fcb\", \"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n",
+          "group": "chat",
+          "name": "The chat completion chunk object"
+        }
       },
       "CreateCompletionRequest": {
         "properties": {
@@ -438,7 +1298,7 @@
           },
           "frequency_penalty": {
             "default": 0,
-            "description": "Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.\n\n[See more information about frequency and presence penalties.](https://platform.openai.com/docs/api-reference/parameter-details)\n",
+            "description": "Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.\n\n[See more information about frequency and presence penalties.](/docs/guides/gpt/parameter-details)\n",
             "maximum": 2,
             "minimum": -2,
             "nullable": true,
@@ -449,7 +1309,7 @@
               "type": "integer"
             },
             "default": null,
-            "description": "Modify the likelihood of specified tokens appearing in the completion.\n\nAccepts a json object that maps tokens (specified by their token ID in the GPT tokenizer) to an associated bias value from -100 to 100. You can use this [tokenizer tool](/tokenizer?view=bpe) (which works for both GPT-2 and GPT-3) to convert text to token IDs. Mathematically, the bias is added to the logits generated by the model prior to sampling. The exact effect will vary per model, but values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.\n\nAs an example, you can pass `{\"50256\": -100}` to prevent the <|endoftext|> token from being generated.\n",
+            "description": "Modify the likelihood of specified tokens appearing in the completion.\n\nAccepts a JSON object that maps tokens (specified by their token ID in the GPT tokenizer) to an associated bias value from -100 to 100. You can use this [tokenizer tool](/tokenizer?view=bpe) (which works for both GPT-2 and GPT-3) to convert text to token IDs. Mathematically, the bias is added to the logits generated by the model prior to sampling. The exact effect will vary per model, but values between -1 and 1 should decrease or increase likelihood of selection; values like -100 or 100 should result in a ban or exclusive selection of the relevant token.\n\nAs an example, you can pass `{\"50256\": -100}` to prevent the <|endoftext|> token from being generated.\n",
             "nullable": true,
             "type": "object",
             "x-oaiTypeLabel": "map"
@@ -464,24 +1324,34 @@
           },
           "max_tokens": {
             "default": 16,
-            "description": "The maximum number of [tokens](/tokenizer) to generate in the completion.\n\nThe token count of your prompt plus `max_tokens` cannot exceed the model's context length. [Example Python code](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb) for counting tokens.\n",
+            "description": "The maximum number of [tokens](/tokenizer) to generate in the completion.\n\nThe token count of your prompt plus `max_tokens` cannot exceed the model's context length. [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken) for counting tokens.\n",
             "example": 16,
             "minimum": 0,
             "nullable": true,
             "type": "integer"
           },
           "model": {
-            "description": "ID of the model to use. You can use the [List models](https://platform.openai.com/docs/api-reference/models/list) API to see all of your available models, or see our [Model overview](https://platform.openai.com/docs/models/overview) for descriptions of them.\n",
-            "enum": [
-              "text-davinci-003",
-              "text-davinci-002",
-              "text-davinci-001",
-              "code-davinci-002",
-              "text-curie-001",
-              "text-babbage-001",
-              "text-ada-001"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "babbage-002",
+                  "davinci-002",
+                  "gpt-3.5-turbo-instruct",
+                  "text-davinci-003",
+                  "text-davinci-002",
+                  "text-davinci-001",
+                  "code-davinci-002",
+                  "text-curie-001",
+                  "text-babbage-001",
+                  "text-ada-001"
+                ],
+                "type": "string"
+              }
             ],
-            "type": "string",
+            "description": "ID of the model to use. You can use the [List models](/docs/api-reference/models/list) API to see all of your available models, or see our [Model overview](/docs/models/overview) for descriptions of them.\n",
             "x-oaiTypeLabel": "string"
           },
           "n": {
@@ -495,7 +1365,7 @@
           },
           "presence_penalty": {
             "default": 0,
-            "description": "Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.\n\n[See more information about frequency and presence penalties.](https://platform.openai.com/docs/api-reference/parameter-details)\n",
+            "description": "Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.\n\n[See more information about frequency and presence penalties.](/docs/guides/gpt/parameter-details)\n",
             "maximum": 2,
             "minimum": -2,
             "nullable": true,
@@ -541,6 +1411,13 @@
               }
             ]
           },
+          "seed": {
+            "description": "If specified, our system will make a best effort to sample deterministically, such that repeated requests with the same `seed` and parameters should return the same result.\n\nDeterminism is not guaranteed, and you should refer to the `system_fingerprint` response parameter to monitor changes in the backend.\n",
+            "maximum": 9223372036854776000,
+            "minimum": -9223372036854776000,
+            "nullable": true,
+            "type": "integer"
+          },
           "stop": {
             "default": null,
             "description": "Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence.\n",
@@ -565,7 +1442,7 @@
           },
           "stream": {
             "default": false,
-            "description": "Whether to stream back partial progress. If set, tokens will be sent as data-only [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format) as they become available, with the stream terminated by a `data: [DONE]` message. [Example Python code](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_stream_completions.ipynb).\n",
+            "description": "Whether to stream back partial progress. If set, tokens will be sent as data-only [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format) as they become available, with the stream terminated by a `data: [DONE]` message. [Example Python code](https://cookbook.openai.com/examples/how_to_stream_completions).\n",
             "nullable": true,
             "type": "boolean"
           },
@@ -595,7 +1472,7 @@
             "type": "number"
           },
           "user": {
-            "description": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).\n",
+            "description": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](/docs/guides/safety-best-practices/end-user-ids).\n",
             "example": "user-1234",
             "type": "string"
           }
@@ -607,14 +1484,18 @@
         "type": "object"
       },
       "CreateCompletionResponse": {
+        "description": "Represents a completion response from the API. Note: both the streamed and non-streamed response objects share the same shape (unlike the chat endpoint).\n",
         "properties": {
           "choices": {
+            "description": "The list of completion choices the model generated for the input prompt.",
             "items": {
               "properties": {
                 "finish_reason": {
+                  "description": "The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,\n`length` if the maximum number of tokens specified in the request was reached,\nor `content_filter` if content was omitted due to a flag from our content filters.\n",
                   "enum": [
                     "stop",
-                    "length"
+                    "length",
+                    "content_filter"
                   ],
                   "type": "string"
                 },
@@ -659,45 +1540,40 @@
                 }
               },
               "required": [
-                "text",
+                "finish_reason",
                 "index",
                 "logprobs",
-                "finish_reason"
+                "text"
               ],
               "type": "object"
             },
             "type": "array"
           },
           "created": {
+            "description": "The Unix timestamp (in seconds) of when the completion was created.",
             "type": "integer"
           },
           "id": {
+            "description": "A unique identifier for the completion.",
             "type": "string"
           },
           "model": {
+            "description": "The model used for completion.",
             "type": "string"
           },
           "object": {
+            "description": "The object type, which is always \"text_completion\"",
+            "enum": [
+              "text_completion"
+            ],
+            "type": "string"
+          },
+          "system_fingerprint": {
+            "description": "This fingerprint represents the backend configuration that the model runs with.\n\nCan be used in conjunction with the `seed` request parameter to understand when backend changes have been made that might impact determinism.\n",
             "type": "string"
           },
           "usage": {
-            "properties": {
-              "completion_tokens": {
-                "type": "integer"
-              },
-              "prompt_tokens": {
-                "type": "integer"
-              },
-              "total_tokens": {
-                "type": "integer"
-              }
-            },
-            "required": [
-              "prompt_tokens",
-              "completion_tokens",
-              "total_tokens"
-            ],
-            "type": "object"
+            "$ref": "#/components/schemas/CompletionUsage"
           }
         },
         "required": [
@@ -707,7 +1583,12 @@
           "model",
           "choices"
         ],
-        "type": "object"
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"id\": \"cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7\",\n  \"object\": \"text_completion\",\n  \"created\": 1589478378,\n  \"model\": \"gpt-3.5-turbo\",\n  \"choices\": [\n    {\n      \"text\": \"\\n\\nThis is indeed a test\",\n      \"index\": 0,\n      \"logprobs\": null,\n      \"finish_reason\": \"length\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 5,\n    \"completion_tokens\": 7,\n    \"total_tokens\": 12\n  }\n}\n",
+          "legacy": true,
+          "name": "The completion object"
+        }
       },
       "CreateEditRequest": {
         "properties": {
@@ -724,13 +1605,20 @@
             "type": "string"
           },
           "model": {
-            "description": "ID of the model to use. You can use the `text-davinci-edit-001` or `code-davinci-edit-001` model with this endpoint.",
-            "enum": [
-              "text-davinci-edit-001",
-              "code-davinci-edit-001"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "text-davinci-edit-001",
+                  "code-davinci-edit-001"
+                ],
+                "type": "string"
+              }
             ],
+            "description": "ID of the model to use. You can use the `text-davinci-edit-001` or `code-davinci-edit-001` model with this endpoint.",
             "example": "text-davinci-edit-001",
-            "type": "string",
             "x-oaiTypeLabel": "string"
           },
           "n": {
@@ -768,11 +1656,14 @@
         "type": "object"
       },
       "CreateEditResponse": {
+        "deprecated": true,
         "properties": {
           "choices": {
+            "description": "A list of edit choices. Can be more than one if `n` is greater than 1.",
             "items": {
               "properties": {
                 "finish_reason": {
+                  "description": "The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,\n`length` if the maximum number of tokens specified in the request was reached,\nor `content_filter` if content was omitted due to a flag from our content filters.\n",
                   "enum": [
                     "stop",
                     "length"
@@ -780,9 +1671,11 @@
                   "type": "string"
                 },
                 "index": {
+                  "description": "The index of the choice in the list of choices.",
                   "type": "integer"
                 },
                 "text": {
+                  "description": "The edited result.",
                   "type": "string"
                 }
               },
@@ -796,29 +1689,18 @@
             "type": "array"
           },
           "created": {
+            "description": "The Unix timestamp (in seconds) of when the edit was created.",
             "type": "integer"
           },
           "object": {
+            "description": "The object type, which is always `edit`.",
+            "enum": [
+              "edit"
+            ],
             "type": "string"
           },
           "usage": {
-            "properties": {
-              "completion_tokens": {
-                "type": "integer"
-              },
-              "prompt_tokens": {
-                "type": "integer"
-              },
-              "total_tokens": {
-                "type": "integer"
-              }
-            },
-            "required": [
-              "prompt_tokens",
-              "completion_tokens",
-              "total_tokens"
-            ],
-            "type": "object"
+            "$ref": "#/components/schemas/CompletionUsage"
           }
         },
         "required": [
@@ -827,13 +1709,28 @@
           "choices",
           "usage"
         ],
-        "type": "object"
+        "title": "Edit",
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"object\": \"edit\",\n  \"created\": 1589478378,\n  \"choices\": [\n    {\n      \"text\": \"What day of the week is it?\",\n      \"index\": 0,\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 25,\n    \"completion_tokens\": 32,\n    \"total_tokens\": 57\n  }\n}\n",
+          "name": "The edit object"
+        }
       },
       "CreateEmbeddingRequest": {
         "additionalProperties": false,
         "properties": {
+          "encoding_format": {
+            "default": "float",
+            "description": "The format to return the embeddings in. Can be either `float` or [`base64`](https://pypi.org/project/pybase64/).",
+            "enum": [
+              "float",
+              "base64"
+            ],
+            "example": "float",
+            "type": "string"
+          },
           "input": {
-            "description": "Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays. Each input must not exceed the max input tokens for the model (8191 tokens for `text-embedding-ada-002`). [Example Python code](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb) for counting tokens.\n",
+            "description": "Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays. The input must not exceed the max input tokens for the model (8192 tokens for `text-embedding-ada-002`) and cannot be an empty string. [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken) for counting tokens.\n",
             "example": "The quick brown fox jumped over the lazy dog",
             "oneOf": [
               {
@@ -847,6 +1744,7 @@
                   "example": "This is a test.",
                   "type": "string"
                 },
+                "minItems": 1,
                 "type": "array"
               },
               {
@@ -872,7 +1770,7 @@
             ]
           },
           "model": {
-            "description": "ID of the model to use. You can use the [List models](https://platform.openai.com/docs/api-reference/models/list) API to see all of your available models, or see our [Model overview](https://platform.openai.com/docs/models/overview) for descriptions of them.\n",
+            "description": "ID of the model to use. You can use the [List models](/docs/api-reference/models/list) API to see all of your available models, or see our [Model overview](/docs/models/overview) for descriptions of them.\n",
             "enum": [
               "text-embedding-ada-002"
             ],
@@ -881,7 +1779,7 @@
             "x-oaiTypeLabel": "string"
           },
           "user": {
-            "description": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).\n",
+            "description": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](/docs/guides/safety-best-practices/end-user-ids).\n",
             "example": "user-1234",
             "type": "string"
           }
@@ -895,42 +1793,32 @@
       "CreateEmbeddingResponse": {
         "properties": {
           "data": {
+            "description": "The list of embeddings generated by the model.",
             "items": {
-              "properties": {
-                "embedding": {
-                  "items": {
-                    "type": "number"
-                  },
-                  "type": "array"
-                },
-                "index": {
-                  "type": "integer"
-                },
-                "object": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "index",
-                "object",
-                "embedding"
-              ],
-              "type": "object"
+              "$ref": "#/components/schemas/Embedding"
             },
             "type": "array"
           },
           "model": {
+            "description": "The name of the model used to generate the embedding.",
             "type": "string"
           },
           "object": {
+            "description": "The object type, which is always \"embedding\".",
+            "enum": [
+              "embedding"
+            ],
             "type": "string"
           },
           "usage": {
+            "description": "The usage information for the request.",
             "properties": {
               "prompt_tokens": {
+                "description": "The number of tokens used by the prompt.",
                 "type": "integer"
               },
               "total_tokens": {
+                "description": "The total number of tokens used by the request.",
                 "type": "integer"
               }
             },
@@ -953,12 +1841,16 @@
         "additionalProperties": false,
         "properties": {
           "file": {
-            "description": "Name of the [JSON Lines](https://jsonlines.readthedocs.io/en/latest/) file to be uploaded.\n\nIf the `purpose` is set to \"fine-tune\", each line is a JSON record with \"prompt\" and \"completion\" fields representing your [training examples](https://platform.openai.com/docs/guides/fine-tuning/prepare-training-data).\n",
+            "description": "The File object (not file name) to be uploaded.\n",
             "format": "binary",
             "type": "string"
           },
           "purpose": {
-            "description": "The intended purpose of the uploaded documents.\n\nUse \"fine-tune\" for [Fine-tuning](https://platform.openai.com/docs/api-reference/fine-tunes). This allows us to validate the format of the uploaded file.\n",
+            "description": "The intended purpose of the uploaded file.\n\nUse \"fine-tune\" for [Fine-tuning](/docs/api-reference/fine-tuning) and \"assistants\" for [Assistants](/docs/api-reference/assistants) and [Messages](/docs/api-reference/messages). This allows us to validate the format of the uploaded file is correct for fine-tuning.\n",
+            "enum": [
+              "fine-tune",
+              "assistants"
+            ],
             "type": "string"
           }
         },
@@ -1005,9 +1897,32 @@
           },
           "compute_classification_metrics": {
             "default": false,
-            "description": "If set, we calculate classification-specific metrics such as accuracy\nand F-1 score using the validation set at the end of every epoch.\nThese metrics can be viewed in the [results file](https://platform.openai.com/docs/guides/fine-tuning/analyzing-your-fine-tuned-model).\n\nIn order to compute classification metrics, you must provide a\n`validation_file`. Additionally, you must\nspecify `classification_n_classes` for multiclass classification or\n`classification_positive_class` for binary classification.\n",
+            "description": "If set, we calculate classification-specific metrics such as accuracy\nand F-1 score using the validation set at the end of every epoch.\nThese metrics can be viewed in the [results file](/docs/guides/legacy-fine-tuning/analyzing-your-fine-tuned-model).\n\nIn order to compute classification metrics, you must provide a\n`validation_file`. Additionally, you must\nspecify `classification_n_classes` for multiclass classification or\n`classification_positive_class` for binary classification.\n",
             "nullable": true,
             "type": "boolean"
+          },
+          "hyperparameters": {
+            "description": "The hyperparameters used for the fine-tuning job.",
+            "properties": {
+              "n_epochs": {
+                "default": "auto",
+                "description": "The number of epochs to train the model for. An epoch refers to one\nfull cycle through the training dataset.\n",
+                "oneOf": [
+                  {
+                    "enum": [
+                      "auto"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  }
+                ]
+              }
+            },
+            "type": "object"
           },
           "learning_rate_multiplier": {
             "default": null,
@@ -1016,24 +1931,25 @@
             "type": "number"
           },
           "model": {
-            "default": "curie",
-            "description": "The name of the base model to fine-tune. You can select one of \"ada\",\n\"babbage\", \"curie\", \"davinci\", or a fine-tuned model created after 2022-04-21.\nTo learn more about these models, see the\n[Models](https://platform.openai.com/docs/models) documentation.\n",
-            "enum": [
-              "ada",
-              "babbage",
-              "curie",
-              "davinci"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "ada",
+                  "babbage",
+                  "curie",
+                  "davinci"
+                ],
+                "type": "string"
+              }
             ],
+            "default": "curie",
+            "description": "The name of the base model to fine-tune. You can select one of \"ada\",\n\"babbage\", \"curie\", \"davinci\", or a fine-tuned model created after 2022-04-21 and before 2023-08-22.\nTo learn more about these models, see the\n[Models](/docs/models) documentation.\n",
             "example": "curie",
             "nullable": true,
-            "type": "string",
             "x-oaiTypeLabel": "string"
-          },
-          "n_epochs": {
-            "default": 4,
-            "description": "The number of epochs to train the model for. An epoch refers to one\nfull cycle through the training dataset.\n",
-            "nullable": true,
-            "type": "integer"
           },
           "prompt_loss_weight": {
             "default": 0.01,
@@ -1050,18 +1966,121 @@
             "type": "string"
           },
           "training_file": {
-            "description": "The ID of an uploaded file that contains training data.\n\nSee [upload file](https://platform.openai.com/docs/api-reference/files/upload) for how to upload a file.\n\nYour dataset must be formatted as a JSONL file, where each training\nexample is a JSON object with the keys \"prompt\" and \"completion\".\nAdditionally, you must upload your file with the purpose `fine-tune`.\n\nSee the [fine-tuning guide](https://platform.openai.com/docs/guides/fine-tuning/creating-training-data) for more details.\n",
-            "example": "file-ajSREls59WBbvgSzJSVWxMCB",
+            "description": "The ID of an uploaded file that contains training data.\n\nSee [upload file](/docs/api-reference/files/upload) for how to upload a file.\n\nYour dataset must be formatted as a JSONL file, where each training\nexample is a JSON object with the keys \"prompt\" and \"completion\".\nAdditionally, you must upload your file with the purpose `fine-tune`.\n\nSee the [fine-tuning guide](/docs/guides/legacy-fine-tuning/creating-training-data) for more details.\n",
+            "example": "file-abc123",
             "type": "string"
           },
           "validation_file": {
-            "description": "The ID of an uploaded file that contains validation data.\n\nIf you provide this file, the data is used to generate validation\nmetrics periodically during fine-tuning. These metrics can be viewed in\nthe [fine-tuning results file](https://platform.openai.com/docs/guides/fine-tuning/analyzing-your-fine-tuned-model).\nYour train and validation data should be mutually exclusive.\n\nYour dataset must be formatted as a JSONL file, where each validation\nexample is a JSON object with the keys \"prompt\" and \"completion\".\nAdditionally, you must upload your file with the purpose `fine-tune`.\n\nSee the [fine-tuning guide](https://platform.openai.com/docs/guides/fine-tuning/creating-training-data) for more details.\n",
-            "example": "file-XjSREls59WBbvgSzJSVWxMCa",
+            "description": "The ID of an uploaded file that contains validation data.\n\nIf you provide this file, the data is used to generate validation\nmetrics periodically during fine-tuning. These metrics can be viewed in\nthe [fine-tuning results file](/docs/guides/legacy-fine-tuning/analyzing-your-fine-tuned-model).\nYour train and validation data should be mutually exclusive.\n\nYour dataset must be formatted as a JSONL file, where each validation\nexample is a JSON object with the keys \"prompt\" and \"completion\".\nAdditionally, you must upload your file with the purpose `fine-tune`.\n\nSee the [fine-tuning guide](/docs/guides/legacy-fine-tuning/creating-training-data) for more details.\n",
+            "example": "file-abc123",
             "nullable": true,
             "type": "string"
           }
         },
         "required": [
+          "training_file"
+        ],
+        "type": "object"
+      },
+      "CreateFineTuningJobRequest": {
+        "properties": {
+          "hyperparameters": {
+            "description": "The hyperparameters used for the fine-tuning job.",
+            "properties": {
+              "batch_size": {
+                "default": "auto",
+                "description": "Number of examples in each batch. A larger batch size means that model parameters\nare updated less frequently, but with lower variance.\n",
+                "oneOf": [
+                  {
+                    "enum": [
+                      "auto"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "maximum": 256,
+                    "minimum": 1,
+                    "type": "integer"
+                  }
+                ]
+              },
+              "learning_rate_multiplier": {
+                "default": "auto",
+                "description": "Scaling factor for the learning rate. A smaller learning rate may be useful to avoid\noverfitting.\n",
+                "oneOf": [
+                  {
+                    "enum": [
+                      "auto"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "type": "number"
+                  }
+                ]
+              },
+              "n_epochs": {
+                "default": "auto",
+                "description": "The number of epochs to train the model for. An epoch refers to one full cycle \nthrough the training dataset.\n",
+                "oneOf": [
+                  {
+                    "enum": [
+                      "auto"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  }
+                ]
+              }
+            },
+            "type": "object"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "babbage-002",
+                  "davinci-002",
+                  "gpt-3.5-turbo"
+                ],
+                "type": "string"
+              }
+            ],
+            "description": "The name of the model to fine-tune. You can select one of the\n[supported models](/docs/guides/fine-tuning/what-models-can-be-fine-tuned).\n",
+            "example": "gpt-3.5-turbo",
+            "x-oaiTypeLabel": "string"
+          },
+          "suffix": {
+            "default": null,
+            "description": "A string of up to 18 characters that will be added to your fine-tuned model name.\n\nFor example, a `suffix` of \"custom-model-name\" would produce a model name like `ft:gpt-3.5-turbo:openai:custom-model-name:7p4lURel`.\n",
+            "maxLength": 40,
+            "minLength": 1,
+            "nullable": true,
+            "type": "string"
+          },
+          "training_file": {
+            "description": "The ID of an uploaded file that contains training data.\n\nSee [upload file](/docs/api-reference/files/upload) for how to upload a file.\n\nYour dataset must be formatted as a JSONL file. Additionally, you must upload your file with the purpose `fine-tune`.\n\nSee the [fine-tuning guide](/docs/guides/fine-tuning) for more details.\n",
+            "example": "file-abc123",
+            "type": "string"
+          },
+          "validation_file": {
+            "description": "The ID of an uploaded file that contains validation data.\n\nIf you provide this file, the data is used to generate validation\nmetrics periodically during fine-tuning. These metrics can be viewed in\nthe fine-tuning results file.\nThe same data should not be present in both train and validation files.\n\nYour dataset must be formatted as a JSONL file. You must upload your file with the purpose `fine-tune`.\n\nSee the [fine-tuning guide](/docs/guides/fine-tuning) for more details.\n",
+            "example": "file-abc123",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "model",
           "training_file"
         ],
         "type": "object"
@@ -1077,6 +2096,24 @@
             "description": "An additional image whose fully transparent areas (e.g. where alpha is zero) indicate where `image` should be edited. Must be a valid PNG file, less than 4MB, and have the same dimensions as `image`.",
             "format": "binary",
             "type": "string"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "dall-e-2"
+                ],
+                "type": "string"
+              }
+            ],
+            "default": "dall-e-2",
+            "description": "The model to use for image generation. Only `dall-e-2` is supported at this time.",
+            "example": "dall-e-2",
+            "nullable": true,
+            "x-oaiTypeLabel": "string"
           },
           "n": {
             "default": 1,
@@ -1116,7 +2153,7 @@
             "type": "string"
           },
           "user": {
-            "description": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).\n",
+            "description": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](/docs/guides/safety-best-practices/end-user-ids).\n",
             "example": "user-1234",
             "type": "string"
           }
@@ -1129,9 +2166,23 @@
       },
       "CreateImageRequest": {
         "properties": {
+          "model": {
+            
+                "enum": [
+                  "dall-e-2",
+                  "dall-e-3"
+                ],
+                "type": "string",
+              
+            "default": "dall-e-2",
+            "description": "The model to use for image generation.",
+            "example": "dall-e-3",
+            "nullable": true,
+            "x-oaiTypeLabel": "string"
+          },
           "n": {
             "default": 1,
-            "description": "The number of images to generate. Must be between 1 and 10.",
+            "description": "The number of images to generate. Must be between 1 and 10. For `dall-e-3`, only `n=1` is supported.",
             "example": 1,
             "maximum": 10,
             "minimum": 1,
@@ -1139,8 +2190,18 @@
             "type": "integer"
           },
           "prompt": {
-            "description": "A text description of the desired image(s). The maximum length is 1000 characters.",
+            "description": "A text description of the desired image(s). The maximum length is 1000 characters for `dall-e-2` and 4000 characters for `dall-e-3`.",
             "example": "A cute baby sea otter",
+            "type": "string"
+          },
+          "quality": {
+            "default": "standard",
+            "description": "The quality of the image that will be generated. `hd` creates images with finer details and greater consistency across the image. This param is only supported for `dall-e-3`.",
+            "enum": [
+              "standard",
+              "hd"
+            ],
+            "example": "standard",
             "type": "string"
           },
           "response_format": {
@@ -1156,18 +2217,31 @@
           },
           "size": {
             "default": "1024x1024",
-            "description": "The size of the generated images. Must be one of `256x256`, `512x512`, or `1024x1024`.",
+            "description": "The size of the generated images. Must be one of `256x256`, `512x512`, or `1024x1024` for `dall-e-2`. Must be one of `1024x1024`, `1792x1024`, or `1024x1792` for `dall-e-3` models.",
             "enum": [
               "256x256",
               "512x512",
-              "1024x1024"
+              "1024x1024",
+              "1792x1024",
+              "1024x1792"
             ],
             "example": "1024x1024",
             "nullable": true,
             "type": "string"
           },
+          "style": {
+            "default": "vivid",
+            "description": "The style of the generated images. Must be one of `vivid` or `natural`. Vivid causes the model to lean towards generating hyper-real and dramatic images. Natural causes the model to produce more natural, less hyper-real looking images. This param is only supported for `dall-e-3`.",
+            "enum": [
+              "vivid",
+              "natural"
+            ],
+            "example": "vivid",
+            "nullable": true,
+            "type": "string"
+          },
           "user": {
-            "description": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).\n",
+            "description": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](/docs/guides/safety-best-practices/end-user-ids).\n",
             "example": "user-1234",
             "type": "string"
           }
@@ -1184,9 +2258,27 @@
             "format": "binary",
             "type": "string"
           },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "dall-e-2"
+                ],
+                "type": "string"
+              }
+            ],
+            "default": "dall-e-2",
+            "description": "The model to use for image generation. Only `dall-e-2` is supported at this time.",
+            "example": "dall-e-2",
+            "nullable": true,
+            "x-oaiTypeLabel": "string"
+          },
           "n": {
             "default": 1,
-            "description": "The number of images to generate. Must be between 1 and 10.",
+            "description": "The number of images to generate. Must be between 1 and 10. For `dall-e-3`, only `n=1` is supported.",
             "example": 1,
             "maximum": 10,
             "minimum": 1,
@@ -1217,13 +2309,52 @@
             "type": "string"
           },
           "user": {
-            "description": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids).\n",
+            "description": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](/docs/guides/safety-best-practices/end-user-ids).\n",
             "example": "user-1234",
             "type": "string"
           }
         },
         "required": [
           "image"
+        ],
+        "type": "object"
+      },
+      "CreateMessageRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "description": "The content of the message.",
+            "maxLength": 32768,
+            "minLength": 1,
+            "type": "string"
+          },
+          "file_ids": {
+            "default": [],
+            "description": "A list of [File](/docs/api-reference/files) IDs that the message should use. There can be a maximum of 10 files attached to a message. Useful for tools like `retrieval` and `code_interpreter` that can access and use files.",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 10,
+            "minItems": 1,
+            "type": "array"
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "nullable": true,
+            "type": "object",
+            "x-oaiTypeLabel": "map"
+          },
+          "role": {
+            "description": "The role of the entity that is creating the message. Currently only `user` is supported.",
+            "enum": [
+              "user"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "role",
+          "content"
         ],
         "type": "object"
       },
@@ -1248,15 +2379,22 @@
             ]
           },
           "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "text-moderation-latest",
+                  "text-moderation-stable"
+                ],
+                "type": "string"
+              }
+            ],
             "default": "text-moderation-latest",
             "description": "Two content moderations models are available: `text-moderation-stable` and `text-moderation-latest`.\n\nThe default is `text-moderation-latest` which will be automatically upgraded over time. This ensures you are always using our most accurate model. If you use `text-moderation-stable`, we will provide advanced notice before updating the model. Accuracy of `text-moderation-stable` may be slightly lower than for `text-moderation-latest`.\n",
-            "enum": [
-              "text-moderation-latest",
-              "text-moderation-stable"
-            ],
             "example": "text-moderation-stable",
             "nullable": false,
-            "type": "string",
             "x-oaiTypeLabel": "string"
           }
         },
@@ -1266,44 +2404,76 @@
         "type": "object"
       },
       "CreateModerationResponse": {
+        "description": "Represents policy compliance report by OpenAI's content moderation model against a given input.",
         "properties": {
           "id": {
+            "description": "The unique identifier for the moderation request.",
             "type": "string"
           },
           "model": {
+            "description": "The model used to generate the moderation results.",
             "type": "string"
           },
           "results": {
+            "description": "A list of moderation objects.",
             "items": {
               "properties": {
                 "categories": {
+                  "description": "A list of the categories, and whether they are flagged or not.",
                   "properties": {
+                    "harassment": {
+                      "description": "Content that expresses, incites, or promotes harassing language towards any target.",
+                      "type": "boolean"
+                    },
+                    "harassment/threatening": {
+                      "description": "Harassment content that also includes violence or serious harm towards any target.",
+                      "type": "boolean"
+                    },
                     "hate": {
+                      "description": "Content that expresses, incites, or promotes hate based on race, gender, ethnicity, religion, nationality, sexual orientation, disability status, or caste. Hateful content aimed at non-protected groups (e.g., chess players) is harrassment.",
                       "type": "boolean"
                     },
                     "hate/threatening": {
+                      "description": "Hateful content that also includes violence or serious harm towards the targeted group based on race, gender, ethnicity, religion, nationality, sexual orientation, disability status, or caste.",
                       "type": "boolean"
                     },
                     "self-harm": {
+                      "description": "Content that promotes, encourages, or depicts acts of self-harm, such as suicide, cutting, and eating disorders.",
+                      "type": "boolean"
+                    },
+                    "self-harm/instructions": {
+                      "description": "Content that encourages performing acts of self-harm, such as suicide, cutting, and eating disorders, or that gives instructions or advice on how to commit such acts.",
+                      "type": "boolean"
+                    },
+                    "self-harm/intent": {
+                      "description": "Content where the speaker expresses that they are engaging or intend to engage in acts of self-harm, such as suicide, cutting, and eating disorders.",
                       "type": "boolean"
                     },
                     "sexual": {
+                      "description": "Content meant to arouse sexual excitement, such as the description of sexual activity, or that promotes sexual services (excluding sex education and wellness).",
                       "type": "boolean"
                     },
                     "sexual/minors": {
+                      "description": "Sexual content that includes an individual who is under 18 years old.",
                       "type": "boolean"
                     },
                     "violence": {
+                      "description": "Content that depicts death, violence, or physical injury.",
                       "type": "boolean"
                     },
                     "violence/graphic": {
+                      "description": "Content that depicts death, violence, or physical injury in graphic detail.",
                       "type": "boolean"
                     }
                   },
                   "required": [
                     "hate",
                     "hate/threatening",
+                    "harassment",
+                    "harassment/threatening",
                     "self-harm",
+                    "self-harm/intent",
+                    "self-harm/instructions",
                     "sexual",
                     "sexual/minors",
                     "violence",
@@ -1312,33 +2482,61 @@
                   "type": "object"
                 },
                 "category_scores": {
+                  "description": "A list of the categories along with their scores as predicted by model.",
                   "properties": {
+                    "harassment": {
+                      "description": "The score for the category 'harassment'.",
+                      "type": "number"
+                    },
+                    "harassment/threatening": {
+                      "description": "The score for the category 'harassment/threatening'.",
+                      "type": "number"
+                    },
                     "hate": {
+                      "description": "The score for the category 'hate'.",
                       "type": "number"
                     },
                     "hate/threatening": {
+                      "description": "The score for the category 'hate/threatening'.",
                       "type": "number"
                     },
                     "self-harm": {
+                      "description": "The score for the category 'self-harm'.",
+                      "type": "number"
+                    },
+                    "self-harm/instructions": {
+                      "description": "The score for the category 'self-harm/instructions'.",
+                      "type": "number"
+                    },
+                    "self-harm/intent": {
+                      "description": "The score for the category 'self-harm/intent'.",
                       "type": "number"
                     },
                     "sexual": {
+                      "description": "The score for the category 'sexual'.",
                       "type": "number"
                     },
                     "sexual/minors": {
+                      "description": "The score for the category 'sexual/minors'.",
                       "type": "number"
                     },
                     "violence": {
+                      "description": "The score for the category 'violence'.",
                       "type": "number"
                     },
                     "violence/graphic": {
+                      "description": "The score for the category 'violence/graphic'.",
                       "type": "number"
                     }
                   },
                   "required": [
                     "hate",
                     "hate/threatening",
+                    "harassment",
+                    "harassment/threatening",
                     "self-harm",
+                    "self-harm/intent",
+                    "self-harm/instructions",
                     "sexual",
                     "sexual/minors",
                     "violence",
@@ -1347,6 +2545,7 @@
                   "type": "object"
                 },
                 "flagged": {
+                  "description": "Whether the content violates [OpenAI's usage policies](/policies/usage-policies).",
                   "type": "boolean"
                 }
               },
@@ -1365,19 +2564,207 @@
           "model",
           "results"
         ],
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"id\": \"modr-XXXXX\",\n  \"model\": \"text-moderation-005\",\n  \"results\": [\n    {\n      \"flagged\": true,\n      \"categories\": {\n        \"sexual\": false,\n        \"hate\": false,\n        \"harassment\": false,\n        \"self-harm\": false,\n        \"sexual/minors\": false,\n        \"hate/threatening\": false,\n        \"violence/graphic\": false,\n        \"self-harm/intent\": false,\n        \"self-harm/instructions\": false,\n        \"harassment/threatening\": true,\n        \"violence\": true,\n      },\n      \"category_scores\": {\n        \"sexual\": 1.2282071e-06,\n        \"hate\": 0.010696256,\n        \"harassment\": 0.29842457,\n        \"self-harm\": 1.5236925e-08,\n        \"sexual/minors\": 5.7246268e-08,\n        \"hate/threatening\": 0.0060676364,\n        \"violence/graphic\": 4.435014e-06,\n        \"self-harm/intent\": 8.098441e-10,\n        \"self-harm/instructions\": 2.8498655e-11,\n        \"harassment/threatening\": 0.63055265,\n        \"violence\": 0.99011886,\n      }\n    }\n  ]\n}\n",
+          "name": "The moderation object"
+        }
+      },
+      "CreateRunRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "assistant_id": {
+            "description": "The ID of the [assistant](/docs/api-reference/assistants) to use to execute this run.",
+            "type": "string"
+          },
+          "instructions": {
+            "description": "Override the default system message of the assistant. This is useful for modifying the behavior on a per-run basis.",
+            "nullable": true,
+            "type": "string"
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "nullable": true,
+            "type": "object",
+            "x-oaiTypeLabel": "map"
+          },
+          "model": {
+            "description": "The ID of the [Model](/docs/api-reference/models) to be used to execute this run. If a value is provided here, it will override the model associated with the assistant. If not, the model associated with the assistant will be used.",
+            "nullable": true,
+            "type": "string"
+          },
+          "tools": {
+            "description": "Override the tools the assistant can use for this run. This is useful for modifying the behavior on a per-run basis.",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AssistantToolsCode"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsRetrieval"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsFunction"
+                }
+              ],
+              "x-oaiExpandable": true
+            },
+            "maxItems": 20,
+            "nullable": true,
+            "type": "array"
+          }
+        },
+        "required": [
+          "thread_id",
+          "assistant_id"
+        ],
+        "type": "object"
+      },
+      "CreateSpeechRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "input": {
+            "description": "The text to generate audio for. The maximum length is 4096 characters.",
+            "maxLength": 4096,
+            "type": "string"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "tts-1",
+                  "tts-1-hd"
+                ],
+                "type": "string"
+              }
+            ],
+            "description": "One of the available [TTS models](/docs/models/tts): `tts-1` or `tts-1-hd`\n",
+            "x-oaiTypeLabel": "string"
+          },
+          "response_format": {
+            "default": "mp3",
+            "description": "The format to audio in. Supported formats are `mp3`, `opus`, `aac`, and `flac`.",
+            "enum": [
+              "mp3",
+              "opus",
+              "aac",
+              "flac"
+            ],
+            "type": "string"
+          },
+          "speed": {
+            "default": 1,
+            "description": "The speed of the generated audio. Select a value from `0.25` to `4.0`. `1.0` is the default.",
+            "maximum": 4,
+            "minimum": 0.25,
+            "type": "number"
+          },
+          "voice": {
+            "description": "The voice to use when generating the audio. Supported voices are `alloy`, `echo`, `fable`, `onyx`, `nova`, and `shimmer`.",
+            "enum": [
+              "alloy",
+              "echo",
+              "fable",
+              "onyx",
+              "nova",
+              "shimmer"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "model",
+          "input",
+          "voice"
+        ],
+        "type": "object"
+      },
+      "CreateThreadAndRunRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "assistant_id": {
+            "description": "The ID of the [assistant](/docs/api-reference/assistants) to use to execute this run.",
+            "type": "string"
+          },
+          "instructions": {
+            "description": "Override the default system message of the assistant. This is useful for modifying the behavior on a per-run basis.",
+            "nullable": true,
+            "type": "string"
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "nullable": true,
+            "type": "object",
+            "x-oaiTypeLabel": "map"
+          },
+          "model": {
+            "description": "The ID of the [Model](/docs/api-reference/models) to be used to execute this run. If a value is provided here, it will override the model associated with the assistant. If not, the model associated with the assistant will be used.",
+            "nullable": true,
+            "type": "string"
+          },
+          "thread": {
+            "$ref": "#/components/schemas/CreateThreadRequest",
+            "description": "If no thread is provided, an empty thread will be created."
+          },
+          "tools": {
+            "description": "Override the tools the assistant can use for this run. This is useful for modifying the behavior on a per-run basis.",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AssistantToolsCode"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsRetrieval"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsFunction"
+                }
+              ]
+            },
+            "maxItems": 20,
+            "nullable": true,
+            "type": "array"
+          }
+        },
+        "required": [
+          "thread_id",
+          "assistant_id"
+        ],
+        "type": "object"
+      },
+      "CreateThreadRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "messages": {
+            "description": "A list of [messages](/docs/api-reference/messages) to start the thread with.",
+            "items": {
+              "$ref": "#/components/schemas/CreateMessageRequest"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "nullable": true,
+            "type": "object",
+            "x-oaiTypeLabel": "map"
+          }
+        },
         "type": "object"
       },
       "CreateTranscriptionRequest": {
         "additionalProperties": false,
         "properties": {
           "file": {
-            "description": "The audio file object (not file name) to transcribe, in one of these formats: mp3, mp4, mpeg, mpga, m4a, wav, or webm.\n",
+            "description": "The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.\n",
             "format": "binary",
             "type": "string",
             "x-oaiTypeLabel": "file"
           },
           "language": {
-            "description": "The language of the input audio. Supplying the input language in <a href=\"https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes\">ISO-639-1</a> format will improve accuracy and latency.\n",
+            "description": "The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format will improve accuracy and latency.\n",
             "type": "string"
           },
           "model": {
@@ -1390,12 +2777,12 @@
             "x-oaiTypeLabel": "string"
           },
           "prompt": {
-            "description": "An optional text to guide the model's style or continue a previous audio segment. The <a href=\"https://platform.openai.com/docs/guides/speech-to-text/prompting\">prompt</a> should match the audio language.\n",
+            "description": "An optional text to guide the model's style or continue a previous audio segment. The [prompt](/docs/guides/speech-to-text/prompting) should match the audio language.\n",
             "type": "string"
           },
           "response_format": {
             "default": "json",
-            "description": "The format of the transcript output, in one of these options: json, text, srt, verbose_json, or vtt.\n",
+            "description": "The format of the transcript output, in one of these options: `json`, `text`, `srt`, `verbose_json`, or `vtt`.\n",
             "enum": [
               "json",
               "text",
@@ -1407,7 +2794,7 @@
           },
           "temperature": {
             "default": 0,
-            "description": "The sampling temperature, between 0 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. If set to 0, the model will use <a href=\"https://en.wikipedia.org/wiki/Log_probability\">log probability</a> to automatically increase the temperature until certain thresholds are hit.\n",
+            "description": "The sampling temperature, between 0 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. If set to 0, the model will use [log probability](https://en.wikipedia.org/wiki/Log_probability) to automatically increase the temperature until certain thresholds are hit.\n",
             "type": "number"
           }
         },
@@ -1432,27 +2819,34 @@
         "additionalProperties": false,
         "properties": {
           "file": {
-            "description": "The audio file object (not file name) translate, in one of these formats: mp3, mp4, mpeg, mpga, m4a, wav, or webm.\n",
+            "description": "The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.\n",
             "format": "binary",
             "type": "string",
             "x-oaiTypeLabel": "file"
           },
           "model": {
-            "description": "ID of the model to use. Only `whisper-1` is currently available.\n",
-            "enum": [
-              "whisper-1"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "whisper-1"
+                ],
+                "type": "string"
+              }
             ],
+            "description": "ID of the model to use. Only `whisper-1` is currently available.\n",
             "example": "whisper-1",
-            "type": "string",
             "x-oaiTypeLabel": "string"
           },
           "prompt": {
-            "description": "An optional text to guide the model's style or continue a previous audio segment. The [prompt](https://platform.openai.com/docs/guides/speech-to-text/prompting) should be in English.\n",
+            "description": "An optional text to guide the model's style or continue a previous audio segment. The [prompt](/docs/guides/speech-to-text/prompting) should be in English.\n",
             "type": "string"
           },
           "response_format": {
             "default": "json",
-            "description": "The format of the transcript output, in one of these options: json, text, srt, verbose_json, or vtt.\n",
+            "description": "The format of the transcript output, in one of these options: `json`, `text`, `srt`, `verbose_json`, or `vtt`.\n",
             "type": "string"
           },
           "temperature": {
@@ -1478,6 +2872,51 @@
         ],
         "type": "object"
       },
+      "DeleteAssistantFileResponse": {
+        "description": "Deletes the association between the assistant and the file, but does not delete the [File](/docs/api-reference/files) object itself.",
+        "properties": {
+          "deleted": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "enum": [
+              "assistant.file.deleted"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "deleted"
+        ],
+        "type": "object"
+      },
+      "DeleteAssistantResponse": {
+        "properties": {
+          "deleted": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "enum": [
+              "assistant.deleted"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "deleted"
+        ],
+        "type": "object"
+      },
       "DeleteFileResponse": {
         "properties": {
           "deleted": {
@@ -1487,6 +2926,31 @@
             "type": "string"
           },
           "object": {
+            "enum": [
+              "file"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "deleted"
+        ],
+        "type": "object"
+      },
+      "DeleteMessageResponse": {
+        "properties": {
+          "deleted": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "enum": [
+              "thread.message.deleted"
+            ],
             "type": "string"
           }
         },
@@ -1515,6 +2979,61 @@
           "deleted"
         ],
         "type": "object"
+      },
+      "DeleteThreadResponse": {
+        "properties": {
+          "deleted": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "enum": [
+              "thread.deleted"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "deleted"
+        ],
+        "type": "object"
+      },
+      "Embedding": {
+        "description": "Represents an embedding vector returned by embedding endpoint.\n",
+        "properties": {
+          "embedding": {
+            "description": "The embedding vector, which is a list of floats. The length of vector depends on the model as listed in the [embedding guide](/docs/guides/embeddings).\n",
+            "items": {
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "index": {
+            "description": "The index of the embedding in the list of embeddings.",
+            "type": "integer"
+          },
+          "object": {
+            "description": "The object type, which is always \"embedding\".",
+            "enum": [
+              "embedding"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "index",
+          "object",
+          "embedding"
+        ],
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"object\": \"embedding\",\n  \"embedding\": [\n    0.0023064255,\n    -0.009327292,\n    .... (1536 floats total for ada-002)\n    -0.0028842222,\n  ],\n  \"index\": 0\n}\n",
+          "name": "The embedding object"
+        }
       },
       "Error": {
         "properties": {
@@ -1555,83 +3074,108 @@
         "type": "object"
       },
       "FineTune": {
+        "deprecated": true,
+        "description": "The `FineTune` object represents a legacy fine-tune job that has been created through the API.\n",
         "properties": {
           "created_at": {
+            "description": "The Unix timestamp (in seconds) for when the fine-tuning job was created.",
             "type": "integer"
           },
           "events": {
+            "description": "The list of events that have been observed in the lifecycle of the FineTune job.",
             "items": {
               "$ref": "#/components/schemas/FineTuneEvent"
             },
             "type": "array"
           },
           "fine_tuned_model": {
+            "description": "The name of the fine-tuned model that is being created.",
             "nullable": true,
             "type": "string"
           },
           "hyperparams": {
+            "description": "The hyperparameters used for the fine-tuning job. See the [fine-tuning guide](/docs/guides/legacy-fine-tuning/hyperparameters) for more details.",
             "properties": {
               "batch_size": {
+                "description": "The batch size to use for training. The batch size is the number of\ntraining examples used to train a single forward and backward pass.\n",
                 "type": "integer"
               },
               "classification_n_classes": {
+                "description": "The number of classes to use for computing classification metrics.\n",
                 "type": "integer"
               },
               "classification_positive_class": {
+                "description": "The positive class to use for computing classification metrics.\n",
                 "type": "string"
               },
               "compute_classification_metrics": {
+                "description": "The classification metrics to compute using the validation dataset at the end of every epoch.\n",
                 "type": "boolean"
               },
               "learning_rate_multiplier": {
+                "description": "The learning rate multiplier to use for training.\n",
                 "type": "number"
               },
               "n_epochs": {
+                "description": "The number of epochs to train the model for. An epoch refers to one\nfull cycle through the training dataset.\n",
                 "type": "integer"
               },
               "prompt_loss_weight": {
+                "description": "The weight to use for loss on the prompt tokens.\n",
                 "type": "number"
               }
             },
             "required": [
-              "n_epochs",
               "batch_size",
-              "prompt_loss_weight",
-              "learning_rate_multiplier"
+              "learning_rate_multiplier",
+              "n_epochs",
+              "prompt_loss_weight"
             ],
             "type": "object"
           },
           "id": {
+            "description": "The object identifier, which can be referenced in the API endpoints.",
             "type": "string"
           },
           "model": {
+            "description": "The base model that is being fine-tuned.",
             "type": "string"
           },
           "object": {
+            "description": "The object type, which is always \"fine-tune\".",
+            "enum": [
+              "fine-tune"
+            ],
             "type": "string"
           },
           "organization_id": {
+            "description": "The organization that owns the fine-tuning job.",
             "type": "string"
           },
           "result_files": {
+            "description": "The compiled results files for the fine-tuning job.",
             "items": {
               "$ref": "#/components/schemas/OpenAIFile"
             },
             "type": "array"
           },
           "status": {
+            "description": "The current status of the fine-tuning job, which can be either `created`, `running`, `succeeded`, `failed`, or `cancelled`.",
             "type": "string"
           },
           "training_files": {
+            "description": "The list of files used for training.",
             "items": {
               "$ref": "#/components/schemas/OpenAIFile"
             },
             "type": "array"
           },
           "updated_at": {
+            "description": "The Unix timestamp (in seconds) for when the fine-tuning job was last updated.",
             "type": "integer"
           },
           "validation_files": {
+            "description": "The list of files used for validation.",
             "items": {
               "$ref": "#/components/schemas/OpenAIFile"
             },
@@ -1639,22 +3183,28 @@
           }
         },
         "required": [
-          "id",
-          "object",
           "created_at",
-          "updated_at",
-          "model",
           "fine_tuned_model",
-          "organization_id",
-          "status",
           "hyperparams",
+          "id",
+          "model",
+          "object",
+          "organization_id",
+          "result_files",
+          "status",
           "training_files",
-          "validation_files",
-          "result_files"
+          "updated_at",
+          "validation_files"
         ],
-        "title": "FineTune"
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"id\": \"ft-AF1WoRqd3aJAHsqc9NY7iL8F\",\n  \"object\": \"fine-tune\",\n  \"model\": \"curie\",\n  \"created_at\": 1614807352,\n  \"events\": [\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807352,\n      \"level\": \"info\",\n      \"message\": \"Job enqueued. Waiting for jobs ahead to complete. Queue number: 0.\"\n    },\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807356,\n      \"level\": \"info\",\n      \"message\": \"Job started.\"\n    },\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807861,\n      \"level\": \"info\",\n      \"message\": \"Uploaded snapshot: curie:ft-acmeco-2021-03-03-21-44-20.\"\n    },\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807864,\n      \"level\": \"info\",\n      \"message\": \"Uploaded result files: file-abc123.\"\n    },\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807864,\n      \"level\": \"info\",\n      \"message\": \"Job succeeded.\"\n    }\n  ],\n  \"fine_tuned_model\": \"curie:ft-acmeco-2021-03-03-21-44-20\",\n  \"hyperparams\": {\n    \"batch_size\": 4,\n    \"learning_rate_multiplier\": 0.1,\n    \"n_epochs\": 4,\n    \"prompt_loss_weight\": 0.1,\n  },\n  \"organization_id\": \"org-123\",\n  \"result_files\": [\n    {\n      \"id\": \"file-abc123\",\n      \"object\": \"file\",\n      \"bytes\": 81509,\n      \"created_at\": 1614807863,\n      \"filename\": \"compiled_results.csv\",\n      \"purpose\": \"fine-tune-results\"\n    }\n  ],\n  \"status\": \"succeeded\",\n  \"validation_files\": [],\n  \"training_files\": [\n    {\n      \"id\": \"file-abc123\",\n      \"object\": \"file\",\n      \"bytes\": 1547276,\n      \"created_at\": 1610062281,\n      \"filename\": \"my-data-train.jsonl\",\n      \"purpose\": \"fine-tune\"\n    }\n  ],\n  \"updated_at\": 1614807865,\n}\n",
+          "name": "The fine-tune object"
+        }
       },
       "FineTuneEvent": {
+        "deprecated": true,
+        "description": "Fine-tune event object",
         "properties": {
           "created_at": {
             "type": "integer"
@@ -1666,6 +3216,9 @@
             "type": "string"
           },
           "object": {
+            "enum": [
+              "fine-tune-event"
+            ],
             "type": "string"
           }
         },
@@ -1675,7 +3228,218 @@
           "level",
           "message"
         ],
-        "title": "FineTuneEvent"
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"object\": \"fine-tune-event\",\n  \"created_at\": 1677610602,\n  \"level\": \"info\",\n  \"message\": \"Created fine-tune job\"\n}\n",
+          "name": "The fine-tune event object"
+        }
+      },
+      "FineTuningJob": {
+        "description": "The `fine_tuning.job` object represents a fine-tuning job that has been created through the API.\n",
+        "properties": {
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) for when the fine-tuning job was created.",
+            "type": "integer"
+          },
+          "error": {
+            "description": "For fine-tuning jobs that have `failed`, this will contain more information on the cause of the failure.",
+            "nullable": true,
+            "properties": {
+              "code": {
+                "description": "A machine-readable error code.",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human-readable error message.",
+                "type": "string"
+              },
+              "param": {
+                "description": "The parameter that was invalid, usually `training_file` or `validation_file`. This field will be null if the failure was not parameter-specific.",
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "required": [
+              "code",
+              "message",
+              "param"
+            ],
+            "type": "object"
+          },
+          "fine_tuned_model": {
+            "description": "The name of the fine-tuned model that is being created. The value will be null if the fine-tuning job is still running.",
+            "nullable": true,
+            "type": "string"
+          },
+          "finished_at": {
+            "description": "The Unix timestamp (in seconds) for when the fine-tuning job was finished. The value will be null if the fine-tuning job is still running.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "hyperparameters": {
+            "description": "The hyperparameters used for the fine-tuning job. See the [fine-tuning guide](/docs/guides/fine-tuning) for more details.",
+            "properties": {
+              "n_epochs": {
+                "default": "auto",
+                "description": "The number of epochs to train the model for. An epoch refers to one full cycle through the training dataset.\n\"auto\" decides the optimal number of epochs based on the size of the dataset. If setting the number manually, we support any number between 1 and 50 epochs.",
+                "oneOf": [
+                  {
+                    "enum": [
+                      "auto"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "maximum": 50,
+                    "minimum": 1,
+                    "type": "integer"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "n_epochs"
+            ],
+            "type": "object"
+          },
+          "id": {
+            "description": "The object identifier, which can be referenced in the API endpoints.",
+            "type": "string"
+          },
+          "model": {
+            "description": "The base model that is being fine-tuned.",
+            "type": "string"
+          },
+          "object": {
+            "description": "The object type, which is always \"fine_tuning.job\".",
+            "enum": [
+              "fine_tuning.job"
+            ],
+            "type": "string"
+          },
+          "organization_id": {
+            "description": "The organization that owns the fine-tuning job.",
+            "type": "string"
+          },
+          "result_files": {
+            "description": "The compiled results file ID(s) for the fine-tuning job. You can retrieve the results with the [Files API](/docs/api-reference/files/retrieve-contents).",
+            "items": {
+              "example": "file-abc123",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "status": {
+            "description": "The current status of the fine-tuning job, which can be either `validating_files`, `queued`, `running`, `succeeded`, `failed`, or `cancelled`.",
+            "enum": [
+              "validating_files",
+              "queued",
+              "running",
+              "succeeded",
+              "failed",
+              "cancelled"
+            ],
+            "type": "string"
+          },
+          "trained_tokens": {
+            "description": "The total number of billable tokens processed by this fine-tuning job. The value will be null if the fine-tuning job is still running.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "training_file": {
+            "description": "The file ID used for training. You can retrieve the training data with the [Files API](/docs/api-reference/files/retrieve-contents).",
+            "type": "string"
+          },
+          "validation_file": {
+            "description": "The file ID used for validation. You can retrieve the validation results with the [Files API](/docs/api-reference/files/retrieve-contents).",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "created_at",
+          "error",
+          "finished_at",
+          "fine_tuned_model",
+          "hyperparameters",
+          "id",
+          "model",
+          "object",
+          "organization_id",
+          "result_files",
+          "status",
+          "trained_tokens",
+          "training_file",
+          "validation_file"
+        ],
+        "title": "FineTuningJob",
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"object\": \"fine_tuning.job\",\n  \"id\": \"ftjob-abc123\",\n  \"model\": \"davinci-002\",\n  \"created_at\": 1692661014,\n  \"finished_at\": 1692661190,\n  \"fine_tuned_model\": \"ft:davinci-002:my-org:custom_suffix:7q8mpxmy\",\n  \"organization_id\": \"org-123\",\n  \"result_files\": [\n      \"file-abc123\"\n  ],\n  \"status\": \"succeeded\",\n  \"validation_file\": null,\n  \"training_file\": \"file-abc123\",\n  \"hyperparameters\": {\n      \"n_epochs\": 4,\n  },\n  \"trained_tokens\": 5768\n}\n",
+          "name": "The fine-tuning job object"
+        }
+      },
+      "FineTuningJobEvent": {
+        "description": "Fine-tuning job event object",
+        "properties": {
+          "created_at": {
+            "type": "integer"
+          },
+          "id": {
+            "type": "string"
+          },
+          "level": {
+            "enum": [
+              "info",
+              "warn",
+              "error"
+            ],
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "object": {
+            "enum": [
+              "fine_tuning.job.event"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "created_at",
+          "level",
+          "message"
+        ],
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"object\": \"fine_tuning.job.event\",\n  \"id\": \"ftevent-abc123\"\n  \"created_at\": 1677610602,\n  \"level\": \"info\",\n  \"message\": \"Created fine-tuning job\"\n}\n",
+          "name": "The fine-tuning job event object"
+        }
+      },
+      "Image": {
+        "description": "Represents the url or the content of an image generated by the OpenAI API.",
+        "properties": {
+          "b64_json": {
+            "description": "The base64-encoded JSON of the generated image, if `response_format` is `b64_json`.",
+            "type": "string"
+          },
+          "revised_prompt": {
+            "description": "The prompt that was used to generate the image, if there was any revision to the prompt.",
+            "type": "string"
+          },
+          "url": {
+            "description": "The URL of the generated image, if `response_format` is `url` (default).",
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"url\": \"...\",\n  \"revised_prompt\": \"...\"\n}\n",
+          "name": "The image object"
+        }
       },
       "ImagesResponse": {
         "properties": {
@@ -1684,15 +3448,7 @@
           },
           "data": {
             "items": {
-              "properties": {
-                "b64_json": {
-                  "type": "string"
-                },
-                "url": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
+              "$ref": "#/components/schemas/Image"
             },
             "type": "array"
           }
@@ -1701,6 +3457,79 @@
           "created",
           "data"
         ]
+      },
+      "ListAssistantFilesResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/AssistantFileObject"
+            },
+            "type": "array"
+          },
+          "first_id": {
+            "example": "file-hLBK7PXBv5Lr2NQT7KLY0ag1",
+            "type": "string"
+          },
+          "has_more": {
+            "example": false,
+            "type": "boolean"
+          },
+          "last_id": {
+            "example": "file-QLoItBbqwyAJEzlTy4y9kOMM",
+            "type": "string"
+          },
+          "object": {
+            "example": "list",
+            "type": "string"
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "items",
+          "first_id",
+          "last_id",
+          "has_more"
+        ]
+      },
+      "ListAssistantsResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/AssistantObject"
+            },
+            "type": "array"
+          },
+          "first_id": {
+            "example": "asst_hLBK7PXBv5Lr2NQT7KLY0ag1",
+            "type": "string"
+          },
+          "has_more": {
+            "example": false,
+            "type": "boolean"
+          },
+          "last_id": {
+            "example": "asst_QLoItBbqwyAJEzlTy4y9kOMM",
+            "type": "string"
+          },
+          "object": {
+            "example": "list",
+            "type": "string"
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "first_id",
+          "last_id",
+          "has_more"
+        ],
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"id\": \"asst_abc123\",\n      \"object\": \"assistant\",\n      \"created_at\": 1698982736,\n      \"name\": \"Coding Tutor\",\n      \"description\": null,\n      \"model\": \"gpt-4\",\n      \"instructions\": \"You are a helpful assistant designed to make me better at coding!\",\n      \"tools\": [],\n      \"file_ids\": [],\n      \"metadata\": {}\n    },\n    {\n      \"id\": \"asst_abc456\",\n      \"object\": \"assistant\",\n      \"created_at\": 1698982718,\n      \"name\": \"My Assistant\",\n      \"description\": null,\n      \"model\": \"gpt-4\",\n      \"instructions\": \"You are a helpful assistant designed to make me better at coding!\",\n      \"tools\": [],\n      \"file_ids\": [],\n      \"metadata\": {}\n    },\n    {\n      \"id\": \"asst_abc789\",\n      \"object\": \"assistant\",\n      \"created_at\": 1698982643,\n      \"name\": null,\n      \"description\": null,\n      \"model\": \"gpt-4\",\n      \"instructions\": null,\n      \"tools\": [],\n      \"file_ids\": [],\n      \"metadata\": {}\n    }\n  ],\n  \"first_id\": \"asst_abc123\",\n  \"last_id\": \"asst_abc789\",\n  \"has_more\": false\n}\n",
+          "group": "chat",
+          "name": "List assistants response object"
+        }
       },
       "ListFilesResponse": {
         "properties": {
@@ -1711,6 +3540,9 @@
             "type": "array"
           },
           "object": {
+            "enum": [
+              "list"
+            ],
             "type": "string"
           }
         },
@@ -1729,6 +3561,9 @@
             "type": "array"
           },
           "object": {
+            "enum": [
+              "list"
+            ],
             "type": "string"
           }
         },
@@ -1747,6 +3582,9 @@
             "type": "array"
           },
           "object": {
+            "enum": [
+              "list"
+            ],
             "type": "string"
           }
         },
@@ -1755,6 +3593,94 @@
           "data"
         ],
         "type": "object"
+      },
+      "ListFineTuningJobEventsResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/FineTuningJobEvent"
+            },
+            "type": "array"
+          },
+          "object": {
+            "enum": [
+              "list"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "object",
+          "data"
+        ],
+        "type": "object"
+      },
+      "ListMessageFilesResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/MessageFileObject"
+            },
+            "type": "array"
+          },
+          "first_id": {
+            "example": "file-hLBK7PXBv5Lr2NQT7KLY0ag1",
+            "type": "string"
+          },
+          "has_more": {
+            "example": false,
+            "type": "boolean"
+          },
+          "last_id": {
+            "example": "file-QLoItBbqwyAJEzlTy4y9kOMM",
+            "type": "string"
+          },
+          "object": {
+            "example": "list",
+            "type": "string"
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "items",
+          "first_id",
+          "last_id",
+          "has_more"
+        ]
+      },
+      "ListMessagesResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/MessageObject"
+            },
+            "type": "array"
+          },
+          "first_id": {
+            "example": "msg_hLBK7PXBv5Lr2NQT7KLY0ag1",
+            "type": "string"
+          },
+          "has_more": {
+            "example": false,
+            "type": "boolean"
+          },
+          "last_id": {
+            "example": "msg_QLoItBbqwyAJEzlTy4y9kOMM",
+            "type": "string"
+          },
+          "object": {
+            "example": "list",
+            "type": "string"
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "first_id",
+          "last_id",
+          "has_more"
+        ]
       },
       "ListModelsResponse": {
         "properties": {
@@ -1765,6 +3691,9 @@
             "type": "array"
           },
           "object": {
+            "enum": [
+              "list"
+            ],
             "type": "string"
           }
         },
@@ -1774,18 +3703,449 @@
         ],
         "type": "object"
       },
-      "Model": {
+      "ListPaginatedFineTuningJobsResponse": {
         "properties": {
-          "created": {
-            "type": "integer"
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/FineTuningJob"
+            },
+            "type": "array"
           },
-          "id": {
+          "has_more": {
+            "type": "boolean"
+          },
+          "object": {
+            "enum": [
+              "list"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "has_more"
+        ],
+        "type": "object"
+      },
+      "ListRunStepsResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/RunStepObject"
+            },
+            "type": "array"
+          },
+          "first_id": {
+            "example": "step_hLBK7PXBv5Lr2NQT7KLY0ag1",
+            "type": "string"
+          },
+          "has_more": {
+            "example": false,
+            "type": "boolean"
+          },
+          "last_id": {
+            "example": "step_QLoItBbqwyAJEzlTy4y9kOMM",
             "type": "string"
           },
           "object": {
+            "example": "list",
+            "type": "string"
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "first_id",
+          "last_id",
+          "has_more"
+        ]
+      },
+      "ListRunsResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/RunObject"
+            },
+            "type": "array"
+          },
+          "first_id": {
+            "example": "run_hLBK7PXBv5Lr2NQT7KLY0ag1",
+            "type": "string"
+          },
+          "has_more": {
+            "example": false,
+            "type": "boolean"
+          },
+          "last_id": {
+            "example": "run_QLoItBbqwyAJEzlTy4y9kOMM",
+            "type": "string"
+          },
+          "object": {
+            "example": "list",
+            "type": "string"
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "first_id",
+          "last_id",
+          "has_more"
+        ],
+        "type": "object"
+      },
+      "ListThreadsResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ThreadObject"
+            },
+            "type": "array"
+          },
+          "first_id": {
+            "example": "asst_hLBK7PXBv5Lr2NQT7KLY0ag1",
+            "type": "string"
+          },
+          "has_more": {
+            "example": false,
+            "type": "boolean"
+          },
+          "last_id": {
+            "example": "asst_QLoItBbqwyAJEzlTy4y9kOMM",
+            "type": "string"
+          },
+          "object": {
+            "example": "list",
+            "type": "string"
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "first_id",
+          "last_id",
+          "has_more"
+        ]
+      },
+      "MessageContentImageFileObject": {
+        "description": "References an image [File](/docs/api-reference/files) in the content of a message.",
+        "properties": {
+          "image_file": {
+            "properties": {
+              "file_id": {
+                "description": "The [File](/docs/api-reference/files) ID of the image in the message content.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "file_id"
+            ],
+            "type": "object"
+          },
+          "type": {
+            "description": "Always `image_file`.",
+            "enum": [
+              "image_file"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "image_file"
+        ],
+        "title": "Image file",
+        "type": "object"
+      },
+      "MessageContentTextAnnotationsFileCitationObject": {
+        "description": "A citation within the message that points to a specific quote from a specific File associated with the assistant or the message. Generated when the assistant uses the \"retrieval\" tool to search files.",
+        "properties": {
+          "end_index": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "file_citation": {
+            "properties": {
+              "file_id": {
+                "description": "The ID of the specific File the citation is from.",
+                "type": "string"
+              },
+              "quote": {
+                "description": "The specific quote in the file.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "file_id",
+              "quote"
+            ],
+            "type": "object"
+          },
+          "start_index": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "text": {
+            "description": "The text in the message content that needs to be replaced.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Always `file_citation`.",
+            "enum": [
+              "file_citation"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text",
+          "file_citation",
+          "start_index",
+          "end_index"
+        ],
+        "title": "File citation",
+        "type": "object"
+      },
+      "MessageContentTextAnnotationsFilePathObject": {
+        "description": "A URL for the file that's generated when the assistant used the `code_interpreter` tool to generate a file.",
+        "properties": {
+          "end_index": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "file_path": {
+            "properties": {
+              "file_id": {
+                "description": "The ID of the file that was generated.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "file_id"
+            ],
+            "type": "object"
+          },
+          "start_index": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "text": {
+            "description": "The text in the message content that needs to be replaced.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Always `file_path`.",
+            "enum": [
+              "file_path"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text",
+          "file_path",
+          "start_index",
+          "end_index"
+        ],
+        "title": "File path",
+        "type": "object"
+      },
+      "MessageContentTextObject": {
+        "description": "The text content that is part of a message.",
+        "properties": {
+          "text": {
+            "properties": {
+              "annotations": {
+                "items": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/MessageContentTextAnnotationsFileCitationObject"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MessageContentTextAnnotationsFilePathObject"
+                    }
+                  ],
+                  "x-oaiExpandable": true
+                },
+                "type": "array"
+              },
+              "value": {
+                "description": "The data that makes up the text.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "annotations"
+            ],
+            "type": "object"
+          },
+          "type": {
+            "description": "Always `text`.",
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "title": "Text",
+        "type": "object"
+      },
+      "MessageFileObject": {
+        "description": "A list of files attached to a `message`.",
+        "properties": {
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) for when the message file was created.",
+            "type": "integer"
+          },
+          "id": {
+            "description": "The identifier, which can be referenced in API endpoints.",
+            "type": "string"
+          },
+          "message_id": {
+            "description": "The ID of the [message](/docs/api-reference/messages) that the [File](/docs/api-reference/files) is attached to.",
+            "type": "string"
+          },
+          "object": {
+            "description": "The object type, which is always `thread.message.file`.",
+            "enum": [
+              "thread.message.file"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "created_at",
+          "message_id"
+        ],
+        "title": "Message files",
+        "type": "object",
+        "x-oaiMeta": {
+          "beta": true,
+          "example": "{\n  \"id\": \"file-BK7bzQj3FfZFXr7DbL6xJwfo\",\n  \"object\": \"thread.message.file\",\n  \"created_at\": 1698107661,\n  \"message_id\": \"message_QLoItBbqwyAJEzlTy4y9kOMM\",\n  \"file_id\": \"file-BK7bzQj3FfZFXr7DbL6xJwfo\"\n}\n",
+          "name": "The message file object"
+        }
+      },
+      "MessageObject": {
+        "description": "Represents a message within a [thread](/docs/api-reference/threads).",
+        "properties": {
+          "assistant_id": {
+            "description": "If applicable, the ID of the [assistant](/docs/api-reference/assistants) that authored this message.",
+            "nullable": true,
+            "type": "string"
+          },
+          "content": {
+            "description": "The content of the message in array of text and/or images.",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/MessageContentImageFileObject"
+                },
+                {
+                  "$ref": "#/components/schemas/MessageContentTextObject"
+                }
+              ],
+              "x-oaiExpandable": true
+            },
+            "type": "array"
+          },
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) for when the message was created.",
+            "type": "integer"
+          },
+          "file_ids": {
+            "default": [],
+            "description": "A list of [file](/docs/api-reference/files) IDs that the assistant should use. Useful for tools like retrieval and code_interpreter that can access files. A maximum of 10 files can be attached to a message.",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 10,
+            "type": "array"
+          },
+          "id": {
+            "description": "The identifier, which can be referenced in API endpoints.",
+            "type": "string"
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "nullable": true,
+            "type": "object",
+            "x-oaiTypeLabel": "map"
+          },
+          "object": {
+            "description": "The object type, which is always `thread.message`.",
+            "enum": [
+              "thread.message"
+            ],
+            "type": "string"
+          },
+          "role": {
+            "description": "The entity that produced the message. One of `user` or `assistant`.",
+            "enum": [
+              "user",
+              "assistant"
+            ],
+            "type": "string"
+          },
+          "run_id": {
+            "description": "If applicable, the ID of the [run](/docs/api-reference/runs) associated with the authoring of this message.",
+            "nullable": true,
+            "type": "string"
+          },
+          "thread_id": {
+            "description": "The [thread](/docs/api-reference/threads) ID that this message belongs to.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "created_at",
+          "thread_id",
+          "role",
+          "content",
+          "assistant_id",
+          "run_id",
+          "file_ids",
+          "metadata"
+        ],
+        "title": "The message object",
+        "type": "object",
+        "x-oaiMeta": {
+          "beta": true,
+          "example": "{\n  \"id\": \"msg_dKYDWyQvtjDBi3tudL1yWKDa\",\n  \"object\": \"thread.message\",\n  \"created_at\": 1698983503,\n  \"thread_id\": \"thread_RGUhOuO9b2nrktrmsQ2uSR6I\",\n  \"role\": \"assistant\",\n  \"content\": [\n    {\n      \"type\": \"text\",\n      \"text\": {\n        \"value\": \"Hi! How can I help you today?\",\n        \"annotations\": []\n      }\n    }\n  ],\n  \"file_ids\": [],\n  \"assistant_id\": \"asst_ToSF7Gb04YMj8AMMm50ZLLtY\",\n  \"run_id\": \"run_BjylUJgDqYK9bOhy4yjAiMrn\",\n  \"metadata\": {}\n}\n",
+          "name": "The message object"
+        }
+      },
+      "Model": {
+        "description": "Describes an OpenAI model offering that can be used with the API.",
+        "properties": {
+          "created": {
+            "description": "The Unix timestamp (in seconds) when the model was created.",
+            "type": "integer"
+          },
+          "id": {
+            "description": "The model identifier, which can be referenced in the API endpoints.",
+            "type": "string"
+          },
+          "object": {
+            "description": "The object type, which is always \"model\".",
+            "enum": [
+              "model"
+            ],
             "type": "string"
           },
           "owned_by": {
+            "description": "The organization that owns the model.",
             "type": "string"
           }
         },
@@ -1795,33 +4155,164 @@
           "created",
           "owned_by"
         ],
-        "title": "Model"
+        "title": "Model",
+        "x-oaiMeta": {
+          "example": "{\n  \"id\": \"VAR_model_id\",\n  \"object\": \"model\",\n  \"created\": 1686935002,\n  \"owned_by\": \"openai\"\n}\n",
+          "name": "The model object"
+        }
+      },
+      "ModifyAssistantRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "description": "The description of the assistant. The maximum length is 512 characters.\n",
+            "maxLength": 512,
+            "nullable": true,
+            "type": "string"
+          },
+          "file_ids": {
+            "default": [],
+            "description": "A list of [File](/docs/api-reference/files) IDs attached to this assistant. There can be a maximum of 20 files attached to the assistant. Files are ordered by their creation date in ascending order. If a file was previosuly attached to the list but does not show up in the list, it will be deleted from the assistant.\n",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 20,
+            "type": "array"
+          },
+          "instructions": {
+            "description": "The system instructions that the assistant uses. The maximum length is 32768 characters.\n",
+            "maxLength": 32768,
+            "nullable": true,
+            "type": "string"
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "nullable": true,
+            "type": "object",
+            "x-oaiTypeLabel": "map"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              }
+            ],
+            "description": "ID of the model to use. You can use the [List models](/docs/api-reference/models/list) API to see all of your available models, or see our [Model overview](/docs/models/overview) for descriptions of them.\n"
+          },
+          "name": {
+            "description": "The name of the assistant. The maximum length is 256 characters.\n",
+            "maxLength": 256,
+            "nullable": true,
+            "type": "string"
+          },
+          "tools": {
+            "default": [],
+            "description": "A list of tool enabled on the assistant. There can be a maximum of 128 tools per assistant. Tools can be of types `code_interpreter`, `retrieval`, or `function`.\n",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AssistantToolsCode"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsRetrieval"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsFunction"
+                }
+              ],
+              "x-oaiExpandable": true
+            },
+            "maxItems": 128,
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ModifyMessageRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "nullable": true,
+            "type": "object",
+            "x-oaiTypeLabel": "map"
+          }
+        },
+        "type": "object"
+      },
+      "ModifyRunRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "nullable": true,
+            "type": "object",
+            "x-oaiTypeLabel": "map"
+          }
+        },
+        "type": "object"
+      },
+      "ModifyThreadRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "nullable": true,
+            "type": "object",
+            "x-oaiTypeLabel": "map"
+          }
+        },
+        "type": "object"
       },
       "OpenAIFile": {
+        "description": "The `File` object represents a document that has been uploaded to OpenAI.",
         "properties": {
           "bytes": {
+            "description": "The size of the file, in bytes.",
             "type": "integer"
           },
           "created_at": {
+            "description": "The Unix timestamp (in seconds) for when the file was created.",
             "type": "integer"
           },
           "filename": {
+            "description": "The name of the file.",
             "type": "string"
           },
           "id": {
+            "description": "The file identifier, which can be referenced in the API endpoints.",
             "type": "string"
           },
           "object": {
+            "description": "The object type, which is always `file`.",
+            "enum": [
+              "file"
+            ],
             "type": "string"
           },
           "purpose": {
+            "description": "The intended purpose of the file. Supported values are `fine-tune`, `fine-tune-results`, `assistants`, and `assistants_output`.",
+            "enum": [
+              "fine-tune",
+              "fine-tune-results",
+              "assistants",
+              "assistants_output"
+            ],
             "type": "string"
           },
           "status": {
+            "deprecated": true,
+            "description": "Deprecated. The current status of the file, which can be either `uploaded`, `processed`, or `error`.",
+            "enum": [
+              "uploaded",
+              "processed",
+              "error"
+            ],
             "type": "string"
           },
           "status_details": {
-            "nullable": true,
+            "deprecated": true,
+            "description": "Deprecated. For details on why a fine-tuning training file failed validation, see the `error` field on `fine_tuning.job`.",
             "type": "string"
           }
         },
@@ -1831,19 +4322,1282 @@
           "bytes",
           "created_at",
           "filename",
-          "purpose"
+          "purpose",
+          "status"
         ],
-        "title": "OpenAIFile"
+        "title": "OpenAIFile",
+        "x-oaiMeta": {
+          "example": "{\n  \"id\": \"file-BK7bzQj3FfZFXr7DbL6xJwfo\",\n  \"object\": \"file\",\n  \"bytes\": 120000,\n  \"created_at\": 1677610602,\n  \"filename\": \"salesOverview.pdf\",\n  \"purpose\": \"assistants\",\n}\n",
+          "name": "The File object"
+        }
+      },
+      "RunObject": {
+        "description": "Represents an execution run on a [thread](/docs/api-reference/threads).",
+        "properties": {
+          "assistant_id": {
+            "description": "The ID of the [assistant](/docs/api-reference/assistants) used for execution of this run.",
+            "type": "string"
+          },
+          "cancelled_at": {
+            "description": "The Unix timestamp (in seconds) for when the run was cancelled.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "completed_at": {
+            "description": "The Unix timestamp (in seconds) for when the run was completed.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) for when the run was created.",
+            "type": "integer"
+          },
+          "expires_at": {
+            "description": "The Unix timestamp (in seconds) for when the run will expire.",
+            "type": "integer"
+          },
+          "failed_at": {
+            "description": "The Unix timestamp (in seconds) for when the run failed.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "file_ids": {
+            "default": [],
+            "description": "The list of [File](/docs/api-reference/files) IDs the [assistant](/docs/api-reference/assistants) used for this run.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "id": {
+            "description": "The identifier, which can be referenced in API endpoints.",
+            "type": "string"
+          },
+          "instructions": {
+            "description": "The instructions that the [assistant](/docs/api-reference/assistants) used for this run.",
+            "type": "string"
+          },
+          "last_error": {
+            "description": "The last error associated with this run. Will be `null` if there are no errors.",
+            "nullable": true,
+            "properties": {
+              "code": {
+                "description": "One of `server_error` or `rate_limit_exceeded`.",
+                "enum": [
+                  "server_error",
+                  "rate_limit_exceeded"
+                ],
+                "type": "string"
+              },
+              "message": {
+                "description": "A human-readable description of the error.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "code",
+              "message"
+            ],
+            "type": "object"
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "nullable": true,
+            "type": "object",
+            "x-oaiTypeLabel": "map"
+          },
+          "model": {
+            "description": "The model that the [assistant](/docs/api-reference/assistants) used for this run.",
+            "type": "string"
+          },
+          "object": {
+            "description": "The object type, which is always `assistant.run`.",
+            "enum": [
+              "assistant.run"
+            ],
+            "type": "string"
+          },
+          "required_action": {
+            "description": "Details on the action required to continue the run. Will be `null` if no action is required.",
+            "nullable": true,
+            "properties": {
+              "submit_tool_outputs": {
+                "description": "Details on the tool outputs needed for this run to continue.",
+                "properties": {
+                  "tool_calls": {
+                    "description": "A list of the relevant tool calls.",
+                    "items": {
+                      "$ref": "#/components/schemas/RunToolCallObject"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "tool_calls"
+                ],
+                "type": "object"
+              },
+              "type": {
+                "description": "For now, this is always `submit_tool_outputs`.",
+                "enum": [
+                  "submit_tool_outputs"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "submit_tool_outputs"
+            ],
+            "type": "object"
+          },
+          "started_at": {
+            "description": "The Unix timestamp (in seconds) for when the run was started.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "status": {
+            "description": "The status of the run, which can be either `queued`, `in_progress`, `requires_action`, `cancelling`, `cancelled`, `failed`, `completed`, or `expired`.",
+            "enum": [
+              "queued",
+              "in_progress",
+              "requires_action",
+              "cancelling",
+              "cancelled",
+              "failed",
+              "completed",
+              "expired"
+            ],
+            "type": "string"
+          },
+          "thread_id": {
+            "description": "The ID of the [thread](/docs/api-reference/threads) that was executed on as a part of this run.",
+            "type": "string"
+          },
+          "tools": {
+            "default": [],
+            "description": "The list of tools that the [assistant](/docs/api-reference/assistants) used for this run.",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AssistantToolsCode"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsRetrieval"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantToolsFunction"
+                }
+              ],
+              "x-oaiExpandable": true
+            },
+            "maxItems": 20,
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "created_at",
+          "thread_id",
+          "assistant_id",
+          "status",
+          "required_action",
+          "last_error",
+          "expires_at",
+          "started_at",
+          "cancelled_at",
+          "failed_at",
+          "completed_at",
+          "model",
+          "instructions",
+          "tools",
+          "file_ids",
+          "metadata"
+        ],
+        "title": "A run on a thread",
+        "type": "object",
+        "x-oaiMeta": {
+          "beta": true,
+          "example": "{\n  \"id\": \"run_example123\",\n  \"object\": \"thread.run\",\n  \"created_at\": 1698107661,\n  \"assistant_id\": \"asst_gZ1aOomboBuYWPcXJx4vAYB0\",\n  \"thread_id\": \"thread_adOpf7Jbb5Abymz0QbwxAh3c\",\n  \"status\": \"completed\",\n  \"started_at\": 1699073476,\n  \"expires_at\": null,\n  \"cancelled_at\": null,\n  \"failed_at\": null,\n  \"completed_at\": 1699073498,\n  \"last_error\": null,\n  \"model\": \"gpt-4\",\n  \"instructions\": null,\n  \"tools\": [{\"type\": \"retrieval\"}, {\"type\": \"code_interpreter\"}],\n  \"file_ids\": [],\n  \"metadata\": {}\n}\n",
+          "name": "The run object"
+        }
+      },
+      "RunStepDetailsMessageCreationObject": {
+        "description": "Details of the message creation by the run step.",
+        "properties": {
+          "message_creation": {
+            "properties": {
+              "message_id": {
+                "description": "The ID of the message that was created by this run step.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "message_id"
+            ],
+            "type": "object"
+          },
+          "type": {
+            "description": "Always `message_creation``.",
+            "enum": [
+              "message_creation"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "message_creation"
+        ],
+        "title": "Message creation",
+        "type": "object"
+      },
+      "RunStepDetailsToolCallsCodeObject": {
+        "description": "Details of the Code Interpreter tool call the run step was involved in.",
+        "properties": {
+          "code_interpreter": {
+            "description": "The Code Interpreter tool call definition.",
+            "properties": {
+              "input": {
+                "description": "The input to the Code Interpreter tool call.",
+                "type": "string"
+              },
+              "outputs": {
+                "description": "The outputs from the Code Interpreter tool call. Code Interpreter can output one or more items, including text (`logs`) or images (`image`). Each of these are represented by a different object type.",
+                "items": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/RunStepDetailsToolCallsCodeOutputLogsObject"
+                    },
+                    {
+                      "$ref": "#/components/schemas/RunStepDetailsToolCallsCodeOutputImageObject"
+                    }
+                  ],
+                  "type": "object",
+                  "x-oaiExpandable": true
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "input",
+              "outputs"
+            ],
+            "type": "object"
+          },
+          "id": {
+            "description": "The ID of the tool call.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of tool call. This is always going to be `code_interpreter` for this type of tool call.",
+            "enum": [
+              "code_interpreter"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "code_interpreter"
+        ],
+        "title": "Code interpreter tool call",
+        "type": "object"
+      },
+      "RunStepDetailsToolCallsCodeOutputImageObject": {
+        "properties": {
+          "image": {
+            "properties": {
+              "file_id": {
+                "description": "The [file](/docs/api-reference/files) ID of the image.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "file_id"
+            ],
+            "type": "object"
+          },
+          "type": {
+            "description": "Always `image`.",
+            "enum": [
+              "image"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "image"
+        ],
+        "title": "Code interpreter image output",
+        "type": "object"
+      },
+      "RunStepDetailsToolCallsCodeOutputLogsObject": {
+        "description": "Text output from the Code Interpreter tool call as part of a run step.",
+        "properties": {
+          "logs": {
+            "description": "The text output from the Code Interpreter tool call.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Always `logs`.",
+            "enum": [
+              "logs"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "logs"
+        ],
+        "title": "Code interpreter log output",
+        "type": "object"
+      },
+      "RunStepDetailsToolCallsFunctionObject": {
+        "properties": {
+          "function": {
+            "description": "The definition of the function that was called.",
+            "properties": {
+              "arguments": {
+                "description": "The arguments passed to the function.",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the function.",
+                "type": "string"
+              },
+              "output": {
+                "description": "The output of the function. This will be `null` if the outputs have not been [submitted](/docs/api-reference/runs/submitToolOutputs) yet.",
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "arguments",
+              "output"
+            ],
+            "type": "object"
+          },
+          "id": {
+            "description": "The ID of the tool call object.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of tool call. This is always going to be `function` for this type of tool call.",
+            "enum": [
+              "function"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "function"
+        ],
+        "title": "Function tool call",
+        "type": "object"
+      },
+      "RunStepDetailsToolCallsObject": {
+        "description": "Details of the tool call.",
+        "properties": {
+          "tool_calls": {
+            "description": "An array of tool calls the run step was involved in. These can be associated with one of three types of tools: `code_interpreter`, `retrieval`, or `function`.\n",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/RunStepDetailsToolCallsCodeObject"
+                },
+                {
+                  "$ref": "#/components/schemas/RunStepDetailsToolCallsRetrievalObject"
+                },
+                {
+                  "$ref": "#/components/schemas/RunStepDetailsToolCallsFunctionObject"
+                }
+              ],
+              "type": "object",
+              "x-oaiExpandable": true
+            },
+            "type": "array"
+          },
+          "type": {
+            "description": "Always `tool_calls`.",
+            "enum": [
+              "tool_calls"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "tool_calls"
+        ],
+        "title": "Tool calls",
+        "type": "object"
+      },
+      "RunStepDetailsToolCallsRetrievalObject": {
+        "properties": {
+          "id": {
+            "description": "The ID of the tool call object.",
+            "type": "string"
+          },
+          "retrieval": {
+            "description": "For now, this is always going to be an empty object.",
+            "type": "object",
+            "x-oaiTypeLabel": "map"
+          },
+          "type": {
+            "description": "The type of tool call. This is always going to be `retrieval` for this type of tool call.",
+            "enum": [
+              "retrieval"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "retrieval"
+        ],
+        "title": "Retrieval tool call",
+        "type": "object"
+      },
+      "RunStepObject": {
+        "description": "Represents a step in execution of a run.\n",
+        "properties": {
+          "assistant_id": {
+            "description": "The ID of the [assistant](/docs/api-reference/assistants) associated with the run step.",
+            "type": "string"
+          },
+          "cancelled_at": {
+            "description": "The Unix timestamp (in seconds) for when the run step was cancelled.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "completed_at": {
+            "description": "The Unix timestamp (in seconds) for when the run step completed.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) for when the run step was created.",
+            "type": "integer"
+          },
+          "expired_at": {
+            "description": "The Unix timestamp (in seconds) for when the run step expired. A step is considered expired if the parent run is expired.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "failed_at": {
+            "description": "The Unix timestamp (in seconds) for when the run step failed.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "id": {
+            "description": "The identifier of the run step, which can be referenced in API endpoints.",
+            "type": "string"
+          },
+          "last_error": {
+            "description": "The last error associated with this run step. Will be `null` if there are no errors.",
+            "nullable": true,
+            "properties": {
+              "code": {
+                "description": "One of `server_error` or `rate_limit_exceeded`.",
+                "enum": [
+                  "server_error",
+                  "rate_limit_exceeded"
+                ],
+                "type": "string"
+              },
+              "message": {
+                "description": "A human-readable description of the error.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "code",
+              "message"
+            ],
+            "type": "object"
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "nullable": true,
+            "type": "object",
+            "x-oaiTypeLabel": "map"
+          },
+          "object": {
+            "description": "The object type, which is always `assistant.run.step``.",
+            "enum": [
+              "assistant.run.step"
+            ],
+            "type": "string"
+          },
+          "run_id": {
+            "description": "The ID of the [run](/docs/api-reference/runs) that this run step is a part of.",
+            "type": "string"
+          },
+          "status": {
+            "description": "The status of the run, which can be either `in_progress`, `cancelled`, `failed`, `completed`, or `expired`.",
+            "enum": [
+              "in_progress",
+              "cancelled",
+              "failed",
+              "completed",
+              "expired"
+            ],
+            "type": "string"
+          },
+          "step_details": {
+            "description": "The details of the run step.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/RunStepDetailsMessageCreationObject"
+              },
+              {
+                "$ref": "#/components/schemas/RunStepDetailsToolCallsObject"
+              }
+            ],
+            "type": "object",
+            "x-oaiExpandable": true
+          },
+          "thread_id": {
+            "description": "The ID of the [thread](/docs/api-reference/threads) that was run.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of run step, which can be either `message_creation` or `tool_calls`.",
+            "enum": [
+              "message_creation",
+              "tool_calls"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "created_at",
+          "assistant_id",
+          "thread_id",
+          "run_id",
+          "type",
+          "status",
+          "step_details",
+          "last_error",
+          "expired_at",
+          "cancelled_at",
+          "failed_at",
+          "completed_at",
+          "metadata"
+        ],
+        "title": "Run steps",
+        "type": "object",
+        "x-oaiMeta": {
+          "beta": true,
+          "example": "{\n  \"id\": \"step_QyjyrsVsysd7F4K894BZHG97\",\n  \"object\": \"thread.run.step\",\n  \"created_at\": 1699063291,\n  \"run_id\": \"run_UWvV94U0FQYiT2rlbBrdEVmC\",\n  \"assistant_id\": \"asst_nGl00s4xa9zmVY6Fvuvz9wwQ\",\n  \"thread_id\": \"thread_BDDwIqM4KgHibXX3mqmN3Lgs\",\n  \"type\": \"message_creation\",\n  \"status\": \"completed\",\n  \"cancelled_at\": null,\n  \"completed_at\": 1699063291,\n  \"expired_at\": null,\n  \"failed_at\": null,\n  \"last_error\": null,\n  \"step_details\": {\n    \"type\": \"message_creation\",\n    \"message_creation\": {\n      \"message_id\": \"msg_6YmiCRmMbbE6FALYNePPHqwm\"\n    }\n  }\n}\n",
+          "name": "The run step object"
+        }
+      },
+      "RunToolCallObject": {
+        "description": "Tool call objects",
+        "properties": {
+          "function": {
+            "description": "The function definition.",
+            "properties": {
+              "arguments": {
+                "description": "The arguments that the model expects you to pass to the function.",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the function.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "arguments"
+            ],
+            "type": "object"
+          },
+          "id": {
+            "description": "The ID of the tool call. This ID must be referenced when you submit the tool outputs in using the [Submit tool outputs to run](/docs/api-reference/runs/submitToolOutputs) endpoint.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of tool call the output is required for. For now, this is always `function`.",
+            "enum": [
+              "function"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "function"
+        ],
+        "type": "object"
+      },
+      "SubmitToolOutputsRunRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "tool_outputs": {
+            "description": "A list of tools for which the outputs are being submitted.",
+            "items": {
+              "properties": {
+                "output": {
+                  "description": "The output of the tool call to be submitted to continue the run.",
+                  "type": "string"
+                },
+                "tool_call_id": {
+                  "description": "The ID of the tool call in the `required_action` object within the run object the output is being submitted for.",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "tool_outputs"
+        ],
+        "type": "object"
+      },
+      "ThreadObject": {
+        "description": "Represents a thread that contains [messages](/docs/api-reference/messages).",
+        "properties": {
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) for when the thread was created.",
+            "type": "integer"
+          },
+          "id": {
+            "description": "The identifier, which can be referenced in API endpoints.",
+            "type": "string"
+          },
+          "metadata": {
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.\n",
+            "nullable": true,
+            "type": "object",
+            "x-oaiTypeLabel": "map"
+          },
+          "object": {
+            "description": "The object type, which is always `thread`.",
+            "enum": [
+              "thread"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "created_at",
+          "metadata"
+        ],
+        "title": "Thread",
+        "type": "object",
+        "x-oaiMeta": {
+          "beta": true,
+          "example": "{\n  \"id\": \"thread_abc123\",\n  \"object\": \"thread\",\n  \"created_at\": 1698107661,\n  \"metadata\": {}\n}\n",
+          "name": "The thread object"
+        }
+      }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "scheme": "bearer",
+        "type": "http"
       }
     }
   },
   "info": {
-    "description": "APIs for sampling from and fine-tuning language models",
+    "contact": {
+      "name": "OpenAI Support",
+      "url": "https://help.openai.com/"
+    },
+    "description": "The OpenAI REST API. Please see https://platform.openai.com/docs/api-reference for more details.",
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/openai/openai-openapi/blob/master/LICENSE"
+    },
+    "termsOfService": "https://openai.com/policies/terms-of-use",
     "title": "OpenAI API",
     "version": "2.0.0"
   },
   "openapi": "3.0.0",
   "paths": {
+    "/assistants": {
+      "get": {
+        "operationId": "listAssistants",
+        "parameters": [
+          {
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.\n",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and `desc` for descending order.\n",
+            "in": "query",
+            "name": "order",
+            "schema": {
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.\n",
+            "in": "query",
+            "name": "after",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.\n",
+            "in": "query",
+            "name": "before",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListAssistantsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Returns a list of assistants.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl \"https://api.openai.com/v1/assistants?order=desc&limit=20\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v1\"\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const myAssistants = await openai.beta.assistants.list({\n    order: \"desc\",\n    limit: \"20\",\n  });\n\n  console.log(myAssistants.data);\n}\n\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nmy_assistants = openai.beta.assistants.list(\n    order=\"desc\",\n    limit=\"20\",\n)\nprint(my_assistants.data)\n"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"id\": \"asst_abc123\",\n      \"object\": \"assistant\",\n      \"created_at\": 1698982736,\n      \"name\": \"Coding Tutor\",\n      \"description\": null,\n      \"model\": \"gpt-4\",\n      \"instructions\": \"You are a helpful assistant designed to make me better at coding!\",\n      \"tools\": [],\n      \"file_ids\": [],\n      \"metadata\": {}\n    },\n    {\n      \"id\": \"asst_abc456\",\n      \"object\": \"assistant\",\n      \"created_at\": 1698982718,\n      \"name\": \"My Assistant\",\n      \"description\": null,\n      \"model\": \"gpt-4\",\n      \"instructions\": \"You are a helpful assistant designed to make me better at coding!\",\n      \"tools\": [],\n      \"file_ids\": [],\n      \"metadata\": {}\n    },\n    {\n      \"id\": \"asst_abc789\",\n      \"object\": \"assistant\",\n      \"created_at\": 1698982643,\n      \"name\": null,\n      \"description\": null,\n      \"model\": \"gpt-4\",\n      \"instructions\": null,\n      \"tools\": [],\n      \"file_ids\": [],\n      \"metadata\": {}\n    }\n  ],\n  \"first_id\": \"asst_abc123\",\n  \"last_id\": \"asst_abc789\",\n  \"has_more\": false\n}\n"
+          },
+          "name": "List assistants",
+          "returns": "A list of [assistant](/docs/api-reference/assistants/object) objects."
+        }
+      },
+      "post": {
+        "operationId": "createAssistant",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAssistantRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantObject"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Create an assistant with a model and instructions.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": [
+            {
+              "request": {
+                "curl": "curl \"https://api.openai.com/v1/assistants\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v1\" \\\n  -d '{\n    \"instructions\": \"You are a personal math tutor. When asked a question, write and run Python code to answer the question.\",\n    \"name\": \"Math Tutor\"\n    \"tools\": [{\"type\": \"code_interpreter\"}],\n    \"model\": \"gpt-4\"\n  }'\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const myAssistant = await openai.beta.assistants.create({\n    instructions:\n      \"You are a personal math tutor. When asked a question, write and run Python code to answer the question.\",\n    name: \"Math Tutor\",\n    tools: [{ type: \"code_interpreter\" }],\n    model: \"gpt-4\",\n  });\n\n  console.log(myAssistant);\n}\n\nmain();",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nmy_assistant = openai.beta.assistants.create(\n    instructions=\"You are a personal math tutor. When asked a question, write and run Python code to answer the question.\",\n    name=\"Math Tutor\",\n    tools=[{\"type\": \"code_interpreter\"}],\n    model=\"gpt-4\",\n)\nprint(my_assistant)\n"
+              },
+              "response": "{\n  \"id\": \"asst_abc123\",\n  \"object\": \"assistant\",\n  \"created_at\": 1698984975,\n  \"name\": \"Math Tutor\",\n  \"description\": null,\n  \"model\": \"gpt-4\",\n  \"instructions\": \"You are a personal math tutor. When asked a question, write and run Python code to answer the question.\",\n  \"tools\": [\n    {\n      \"type\": \"code_interpreter\"\n    }\n  ],\n  \"file_ids\": [],\n  \"metadata\": {}\n}\n",
+              "title": "Code Interpreter"
+            },
+            {
+              "request": {
+                "curl": "curl https://api.openai.com/v1/assistants \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v1\" \\\n  -d '{\n    \"instructions\": \"You are an HR bot, and you have access to files to answer employee questions about company policies.\",\n    \"tools\": [{\"type\": \"retrieval\"}],\n    \"model\": \"gpt-4\",\n    \"file_ids\": [\"file-abc123\"]\n  }'\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const myAssistant = await openai.beta.assistants.create({\n    instructions:\n      \"You are an HR bot, and you have access to files to answer employee questions about company policies.\",\n    name: \"HR Helper\",\n    tools: [{ type: \"retrieval\" }],\n    model: \"gpt-4\",\n    file_ids: [\"file-abc123\"],\n  });\n\n  console.log(myAssistant);\n}\n\nmain();",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nmy_assistant = openai.beta.assistants.create(\n    instructions=\"You are an HR bot, and you have access to files to answer employee questions about company policies.\",\n    name=\"HR Helper\",\n    tools=[{\"type\": \"retrieval\"}],\n    model=\"gpt-4\",\n    file_ids=[\"file-abc123\"],\n)\nprint(my_assistant)\n"
+              },
+              "response": "{\n  \"id\": \"asst_abc123\",\n  \"object\": \"assistant\",\n  \"created_at\": 1699009403,\n  \"name\": \"HR Helper\",\n  \"description\": null,\n  \"model\": \"gpt-4\",\n  \"instructions\": \"You are an HR bot, and you have access to files to answer employee questions about company policies.\",\n  \"tools\": [\n    {\n      \"type\": \"retrieval\"\n    }\n  ],\n  \"file_ids\": [\n    \"file-abc123\"\n  ],\n  \"metadata\": {}\n}\n",
+              "title": "Files"
+            }
+          ],
+          "name": "Create assistant",
+          "returns": "An [assistant](/docs/api-reference/assistants/object) object."
+        }
+      }
+    },
+    "/assistants/{assistant_id}": {
+      "delete": {
+        "operationId": "deleteAssistant",
+        "parameters": [
+          {
+            "description": "The ID of the assistant to delete.",
+            "in": "path",
+            "name": "assistant_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteAssistantResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Delete an assistant.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/assistants/asst_abc123 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v1\" \\\n  -X DELETE\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const response = await openai.beta.assistants.del(\"asst_QLoItBbqwyAJEzlTy4y9kOMM\");\n\n  console.log(response);\n}\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\nresponse = openai.beta.assistants.delete(\"asst_QLoItBbqwyAJEzlTy4y9kOMM\")\nprint(response)\n"
+            },
+            "response": "{\n  \"id\": \"asst_abc123\",\n  \"object\": \"assistant.deleted\",\n  \"deleted\": true\n}\n"
+          },
+          "name": "Delete assistant",
+          "returns": "Deletion status"
+        }
+      },
+      "get": {
+        "operationId": "getAssistant",
+        "parameters": [
+          {
+            "description": "The ID of the assistant to retrieve.",
+            "in": "path",
+            "name": "assistant_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantObject"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Retrieves an assistant.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/assistants/asst_abc123 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v1\"\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const myAssistant = await openai.beta.assistants.retrieve(\n    \"asst_abc123\"\n  );\n\n  console.log(myAssistant);\n}\n\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nmy_assistant = openai.beta.assistants.retrieve(\"asst_abc123\")\nprint(my_assistant)\n"
+            },
+            "response": "{\n  \"id\": \"asst_abc123\",\n  \"object\": \"assistant\",\n  \"created_at\": 1699009709,\n  \"name\": \"HR Helper\",\n  \"description\": null,\n  \"model\": \"gpt-4\",\n  \"instructions\": \"You are an HR bot, and you have access to files to answer employee questions about company policies.\",\n  \"tools\": [\n    {\n      \"type\": \"retrieval\"\n    }\n  ],\n  \"file_ids\": [\n    \"file-abc123\"\n  ],\n  \"metadata\": {}\n}\n"
+          },
+          "name": "Retrieve assistant",
+          "returns": "The [assistant](/docs/api-reference/assistants/object) object matching the specified ID."
+        }
+      },
+      "post": {
+        "operationId": "modifyAssistant",
+        "parameters": [
+          {
+            "description": "The ID of the assistant to modify.",
+            "in": "path",
+            "name": "assistant_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModifyAssistantRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantObject"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Modifies an assistant.",
+        "tags": [
+          "Assistant"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/assistants/asst_abc123 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v1\" \\\n  -d '{\n      \"instructions\": \"You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.\",\n      \"tools\": [{\"type\": \"retrieval\"}],\n      \"model\": \"gpt-4\",\n      \"file_ids\": [\"file-abc123\", \"file-abc456\"]\n    }'\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const myUpdatedAssistant = await openai.beta.assistants.update(\n    \"asst_abc123\",\n    {\n      instructions:\n        \"You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.\",\n      name: \"HR Helper\",\n      tools: [{ type: \"retrieval\" }],\n      model: \"gpt-4\",\n      file_ids: [\n        \"file-abc123\",\n        \"file-abc456\",\n      ],\n    }\n  );\n\n  console.log(myUpdatedAssistant);\n}\n\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\nmy_updated_assistant = openai.beta.assistants.update(\n  \"asst_abc123\",\n  instructions=\"You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.\",\n  name=\"HR Helper\",\n  tools=[{\"type\": \"retrieval\"}],\n  model=\"gpt-4\",\n  file_ids=[\"file-abc123\", \"file-abc456\"],\n)\n\nprint(my_updated_assistant)\n"
+            },
+            "response": "{\n  \"id\": \"asst_abc123\",\n  \"object\": \"assistant\",\n  \"created_at\": 1699009709,\n  \"name\": \"HR Helper\",\n  \"description\": null,\n  \"model\": \"gpt-4\",\n  \"instructions\": \"You are an HR bot, and you have access to files to answer employee questions about company policies. Always response with info from either of the files.\",\n  \"tools\": [\n    {\n      \"type\": \"retrieval\"\n    }\n  ],\n  \"file_ids\": [\n    \"file-abc123\",\n    \"file-abc456\"\n  ],\n  \"metadata\": {}\n}\n"
+          },
+          "name": "Modify assistant",
+          "returns": "The modified [assistant](/docs/api-reference/assistants/object) object."
+        }
+      }
+    },
+    "/assistants/{assistant_id}/files": {
+      "get": {
+        "operationId": "listAssistantFiles",
+        "parameters": [
+          {
+            "description": "The ID of the assistant the file belongs to.",
+            "in": "path",
+            "name": "assistant_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.\n",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and `desc` for descending order.\n",
+            "in": "query",
+            "name": "order",
+            "schema": {
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.\n",
+            "in": "query",
+            "name": "after",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.\n",
+            "in": "query",
+            "name": "before",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListAssistantFilesResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Returns a list of assistant files.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/assistants/asst_DUGk5I7sK0FpKeijvrO30z9J/files \\\n  -H 'Authorization: Bearer $OPENAI_API_KEY' \\\n  -H 'Content-Type: application/json' \\\n  -H 'OpenAI-Beta: assistants=v1'\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const assistantFiles = await openai.beta.assistants.files.list(\n    \"asst_FBOFvAOHhwEWMghbMGseaPGQ\"\n  );\n  console.log(assistantFiles);\n}\n\nmain();\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nassistant_files = client.beta.assistants.files.list(\n  assistant_id=\"asst_DUGk5I7sK0FpKeijvrO30z9J\"\n)\nprint(assistant_files)\n"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"id\": \"file-dEWwUbt2UGHp3v0e0DpCzemP\",\n      \"object\": \"assistant.file\",\n      \"created_at\": 1699060412,\n      \"assistant_id\": \"asst_DUGk5I7sK0FpKeijvrO30z9J\"\n    },\n    {\n      \"id\": \"file-9F1ex49ipEnKzyLUNnCA0Yzx\",\n      \"object\": \"assistant.file\",\n      \"created_at\": 1699060412,\n      \"assistant_id\": \"asst_DUGk5I7sK0FpKeijvrO30z9J\"\n    }\n  ],\n  \"first_id\": \"file-dEWwUbt2UGHp3v0e0DpCzemP\",\n  \"last_id\": \"file-9F1ex49ipEnKzyLUNnCA0Yzx\",\n  \"has_more\": false\n}\n"
+          },
+          "name": "List assistant files",
+          "returns": "A list of [assistant file](/docs/api-reference/assistants/file-object) objects."
+        }
+      },
+      "post": {
+        "operationId": "createAssistantFile",
+        "parameters": [
+          {
+            "description": "The ID of the assistant for which to create a File.\n",
+            "in": "path",
+            "name": "assistant_id",
+            "required": true,
+            "schema": {
+              "example": "file-AF1WoRqd3aJAHsqc9NY7iL8F",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAssistantFileRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantFileObject"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Create an assistant file by attaching a [File](/docs/api-reference/files) to an [assistant](/docs/api-reference/assistants).",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/assistants/asst_FBOFvAOHhwEWMghbMGseaPGQ/files \\\n    -H 'Authorization: Bearer $OPENAI_API_KEY\"' \\\n    -H 'Content-Type: application/json' \\\n    -H 'OpenAI-Beta: assistants=v1' \\\n    -d '{\n      \"file_id\": \"file-wB6RM6wHdA49HfS2DJ9fEyrH\"\n    }'\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const myAssistantFile = await openai.beta.assistants.files.create(\n    \"asst_FBOFvAOHhwEWMghbMGseaPGQ\", \n    { \n      file_id: \"file-wB6RM6wHdA49HfS2DJ9fEyrH\"\n    }\n  );\n  console.log(myAssistantFile);\n}\n\nmain();\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nassistant_file = client.beta.assistants.files.create(\n  assistant_id=\"asst_FBOFvAOHhwEWMghbMGseaPGQ\", \n  file_id=\"file-wB6RM6wHdA49HfS2DJ9fEyrH\"\n)\nprint(assistant_file)\n"
+            },
+            "response": "{\n  \"id\": \"file-wB6RM6wHdA49HfS2DJ9fEyrH\",\n  \"object\": \"assistant.file\",\n  \"created_at\": 1699055364,\n  \"assistant_id\": \"asst_FBOFvAOHhwEWMghbMGseaPGQ\"\n}\n"
+          },
+          "name": "Create assistant file",
+          "returns": "An [assistant file](/docs/api-reference/assistants/file-object) object."
+        }
+      }
+    },
+    "/assistants/{assistant_id}/files/{file_id}": {
+      "delete": {
+        "operationId": "deleteAssistantFile",
+        "parameters": [
+          {
+            "description": "The ID of the assistant that the file belongs to.",
+            "in": "path",
+            "name": "assistant_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the file to delete.",
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteAssistantFileResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Delete an assistant file.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/assistants/asst_DUGk5I7sK0FpKeijvrO30z9J/files/file-9F1ex49ipEnKzyLUNnCA0Yzx \\\n  -H 'Authorization: Bearer $OPENAI_API_KEY' \\\n  -H 'Content-Type: application/json' \\\n  -H 'OpenAI-Beta: assistants=v1' \\\n  -X DELETE\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const deletedAssistantFile = await openai.beta.assistants.files.del(\n    \"asst_FBOFvAOHhwEWMghbMGseaPGQ\",\n    \"file-wB6RM6wHdA49HfS2DJ9fEyrH\"\n  );\n  console.log(deletedAssistantFile);\n}\n\nmain();\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\ndeleted_assistant_file = client.beta.assistants.files.delete(\n    assistant_id=\"asst_DUGk5I7sK0FpKeijvrO30z9J\",\n    file_id=\"file-dEWwUbt2UGHp3v0e0DpCzemP\"\n)\nprint(deleted_assistant_file)\n"
+            },
+            "response": "{\n  id: \"file-BK7bzQj3FfZFXr7DbL6xJwfo\",\n  object: \"assistant.file.deleted\",\n  deleted: true\n}\n"
+          },
+          "name": "Delete assistant file",
+          "returns": "Deletion status"
+        }
+      },
+      "get": {
+        "operationId": "getAssistantFile",
+        "parameters": [
+          {
+            "description": "The ID of the assistant who the file belongs to.",
+            "in": "path",
+            "name": "assistant_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the file we're getting.",
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantFileObject"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Retrieves an AssistantFile.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/assistants/asst_FBOFvAOHhwEWMghbMGseaPGQ/files/file-wB6RM6wHdA49HfS2DJ9fEyrH \\\n  -H 'Authorization: Bearer $OPENAI_API_KEY\"' \\\n  -H 'Content-Type: application/json' \\\n  -H 'OpenAI-Beta: assistants=v1'\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const myAssistantFile = await openai.beta.assistants.files.retrieve(\n    \"asst_FBOFvAOHhwEWMghbMGseaPGQ\",\n    \"file-wB6RM6wHdA49HfS2DJ9fEyrH\"\n  );\n  console.log(myAssistantFile);\n}\n\nmain();\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nassistant_file = client.beta.assistants.files.retrieve(\n  assistant_id=\"asst_FBOFvAOHhwEWMghbMGseaPGQ\",\n  file_id=\"file-wB6RM6wHdA49HfS2DJ9fEyrH\"\n)\nprint(assistant_file)\n"
+            },
+            "response": "{\n  \"id\": \"file-wB6RM6wHdA49HfS2DJ9fEyrH\",\n  \"object\": \"assistant.file\",\n  \"created_at\": 1699055364,\n  \"assistant_id\": \"asst_FBOFvAOHhwEWMghbMGseaPGQ\"\n}\n"
+          },
+          "name": "Retrieve assistant file",
+          "returns": "The [assistant file](/docs/api-reference/assistants/file-object) object matching the specified ID."
+        }
+      }
+    },
+    "/audio/speech": {
+      "post": {
+        "operationId": "createSpeech",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSpeechRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Transfer-Encoding": {
+                "description": "chunked",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Generates audio from the input text.",
+        "tags": [
+          "Audio"
+        ],
+        "x-oaiMeta": {
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/audio/speech \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"model\": \"tts-1\",\n    \"input\": \"The quick brown fox jumped over the lazy dog.\",\n    \"voice\": \"alloy\"\n  }' \\\n  --output speech.mp3\n",
+              "node": "import fs from \"fs\";\nimport path from \"path\";\nimport OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nconst speechFile = path.resolve(\"./speech.mp3\");\n\nasync function main() {\n  const mp3 = await openai.audio.speech.create({\n    model: \"tts-1\",\n    voice: \"alloy\",\n    input: \"Today is a wonderful day to build something people love!\",\n  });\n  console.log(speechFile);\n  const buffer = Buffer.from(await mp3.arrayBuffer());\n  await fs.promises.writeFile(speechFile, buffer);\n}\nmain();\n",
+              "python": "from pathlib import Path\nimport openai\n\nspeech_file_path = Path(__file__).parent / \"speech.mp3\"\nresponse = openai.audio.speech.create(\n  model=\"tts-1\",\n  voice=\"alloy\",\n  input=\"The quick brown fox jumped over the lazy dog.\"\n)\nresponse.stream_to_file(speech_file_path)\n"
+            }
+          },
+          "name": "Create speech",
+          "returns": "The audio file content."
+        }
+      }
+    },
     "/audio/transcriptions": {
       "post": {
         "operationId": "createTranscription",
@@ -1871,19 +5625,19 @@
         },
         "summary": "Transcribes audio into the input language.",
         "tags": [
-          "OpenAI"
+          "Audio"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/audio/transcriptions \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: multipart/form-data\" \\\n  -F file=\"@/path/to/file/audio.mp3\" \\\n  -F model=\"whisper-1\"\n",
-            "node": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst resp = await openai.createTranscription(\n  fs.createReadStream(\"audio.mp3\"),\n  \"whisper-1\"\n);\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\naudio_file = open(\"audio.mp3\", \"rb\")\ntranscript = openai.Audio.transcribe(\"whisper-1\", audio_file)\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/audio/transcriptions \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: multipart/form-data\" \\\n  -F file=\"@/path/to/file/audio.mp3\" \\\n  -F model=\"whisper-1\"\n",
+              "node": "import fs from \"fs\";\nimport OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const transcription = await openai.audio.transcriptions.create({\n    file: fs.createReadStream(\"audio.mp3\"),\n    model: \"whisper-1\",\n  });\n\n  console.log(transcription.text);\n}\nmain();\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\naudio_file = open(\"speech.mp3\", \"rb\")\ntranscript = client.audio.transcriptions.create(\n  model=\"whisper-1\", \n  file=audio_file\n)\n"
+            },
+            "response": "{\n  \"text\": \"Imagine the wildest idea that you've ever had, and you're curious about how it might scale to something that's a 100, a 1,000 times bigger. This is a place where you can get to do that.\"\n}\n"
           },
-          "group": "audio",
           "name": "Create transcription",
-          "parameters": "{\n  \"file\": \"audio.mp3\",\n  \"model\": \"whisper-1\"\n}\n",
-          "path": "create",
-          "response": "{\n  \"text\": \"Imagine the wildest idea that you've ever had, and you're curious about how it might scale to something that's a 100, a 1,000 times bigger. This is a place where you can get to do that.\"\n}\n"
+          "returns": "The transcribed text."
         }
       }
     },
@@ -1914,19 +5668,19 @@
         },
         "summary": "Translates audio into English.",
         "tags": [
-          "OpenAI"
+          "Audio"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/audio/translations \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: multipart/form-data\" \\\n  -F file=\"@/path/to/file/german.m4a\" \\\n  -F model=\"whisper-1\"\n",
-            "node": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst resp = await openai.createTranslation(\n  fs.createReadStream(\"audio.mp3\"),\n  \"whisper-1\"\n);\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\naudio_file = open(\"german.m4a\", \"rb\")\ntranscript = openai.Audio.translate(\"whisper-1\", audio_file)\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/audio/translations \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: multipart/form-data\" \\\n  -F file=\"@/path/to/file/german.m4a\" \\\n  -F model=\"whisper-1\"\n",
+              "node": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst resp = await openai.createTranslation(\n  fs.createReadStream(\"audio.mp3\"),\n  \"whisper-1\"\n);\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\naudio_file = open(\"speech.mp3\", \"rb\")\ntranscript = client.audio.translations.create(\n  model=\"whisper-1\", \n  file=audio_file\n)\n"
+            },
+            "response": "{\n  \"text\": \"Hello, my name is Wolfgang and I come from Germany. Where are you heading today?\"\n}\n"
           },
-          "group": "audio",
           "name": "Create translation",
-          "parameters": "{\n  \"file\": \"german.m4a\",\n  \"model\": \"whisper-1\"\n}\n",
-          "path": "create",
-          "response": "{\n  \"text\": \"Hello, my name is Wolfgang and I come from Germany. Where are you heading today?\"\n}\n"
+          "returns": "The translated text."
         }
       }
     },
@@ -1957,19 +5711,51 @@
         },
         "summary": "Creates a model response for the given chat conversation.",
         "tags": [
-          "OpenAI"
+          "Chat"
         ],
         "x-oaiMeta": {
-          "examples": {
-            "curl": "curl https://api.openai.com/v1/chat/completions \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"model\": \"gpt-3.5-turbo\",\n    \"messages\": [{\"role\": \"system\", \"content\": \"You are a helpful assistant.\"}, {\"role\": \"user\", \"content\": \"Hello!\"}]\n  }'\n",
-            "node.js": "const { Configuration, OpenAIApi } = require(\"openai\");\n\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\n\nconst completion = await openai.createChatCompletion({\n  model: \"gpt-3.5-turbo\",\n  messages: [{\"role\": \"system\", \"content\": \"You are a helpful assistant.\"}, {role: \"user\", content: \"Hello world\"}],\n});\nconsole.log(completion.data.choices[0].message);\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\n\ncompletion = openai.ChatCompletion.create(\n  model=\"gpt-3.5-turbo\",\n  messages=[\n    {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n    {\"role\": \"user\", \"content\": \"Hello!\"}\n  ]\n)\n\nprint(completion.choices[0].message)\n"
-          },
+          "examples": [
+            {
+              "request": {
+                "curl": "curl https://api.openai.com/v1/chat/completions \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"model\": \"VAR_model_id\",\n    \"messages\": [\n      {\n        \"role\": \"system\",\n        \"content\": \"You are a helpful assistant.\"\n      },\n      {\n        \"role\": \"user\",\n        \"content\": \"Hello!\"\n      }\n    ]\n  }'\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const completion = await openai.chat.completions.create({\n    messages: [{ role: \"system\", content: \"You are a helpful assistant.\" }],\n    model: \"VAR_model_id\",\n  });\n\n  console.log(completion.choices[0]);\n}\n\nmain();",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\ncompletion = client.chat.completions.create(\n  model=\"VAR_model_id\",\n  messages=[\n    {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n    {\"role\": \"user\", \"content\": \"Hello!\"}\n  ]\n)\n\nprint(completion.choices[0].message)\n"
+              },
+              "response": "{\n  \"id\": \"chatcmpl-123\",\n  \"object\": \"chat.completion\",\n  \"created\": 1677652288,\n  \"model\": \"gpt-3.5-turbo-0613\",\n  \"system_fingerprint\": \"fp_44709d6fcb\",\n  \"choices\": [{\n    \"index\": 0,\n    \"message\": {\n      \"role\": \"assistant\",\n      \"content\": \"\\n\\nHello there, how may I assist you today?\",\n    },\n    \"finish_reason\": \"stop\"\n  }],\n  \"usage\": {\n    \"prompt_tokens\": 9,\n    \"completion_tokens\": 12,\n    \"total_tokens\": 21\n  }\n}\n",
+              "title": "Default"
+            },
+            {
+              "request": {
+                "curl": "curl https://api.openai.com/v1/chat/completions \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"model\": \"VAR_model_id\",\n    \"messages\": [\n      {\n        \"role\": \"system\",\n        \"content\": \"You are a helpful assistant.\"\n      },\n      {\n        \"role\": \"user\",\n        \"content\": \"Hello!\"\n      }\n    ]\n  }'\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const completion = await openai.chat.completions.create({\n    messages: [{ role: \"system\", content: \"You are a helpful assistant.\" }],\n    model: \"VAR_model_id\",\n  });\n\n  console.log(completion.choices[0]);\n}\n\nmain();",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\ncompletion = client.chat.completions.create(\n  model=\"VAR_model_id\",\n  messages=[\n    {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n    {\"role\": \"user\", \"content\": \"Hello!\"}\n  ]\n)\n\nprint(completion.choices[0].message)\n"
+              },
+              "response": "{\n  \"id\": \"chatcmpl-123\",\n  \"object\": \"chat.completion\",\n  \"created\": 1677652288,\n  \"model\": \"gpt-3.5-turbo-0613\",\n  \"system_fingerprint\": \"fp_44709d6fcb\",\n  \"choices\": [{\n    \"index\": 0,\n    \"message\": {\n      \"role\": \"assistant\",\n      \"content\": \"\\n\\nHello there, how may I assist you today?\",\n    },\n    \"finish_reason\": \"stop\"\n  }],\n  \"usage\": {\n    \"prompt_tokens\": 9,\n    \"completion_tokens\": 12,\n    \"total_tokens\": 21\n  }\n}\n",
+              "title": "Image input"
+            },
+            {
+              "request": {
+                "curl": "curl https://api.openai.com/v1/chat/completions \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"model\": \"VAR_model_id\",\n    \"messages\": [\n      {\n        \"role\": \"system\",\n        \"content\": \"You are a helpful assistant.\"\n      },\n      {\n        \"role\": \"user\",\n        \"content\": \"Hello!\"\n      }\n    ],\n    \"stream\": true\n  }'\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const completion = await openai.chat.completions.create({\n    model: \"VAR_model_id\",\n    messages: [\n      {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n      {\"role\": \"user\", \"content\": \"Hello!\"}\n    ],\n    stream: true,\n  });\n\n  for await (const chunk of completion) {\n    console.log(chunk.choices[0].delta.content);\n  }\n}\n\nmain();",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\ncompletion = client.chat.completions.create(\n  model=\"VAR_model_id\",\n  messages=[\n    {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n    {\"role\": \"user\", \"content\": \"Hello!\"}\n  ],\n  stream=True\n)\n\nfor chunk in completion:\n  print(chunk.choices[0].delta)\n"
+              },
+              "response": "{\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"created\":1694268190,\"model\":\"gpt-3.5-turbo-0613\", \"system_fingerprint\": \"fp_44709d6fcb\", \"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"},\"finish_reason\":null}]}\n\n{\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"created\":1694268190,\"model\":\"gpt-3.5-turbo-0613\", \"system_fingerprint\": \"fp_44709d6fcb\", \"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n{\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"created\":1694268190,\"model\":\"gpt-3.5-turbo-0613\", \"system_fingerprint\": \"fp_44709d6fcb\", \"choices\":[{\"index\":0,\"delta\":{\"content\":\"!\"},\"finish_reason\":null}]}\n\n....\n\n{\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"created\":1694268190,\"model\":\"gpt-3.5-turbo-0613\", \"system_fingerprint\": \"fp_44709d6fcb\", \"choices\":[{\"index\":0,\"delta\":{\"content\":\" today\"},\"finish_reason\":null}]}\n\n{\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"created\":1694268190,\"model\":\"gpt-3.5-turbo-0613\", \"system_fingerprint\": \"fp_44709d6fcb\", \"choices\":[{\"index\":0,\"delta\":{\"content\":\"?\"},\"finish_reason\":null}]}\n\n{\"id\":\"chatcmpl-123\",\"object\":\"chat.completion.chunk\",\"created\":1694268190,\"model\":\"gpt-3.5-turbo-0613\", \"system_fingerprint\": \"fp_44709d6fcb\", \"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n",
+              "title": "Streaming"
+            },
+            {
+              "request": {
+                "curl": "curl https://api.openai.com/v1/chat/completions \\\n-H \"Content-Type: application/json\" \\\n-H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n-d '{\n  \"model\": \"gpt-3.5-turbo\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is the weather like in Boston?\"\n    }\n  ],\n  \"functions\": [\n    {\n      \"name\": \"get_current_weather\",\n      \"description\": \"Get the current weather in a given location\",\n      \"parameters\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"location\": {\n            \"type\": \"string\",\n            \"description\": \"The city and state, e.g. San Francisco, CA\"\n          },\n          \"unit\": {\n            \"type\": \"string\",\n            \"enum\": [\"celsius\", \"fahrenheit\"]\n          }\n        },\n        \"required\": [\"location\"]\n      }\n    }\n  ],\n  \"function_call\": \"auto\"\n}'\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const messages = [{\"role\": \"user\", \"content\": \"What's the weather like in Boston today?\"}];\n  const functions = [\n      {\n          \"name\": \"get_current_weather\",\n          \"description\": \"Get the current weather in a given location\",\n          \"parameters\": {\n              \"type\": \"object\",\n              \"properties\": {\n                  \"location\": {\n                      \"type\": \"string\",\n                      \"description\": \"The city and state, e.g. San Francisco, CA\",\n                  },\n                  \"unit\": {\"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"]},\n              },\n              \"required\": [\"location\"],\n          },\n      }\n  ];\n\n  const response = await openai.chat.completions.create({\n      model: \"gpt-3.5-turbo\",\n      messages: messages,\n      functions: functions,\n      function_call: \"auto\",  // auto is default, but we'll be explicit\n  });\n\n  console.log(response);\n}\n\nmain();",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nfunctions = [\n  {\n    \"name\": \"get_current_weather\",\n    \"description\": \"Get the current weather in a given location\",\n    \"parameters\": {\n        \"type\": \"object\",\n        \"properties\": {\n            \"location\": {\n                \"type\": \"string\",\n                \"description\": \"The city and state, e.g. San Francisco, CA\",\n            },\n            \"unit\": {\"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"]},\n        },\n        \"required\": [\"location\"],\n    },\n  }\n]\nmessages = [{\"role\": \"user\", \"content\": \"What's the weather like in Boston today?\"}]\ncompletion = client.chat.completions.create(\n  model=\"VAR_model_id\",\n  messages=messages,\n  functions=functions,\n  function_call=\"auto\"\n)\n\nprint(completion)\n"
+              },
+              "response": "{\n  \"choices\": [\n    {\n      \"finish_reason\": \"function_call\",\n      \"index\": 0,\n      \"message\": {\n        \"content\": null,\n        \"function_call\": {\n          \"arguments\": \"{\\n  \\\"location\\\": \\\"Boston, MA\\\"\\n}\",\n          \"name\": \"get_current_weather\"\n        },\n        \"role\": \"assistant\"\n      }\n    }\n  ],\n  \"created\": 1694028367,\n  \"model\": \"gpt-3.5-turbo-0613\",\n  \"system_fingerprint\": \"fp_44709d6fcb\",\n  \"object\": \"chat.completion\",\n  \"usage\": {\n    \"completion_tokens\": 18,\n    \"prompt_tokens\": 82,\n    \"total_tokens\": 100\n  }\n}\n",
+              "title": "Function calling"
+            }
+          ],
           "group": "chat",
           "name": "Create chat completion",
-          "parameters": "{\n  \"model\": \"gpt-3.5-turbo\",\n  \"messages\": [{\"role\": \"system\", \"content\": \"You are a helpful assistant.\"}, {\"role\": \"user\", \"content\": \"Hello!\"}]\n}\n",
           "path": "create",
-          "response": "{\n  \"id\": \"chatcmpl-123\",\n  \"object\": \"chat.completion\",\n  \"created\": 1677652288,\n  \"choices\": [{\n    \"index\": 0,\n    \"message\": {\n      \"role\": \"assistant\",\n      \"content\": \"\\n\\nHello there, how may I assist you today?\",\n    },\n    \"finish_reason\": \"stop\"\n  }],\n  \"usage\": {\n    \"prompt_tokens\": 9,\n    \"completion_tokens\": 12,\n    \"total_tokens\": 21\n  }\n}\n"
+          "returns": "Returns a [chat completion](/docs/api-reference/chat/object) object, or a streamed sequence of [chat completion chunk](/docs/api-reference/chat/streaming) objects if the request is streamed.\n"
         }
       }
     },
@@ -2000,20 +5786,32 @@
         },
         "summary": "Creates a completion for the provided prompt and parameters.",
         "tags": [
-          "OpenAI"
+          "Completions"
         ],
         "x-oaiMeta": {
-          "examples": {
-            "curl": "curl https://api.openai.com/v1/completions \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"model\": \"VAR_model_id\",\n    \"prompt\": \"Say this is a test\",\n    \"max_tokens\": 7,\n    \"temperature\": 0\n  }'\n",
-            "node.js": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst response = await openai.createCompletion({\n  model: \"VAR_model_id\",\n  prompt: \"Say this is a test\",\n  max_tokens: 7,\n  temperature: 0,\n});\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\nopenai.Completion.create(\n  model=\"VAR_model_id\",\n  prompt=\"Say this is a test\",\n  max_tokens=7,\n  temperature=0\n)\n"
-          },
-          "group": "completions",
+          "examples": [
+            {
+              "request": {
+                "curl": "curl https://api.openai.com/v1/completions \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"model\": \"VAR_model_id\",\n    \"prompt\": \"Say this is a test\",\n    \"max_tokens\": 7,\n    \"temperature\": 0\n  }'\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const completion = await openai.completions.create({\n    model: \"VAR_model_id\",\n    prompt: \"Say this is a test.\",\n    max_tokens: 7,\n    temperature: 0,\n  });\n\n  console.log(completion);\n}\nmain();",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.completions.create(\n  model=\"VAR_model_id\",\n  prompt=\"Say this is a test\",\n  max_tokens=7,\n  temperature=0\n)\n"
+              },
+              "response": "{\n  \"id\": \"cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7\",\n  \"object\": \"text_completion\",\n  \"created\": 1589478378,\n  \"model\": \"VAR_model_id\",\n  \"system_fingerprint\": \"fp_44709d6fcb\",\n  \"choices\": [\n    {\n      \"text\": \"\\n\\nThis is indeed a test\",\n      \"index\": 0,\n      \"logprobs\": null,\n      \"finish_reason\": \"length\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 5,\n    \"completion_tokens\": 7,\n    \"total_tokens\": 12\n  }\n}\n",
+              "title": "No streaming"
+            },
+            {
+              "request": {
+                "curl": "curl https://api.openai.com/v1/completions \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"model\": \"VAR_model_id\",\n    \"prompt\": \"Say this is a test\",\n    \"max_tokens\": 7,\n    \"temperature\": 0,\n    \"stream\": true\n  }'\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const stream = await openai.completions.create({\n    model: \"VAR_model_id\",\n    prompt: \"Say this is a test.\",\n    stream: true,\n  });\n\n  for await (const chunk of stream) {\n    console.log(chunk.choices[0].text)\n  }\n}\nmain();",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nfor chunk in client.completions.create(\n  model=\"VAR_model_id\",\n  prompt=\"Say this is a test\",\n  max_tokens=7,\n  temperature=0,\n  stream=True\n):\n  print(chunk.choices[0].text)\n"
+              },
+              "response": "{\n  \"id\": \"cmpl-7iA7iJjj8V2zOkCGvWF2hAkDWBQZe\",\n  \"object\": \"text_completion\",\n  \"created\": 1690759702,\n  \"choices\": [\n    {\n      \"text\": \"This\",\n      \"index\": 0,\n      \"logprobs\": null,\n      \"finish_reason\": null\n    }\n  ],\n  \"model\": \"gpt-3.5-turbo-instruct\"\n  \"system_fingerprint\": \"fp_44709d6fcb\",\n}\n",
+              "title": "Streaming"
+            }
+          ],
           "legacy": true,
           "name": "Create completion",
-          "parameters": "{\n  \"model\": \"VAR_model_id\",\n  \"prompt\": \"Say this is a test\",\n  \"max_tokens\": 7,\n  \"temperature\": 0,\n  \"top_p\": 1,\n  \"n\": 1,\n  \"stream\": false,\n  \"logprobs\": null,\n  \"stop\": \"\\n\"\n}\n",
-          "path": "create",
-          "response": "{\n  \"id\": \"cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7\",\n  \"object\": \"text_completion\",\n  \"created\": 1589478378,\n  \"model\": \"VAR_model_id\",\n  \"choices\": [\n    {\n      \"text\": \"\\n\\nThis is indeed a test\",\n      \"index\": 0,\n      \"logprobs\": null,\n      \"finish_reason\": \"length\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 5,\n    \"completion_tokens\": 7,\n    \"total_tokens\": 12\n  }\n}\n"
+          "returns": "Returns a [completion](/docs/api-reference/completions/object) object, or a sequence of completion objects if the request is streamed.\n"
         }
       }
     },
@@ -2045,19 +5843,20 @@
         },
         "summary": "Creates a new edit for the provided input, instruction, and parameters.",
         "tags": [
-          "OpenAI"
+          "Edits"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/edits \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"model\": \"VAR_model_id\",\n    \"input\": \"What day of the wek is it?\",\n    \"instruction\": \"Fix the spelling mistakes\"\n  }'\n",
-            "node.js": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst response = await openai.createEdit({\n  model: \"VAR_model_id\",\n  input: \"What day of the wek is it?\",\n  instruction: \"Fix the spelling mistakes\",\n});\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\nopenai.Edit.create(\n  model=\"VAR_model_id\",\n  input=\"What day of the wek is it?\",\n  instruction=\"Fix the spelling mistakes\"\n)\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/edits \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"model\": \"VAR_model_id\",\n    \"input\": \"What day of the wek is it?\",\n    \"instruction\": \"Fix the spelling mistakes\"\n  }'\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const edit = await openai.edits.create({\n    model: \"VAR_model_id\",\n    input: \"What day of the wek is it?\",\n    instruction: \"Fix the spelling mistakes.\",\n  });\n\n  console.log(edit);\n}\n\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.edits.create(\n  model=\"VAR_model_id\",\n  input=\"What day of the wek is it?\",\n  instruction=\"Fix the spelling mistakes\"\n)\n"
+            },
+            "response": "{\n  \"object\": \"edit\",\n  \"created\": 1589478378,\n  \"choices\": [\n    {\n      \"text\": \"What day of the week is it?\",\n      \"index\": 0,\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 25,\n    \"completion_tokens\": 32,\n    \"total_tokens\": 57\n  }\n}\n"
           },
           "group": "edits",
           "name": "Create edit",
-          "parameters": "{\n  \"model\": \"VAR_model_id\",\n  \"input\": \"What day of the wek is it?\",\n  \"instruction\": \"Fix the spelling mistakes\"\n}\n",
-          "path": "create",
-          "response": "{\n  \"object\": \"edit\",\n  \"created\": 1589478378,\n  \"choices\": [\n    {\n      \"text\": \"What day of the week is it?\",\n      \"index\": 0,\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 25,\n    \"completion_tokens\": 32,\n    \"total_tokens\": 57\n  }\n}\n"
+          "returns": "Returns an [edit](/docs/api-reference/edits/object) object.\n"
         }
       }
     },
@@ -2088,25 +5887,36 @@
         },
         "summary": "Creates an embedding vector representing the input text.",
         "tags": [
-          "OpenAI"
+          "Embeddings"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/embeddings \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"input\": \"The food was delicious and the waiter...\",\n    \"model\": \"text-embedding-ada-002\"\n  }'\n",
-            "node.js": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst response = await openai.createEmbedding({\n  model: \"text-embedding-ada-002\",\n  input: \"The food was delicious and the waiter...\",\n});\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\nopenai.Embedding.create(\n  model=\"text-embedding-ada-002\",\n  input=\"The food was delicious and the waiter...\"\n)\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/embeddings \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"input\": \"The food was delicious and the waiter...\",\n    \"model\": \"text-embedding-ada-002\",\n    \"encoding_format\": \"float\"\n  }'\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const embedding = await openai.embeddings.create({\n    model: \"text-embedding-ada-002\",\n    input: \"The quick brown fox jumped over the lazy dog\",\n    encoding_format: \"float\",\n  });\n\n  console.log(embedding);\n}\n\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.embeddings.create(\n  model=\"text-embedding-ada-002\",\n  input=\"The food was delicious and the waiter...\",\n  encoding_format=\"float\"\n)\n"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"object\": \"embedding\",\n      \"embedding\": [\n        0.0023064255,\n        -0.009327292,\n        .... (1536 floats total for ada-002)\n        -0.0028842222,\n      ],\n      \"index\": 0\n    }\n  ],\n  \"model\": \"text-embedding-ada-002\",\n  \"usage\": {\n    \"prompt_tokens\": 8,\n    \"total_tokens\": 8\n  }\n}\n"
           },
-          "group": "embeddings",
           "name": "Create embeddings",
-          "parameters": "{\n  \"model\": \"text-embedding-ada-002\",\n  \"input\": \"The food was delicious and the waiter...\"\n}\n",
-          "path": "create",
-          "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"object\": \"embedding\",\n      \"embedding\": [\n        0.0023064255,\n        -0.009327292,\n        .... (1536 floats total for ada-002)\n        -0.0028842222,\n      ],\n      \"index\": 0\n    }\n  ],\n  \"model\": \"text-embedding-ada-002\",\n  \"usage\": {\n    \"prompt_tokens\": 8,\n    \"total_tokens\": 8\n  }\n}\n"
+          "returns": "A list of [embedding](/docs/api-reference/embeddings/object) objects."
         }
       }
     },
     "/files": {
       "get": {
         "operationId": "listFiles",
+        "parameters": [
+          {
+            "description": "Only return files with the given purpose.",
+            "in": "query",
+            "name": "purpose",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -2121,18 +5931,19 @@
         },
         "summary": "Returns a list of files that belong to the user's organization.",
         "tags": [
-          "OpenAI"
+          "Files"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/files \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
-            "node.js": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst response = await openai.listFiles();\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\nopenai.File.list()\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/files \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const list = await openai.files.list();\n\n  for await (const file of list) {\n    console.log(file);\n  }\n}\n\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.files.list()\n"
+            },
+            "response": "{\n  \"data\": [\n    {\n      \"id\": \"file-abc123\",\n      \"object\": \"file\",\n      \"bytes\": 175,\n      \"created_at\": 1613677385,\n      \"filename\": \"salesOverview.pdf\",\n      \"purpose\": \"assistants\",\n    },\n    {\n      \"id\": \"file-abc123\",\n      \"object\": \"file\",\n      \"bytes\": 140,\n      \"created_at\": 1613779121,\n      \"filename\": \"puppy.jsonl\",\n      \"purpose\": \"fine-tune\",\n    }\n  ],\n  \"object\": \"list\"\n}\n"
           },
-          "group": "files",
           "name": "List files",
-          "path": "list",
-          "response": "{\n  \"data\": [\n    {\n      \"id\": \"file-ccdDZrC3iZVNiQVeEA6Z66wf\",\n      \"object\": \"file\",\n      \"bytes\": 175,\n      \"created_at\": 1613677385,\n      \"filename\": \"train.jsonl\",\n      \"purpose\": \"search\"\n    },\n    {\n      \"id\": \"file-XjGxS3KTG0uNmNOK362iJua3\",\n      \"object\": \"file\",\n      \"bytes\": 140,\n      \"created_at\": 1613779121,\n      \"filename\": \"puppy.jsonl\",\n      \"purpose\": \"search\"\n    }\n  ],\n  \"object\": \"list\"\n}\n"
+          "returns": "A list of [File](/docs/api-reference/files/object) objects."
         }
       },
       "post": {
@@ -2159,20 +5970,21 @@
             "description": "OK"
           }
         },
-        "summary": "Upload a file that contains document(s) to be used across various endpoints/features. Currently, the size of all the files uploaded by one organization can be up to 1 GB. Please contact us if you need to increase the storage limit.\n",
+        "summary": "Upload a file that can be used across various endpoints/features. The size of all the files uploaded by one organization can be up to 100 GB.\n\nThe size of individual files for can be a maximum of 512MB. See the [Assistants Tools guide](/docs/assistants/tools) to learn more about the types of files supported. The Fine-tuning API only supports `.jsonl` files.\n\nPlease [contact us](https://help.openai.com/) if you need to increase these storage limits.\n",
         "tags": [
-          "OpenAI"
+          "Files"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/files \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -F purpose=\"fine-tune\" \\\n  -F file=\"@mydata.jsonl\"\n",
-            "node.js": "const fs = require(\"fs\");\nconst { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst response = await openai.createFile(\n  fs.createReadStream(\"mydata.jsonl\"),\n  \"fine-tune\"\n);\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\nopenai.File.create(\n  file=open(\"mydata.jsonl\", \"rb\"),\n  purpose='fine-tune'\n)\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/files \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -F purpose=\"fine-tune\" \\\n  -F file=\"@mydata.jsonl\"\n",
+              "node.js": "import fs from \"fs\";\nimport OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const file = await openai.files.create({\n    file: fs.createReadStream(\"mydata.jsonl\"),\n    purpose: \"fine-tune\",\n  });\n\n  console.log(file);\n}\n\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.files.create(\n  file=open(\"mydata.jsonl\", \"rb\"),\n  purpose=\"fine-tune\"\n)\n"
+            },
+            "response": "{\n  \"id\": \"file-BK7bzQj3FfZFXr7DbL6xJwfo\",\n  \"object\": \"file\",\n  \"bytes\": 120000,\n  \"created_at\": 1677610602,\n  \"filename\": \"mydata.jsonl\",\n  \"purpose\": \"fine-tune\",\n}\n"
           },
-          "group": "files",
           "name": "Upload file",
-          "path": "upload",
-          "response": "{\n  \"id\": \"file-XjGxS3KTG0uNmNOK362iJua3\",\n  \"object\": \"file\",\n  \"bytes\": 140,\n  \"created_at\": 1613779121,\n  \"filename\": \"mydata.jsonl\",\n  \"purpose\": \"fine-tune\"\n}\n"
+          "returns": "The uploaded [File](/docs/api-reference/files/object) object."
         }
       }
     },
@@ -2181,7 +5993,7 @@
         "operationId": "deleteFile",
         "parameters": [
           {
-            "description": "The ID of the file to use for this request",
+            "description": "The ID of the file to use for this request.",
             "in": "path",
             "name": "file_id",
             "required": true,
@@ -2204,25 +6016,26 @@
         },
         "summary": "Delete a file.",
         "tags": [
-          "OpenAI"
+          "Files"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/files/file-XjGxS3KTG0uNmNOK362iJua3 \\\n  -X DELETE \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
-            "node.js": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst response = await openai.deleteFile(\"file-XjGxS3KTG0uNmNOK362iJua3\");\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\nopenai.File.delete(\"file-XjGxS3KTG0uNmNOK362iJua3\")\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/files/file-abc123 \\\n  -X DELETE \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const file = await openai.files.del(\"file-abc123\");\n\n  console.log(file);\n}\n\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.files.delete(\"file-oaG6vwLtV3v3mWpvxexWDKxq\")\n"
+            },
+            "response": "{\n  \"id\": \"file-abc123\",\n  \"object\": \"file\",\n  \"deleted\": true\n}\n"
           },
-          "group": "files",
           "name": "Delete file",
-          "path": "delete",
-          "response": "{\n  \"id\": \"file-XjGxS3KTG0uNmNOK362iJua3\",\n  \"object\": \"file\",\n  \"deleted\": true\n}\n"
+          "returns": "Deletion status."
         }
       },
       "get": {
         "operationId": "retrieveFile",
         "parameters": [
           {
-            "description": "The ID of the file to use for this request",
+            "description": "The ID of the file to use for this request.",
             "in": "path",
             "name": "file_id",
             "required": true,
@@ -2245,18 +6058,19 @@
         },
         "summary": "Returns information about a specific file.",
         "tags": [
-          "OpenAI"
+          "Files"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/files/file-XjGxS3KTG0uNmNOK362iJua3 \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
-            "node.js": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst response = await openai.retrieveFile(\"file-XjGxS3KTG0uNmNOK362iJua3\");\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\nopenai.File.retrieve(\"file-XjGxS3KTG0uNmNOK362iJua3\")\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/files/file-BK7bzQj3FfZFXr7DbL6xJwfo \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const file = await openai.files.retrieve(\"file-BK7bzQj3FfZFXr7DbL6xJwfo\");\n\n  console.log(file);\n}\n\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.files.retrieve(\"file-BK7bzQj3FfZFXr7DbL6xJwfo\")\n"
+            },
+            "response": "{\n  \"id\": \"file-BK7bzQj3FfZFXr7DbL6xJwfo\",\n  \"object\": \"file\",\n  \"bytes\": 120000,\n  \"created_at\": 1677610602,\n  \"filename\": \"mydata.jsonl\",\n  \"purpose\": \"fine-tune\",\n}\n"
           },
-          "group": "files",
           "name": "Retrieve file",
-          "path": "retrieve",
-          "response": "{\n  \"id\": \"file-XjGxS3KTG0uNmNOK362iJua3\",\n  \"object\": \"file\",\n  \"bytes\": 140,\n  \"created_at\": 1613779657,\n  \"filename\": \"mydata.jsonl\",\n  \"purpose\": \"fine-tune\"\n}\n"
+          "returns": "The [File](/docs/api-reference/files/object) object matching the specified ID."
         }
       }
     },
@@ -2265,7 +6079,7 @@
         "operationId": "downloadFile",
         "parameters": [
           {
-            "description": "The ID of the file to use for this request",
+            "description": "The ID of the file to use for this request.",
             "in": "path",
             "name": "file_id",
             "required": true,
@@ -2286,24 +6100,26 @@
             "description": "OK"
           }
         },
-        "summary": "Returns the contents of the specified file",
+        "summary": "Returns the contents of the specified file.",
         "tags": [
-          "OpenAI"
+          "Files"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/files/file-XjGxS3KTG0uNmNOK362iJua3/content \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" > file.jsonl\n",
-            "node.js": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst response = await openai.downloadFile(\"file-XjGxS3KTG0uNmNOK362iJua3\");\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\ncontent = openai.File.download(\"file-XjGxS3KTG0uNmNOK362iJua3\")\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/files/file-BK7bzQj3FfZFXr7DbL6xJwfo/content \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" > file.jsonl\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const file = await openai.files.retrieveContent(\"file-BK7bzQj3FfZFXr7DbL6xJwfo\");\n\n  console.log(file);\n}\n\nmain();\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\ncontent = client.files.retrieve_content(\"file-BK7bzQj3FfZFXr7DbL6xJwfo\")\n"
+            }
           },
-          "group": "files",
           "name": "Retrieve file content",
-          "path": "retrieve-content"
+          "returns": "The file content."
         }
       }
     },
     "/fine-tunes": {
       "get": {
+        "deprecated": true,
         "operationId": "listFineTunes",
         "responses": {
           "200": {
@@ -2319,21 +6135,23 @@
         },
         "summary": "List your organization's fine-tuning jobs\n",
         "tags": [
-          "OpenAI"
+          "Fine-tunes"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/fine-tunes \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
-            "node.js": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst response = await openai.listFineTunes();\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\nopenai.FineTune.list()\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/fine-tunes \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const list = await openai.fineTunes.list();\n\n  for await (const fineTune of list) {\n    console.log(fineTune);\n  }\n}\n\nmain();",
+              "python": "# deprecated\n"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"id\": \"ft-AF1WoRqd3aJAHsqc9NY7iL8F\",\n      \"object\": \"fine-tune\",\n      \"model\": \"curie\",\n      \"created_at\": 1614807352,\n      \"fine_tuned_model\": null,\n      \"hyperparams\": { ... },\n      \"organization_id\": \"org-123\",\n      \"result_files\": [],\n      \"status\": \"pending\",\n      \"validation_files\": [],\n      \"training_files\": [ { ... } ],\n      \"updated_at\": 1614807352,\n    },\n    { ... },\n    { ... }\n  ]\n}\n"
           },
-          "group": "fine-tunes",
           "name": "List fine-tunes",
-          "path": "list",
-          "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"id\": \"ft-AF1WoRqd3aJAHsqc9NY7iL8F\",\n      \"object\": \"fine-tune\",\n      \"model\": \"curie\",\n      \"created_at\": 1614807352,\n      \"fine_tuned_model\": null,\n      \"hyperparams\": { ... },\n      \"organization_id\": \"org-...\",\n      \"result_files\": [],\n      \"status\": \"pending\",\n      \"validation_files\": [],\n      \"training_files\": [ { ... } ],\n      \"updated_at\": 1614807352,\n    },\n    { ... },\n    { ... }\n  ]\n}\n"
+          "returns": "A list of [fine-tune](/docs/api-reference/fine-tunes/object) objects."
         }
       },
       "post": {
+        "deprecated": true,
         "operationId": "createFineTune",
         "requestBody": {
           "content": {
@@ -2357,25 +6175,27 @@
             "description": "OK"
           }
         },
-        "summary": "Creates a job that fine-tunes a specified model from a given dataset.\n\nResponse includes details of the enqueued job including job status and the name of the fine-tuned models once complete.\n\n[Learn more about Fine-tuning](https://platform.openai.com/docs/guides/fine-tuning)\n",
+        "summary": "Creates a job that fine-tunes a specified model from a given dataset.\n\nResponse includes details of the enqueued job including job status and the name of the fine-tuned models once complete.\n\n[Learn more about fine-tuning](/docs/guides/legacy-fine-tuning)\n",
         "tags": [
-          "OpenAI"
+          "Fine-tunes"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/fine-tunes \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"training_file\": \"file-XGinujblHPwGLSztz8cPS8XY\"\n  }'\n",
-            "node.js": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst response = await openai.createFineTune({\n  training_file: \"file-XGinujblHPwGLSztz8cPS8XY\",\n});\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\nopenai.FineTune.create(training_file=\"file-XGinujblHPwGLSztz8cPS8XY\")\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/fine-tunes \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"training_file\": \"file-abc123\"\n  }'\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const fineTune = await openai.fineTunes.create({\n    training_file: \"file-abc123\"\n  });\n\n  console.log(fineTune);\n}\n\nmain();\n",
+              "python": "# deprecated\n"
+            },
+            "response": "{\n  \"id\": \"ft-AF1WoRqd3aJAHsqc9NY7iL8F\",\n  \"object\": \"fine-tune\",\n  \"model\": \"curie\",\n  \"created_at\": 1614807352,\n  \"events\": [\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807352,\n      \"level\": \"info\",\n      \"message\": \"Job enqueued. Waiting for jobs ahead to complete. Queue number: 0.\"\n    }\n  ],\n  \"fine_tuned_model\": null,\n  \"hyperparams\": {\n    \"batch_size\": 4,\n    \"learning_rate_multiplier\": 0.1,\n    \"n_epochs\": 4,\n    \"prompt_loss_weight\": 0.1,\n  },\n  \"organization_id\": \"org-123\",\n  \"result_files\": [],\n  \"status\": \"pending\",\n  \"validation_files\": [],\n  \"training_files\": [\n    {\n      \"id\": \"file-abc123\",\n      \"object\": \"file\",\n      \"bytes\": 1547276,\n      \"created_at\": 1610062281,\n      \"filename\": \"my-data-train.jsonl\",\n      \"purpose\": \"fine-tune-results\"\n    }\n  ],\n  \"updated_at\": 1614807352,\n}\n"
           },
-          "group": "fine-tunes",
           "name": "Create fine-tune",
-          "path": "create",
-          "response": "{\n  \"id\": \"ft-AF1WoRqd3aJAHsqc9NY7iL8F\",\n  \"object\": \"fine-tune\",\n  \"model\": \"curie\",\n  \"created_at\": 1614807352,\n  \"events\": [\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807352,\n      \"level\": \"info\",\n      \"message\": \"Job enqueued. Waiting for jobs ahead to complete. Queue number: 0.\"\n    }\n  ],\n  \"fine_tuned_model\": null,\n  \"hyperparams\": {\n    \"batch_size\": 4,\n    \"learning_rate_multiplier\": 0.1,\n    \"n_epochs\": 4,\n    \"prompt_loss_weight\": 0.1,\n  },\n  \"organization_id\": \"org-...\",\n  \"result_files\": [],\n  \"status\": \"pending\",\n  \"validation_files\": [],\n  \"training_files\": [\n    {\n      \"id\": \"file-XGinujblHPwGLSztz8cPS8XY\",\n      \"object\": \"file\",\n      \"bytes\": 1547276,\n      \"created_at\": 1610062281,\n      \"filename\": \"my-data-train.jsonl\",\n      \"purpose\": \"fine-tune-train\"\n    }\n  ],\n  \"updated_at\": 1614807352,\n}\n"
+          "returns": "A [fine-tune](/docs/api-reference/fine-tunes/object) object."
         }
       }
     },
     "/fine-tunes/{fine_tune_id}": {
       "get": {
+        "deprecated": true,
         "operationId": "retrieveFineTune",
         "parameters": [
           {
@@ -2401,25 +6221,27 @@
             "description": "OK"
           }
         },
-        "summary": "Gets info about the fine-tune job.\n\n[Learn more about Fine-tuning](https://platform.openai.com/docs/guides/fine-tuning)\n",
+        "summary": "Gets info about the fine-tune job.\n\n[Learn more about fine-tuning](/docs/guides/legacy-fine-tuning)\n",
         "tags": [
-          "OpenAI"
+          "Fine-tunes"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/fine-tunes/ft-AF1WoRqd3aJAHsqc9NY7iL8F \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
-            "node.js": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst response = await openai.retrieveFineTune(\"ft-AF1WoRqd3aJAHsqc9NY7iL8F\");\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\nopenai.FineTune.retrieve(id=\"ft-AF1WoRqd3aJAHsqc9NY7iL8F\")\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/fine-tunes/ft-AF1WoRqd3aJAHsqc9NY7iL8F \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const fineTune = await openai.fineTunes.retrieve(\"ft-AF1WoRqd3aJAHsqc9NY7iL8F\");\n\n  console.log(fineTune);\n}\n\nmain();",
+              "python": "# deprecated\n"
+            },
+            "response": "{\n  \"id\": \"ft-AF1WoRqd3aJAHsqc9NY7iL8F\",\n  \"object\": \"fine-tune\",\n  \"model\": \"curie\",\n  \"created_at\": 1614807352,\n  \"events\": [\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807352,\n      \"level\": \"info\",\n      \"message\": \"Job enqueued. Waiting for jobs ahead to complete. Queue number: 0.\"\n    },\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807356,\n      \"level\": \"info\",\n      \"message\": \"Job started.\"\n    },\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807861,\n      \"level\": \"info\",\n      \"message\": \"Uploaded snapshot: curie:ft-acmeco-2021-03-03-21-44-20.\"\n    },\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807864,\n      \"level\": \"info\",\n      \"message\": \"Uploaded result files: file-abc123.\"\n    },\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807864,\n      \"level\": \"info\",\n      \"message\": \"Job succeeded.\"\n    }\n  ],\n  \"fine_tuned_model\": \"curie:ft-acmeco-2021-03-03-21-44-20\",\n  \"hyperparams\": {\n    \"batch_size\": 4,\n    \"learning_rate_multiplier\": 0.1,\n    \"n_epochs\": 4,\n    \"prompt_loss_weight\": 0.1,\n  },\n  \"organization_id\": \"org-123\",\n  \"result_files\": [\n    {\n      \"id\": \"file-abc123\",\n      \"object\": \"file\",\n      \"bytes\": 81509,\n      \"created_at\": 1614807863,\n      \"filename\": \"compiled_results.csv\",\n      \"purpose\": \"fine-tune-results\"\n    }\n  ],\n  \"status\": \"succeeded\",\n  \"validation_files\": [],\n  \"training_files\": [\n    {\n      \"id\": \"file-abc123\",\n      \"object\": \"file\",\n      \"bytes\": 1547276,\n      \"created_at\": 1610062281,\n      \"filename\": \"my-data-train.jsonl\",\n      \"purpose\": \"fine-tune\"\n    }\n  ],\n  \"updated_at\": 1614807865,\n}\n"
           },
-          "group": "fine-tunes",
           "name": "Retrieve fine-tune",
-          "path": "retrieve",
-          "response": "{\n  \"id\": \"ft-AF1WoRqd3aJAHsqc9NY7iL8F\",\n  \"object\": \"fine-tune\",\n  \"model\": \"curie\",\n  \"created_at\": 1614807352,\n  \"events\": [\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807352,\n      \"level\": \"info\",\n      \"message\": \"Job enqueued. Waiting for jobs ahead to complete. Queue number: 0.\"\n    },\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807356,\n      \"level\": \"info\",\n      \"message\": \"Job started.\"\n    },\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807861,\n      \"level\": \"info\",\n      \"message\": \"Uploaded snapshot: curie:ft-acmeco-2021-03-03-21-44-20.\"\n    },\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807864,\n      \"level\": \"info\",\n      \"message\": \"Uploaded result files: file-QQm6ZpqdNwAaVC3aSz5sWwLT.\"\n    },\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807864,\n      \"level\": \"info\",\n      \"message\": \"Job succeeded.\"\n    }\n  ],\n  \"fine_tuned_model\": \"curie:ft-acmeco-2021-03-03-21-44-20\",\n  \"hyperparams\": {\n    \"batch_size\": 4,\n    \"learning_rate_multiplier\": 0.1,\n    \"n_epochs\": 4,\n    \"prompt_loss_weight\": 0.1,\n  },\n  \"organization_id\": \"org-...\",\n  \"result_files\": [\n    {\n      \"id\": \"file-QQm6ZpqdNwAaVC3aSz5sWwLT\",\n      \"object\": \"file\",\n      \"bytes\": 81509,\n      \"created_at\": 1614807863,\n      \"filename\": \"compiled_results.csv\",\n      \"purpose\": \"fine-tune-results\"\n    }\n  ],\n  \"status\": \"succeeded\",\n  \"validation_files\": [],\n  \"training_files\": [\n    {\n      \"id\": \"file-XGinujblHPwGLSztz8cPS8XY\",\n      \"object\": \"file\",\n      \"bytes\": 1547276,\n      \"created_at\": 1610062281,\n      \"filename\": \"my-data-train.jsonl\",\n      \"purpose\": \"fine-tune-train\"\n    }\n  ],\n  \"updated_at\": 1614807865,\n}\n"
+          "returns": "The [fine-tune](/docs/api-reference/fine-tunes/object) object with the given ID."
         }
       }
     },
     "/fine-tunes/{fine_tune_id}/cancel": {
       "post": {
+        "deprecated": true,
         "operationId": "cancelFineTune",
         "parameters": [
           {
@@ -2447,23 +6269,25 @@
         },
         "summary": "Immediately cancel a fine-tune job.\n",
         "tags": [
-          "OpenAI"
+          "Fine-tunes"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/fine-tunes/ft-AF1WoRqd3aJAHsqc9NY7iL8F/cancel \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
-            "node.js": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst response = await openai.cancelFineTune(\"ft-AF1WoRqd3aJAHsqc9NY7iL8F\");\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\nopenai.FineTune.cancel(id=\"ft-AF1WoRqd3aJAHsqc9NY7iL8F\")\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/fine-tunes/ft-AF1WoRqd3aJAHsqc9NY7iL8F/cancel \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const fineTune = await openai.fineTunes.cancel(\"ft-AF1WoRqd3aJAHsqc9NY7iL8F\");\n\n  console.log(fineTune);\n}\nmain();",
+              "python": "# deprecated\n"
+            },
+            "response": "{\n  \"id\": \"ft-xhrpBbvVUzYGo8oUO1FY4nI7\",\n  \"object\": \"fine-tune\",\n  \"model\": \"curie\",\n  \"created_at\": 1614807770,\n  \"events\": [ { ... } ],\n  \"fine_tuned_model\": null,\n  \"hyperparams\": { ... },\n  \"organization_id\": \"org-123\",\n  \"result_files\": [],\n  \"status\": \"cancelled\",\n  \"validation_files\": [],\n  \"training_files\": [\n    {\n      \"id\": \"file-abc123\",\n      \"object\": \"file\",\n      \"bytes\": 1547276,\n      \"created_at\": 1610062281,\n      \"filename\": \"my-data-train.jsonl\",\n      \"purpose\": \"fine-tune\"\n    }\n  ],\n  \"updated_at\": 1614807789,\n}\n"
           },
-          "group": "fine-tunes",
           "name": "Cancel fine-tune",
-          "path": "cancel",
-          "response": "{\n  \"id\": \"ft-xhrpBbvVUzYGo8oUO1FY4nI7\",\n  \"object\": \"fine-tune\",\n  \"model\": \"curie\",\n  \"created_at\": 1614807770,\n  \"events\": [ { ... } ],\n  \"fine_tuned_model\": null,\n  \"hyperparams\": { ... },\n  \"organization_id\": \"org-...\",\n  \"result_files\": [],\n  \"status\": \"cancelled\",\n  \"validation_files\": [],\n  \"training_files\": [\n    {\n      \"id\": \"file-XGinujblHPwGLSztz8cPS8XY\",\n      \"object\": \"file\",\n      \"bytes\": 1547276,\n      \"created_at\": 1610062281,\n      \"filename\": \"my-data-train.jsonl\",\n      \"purpose\": \"fine-tune-train\"\n    }\n  ],\n  \"updated_at\": 1614807789,\n}\n"
+          "returns": "The cancelled [fine-tune](/docs/api-reference/fine-tunes/object) object."
         }
       }
     },
     "/fine-tunes/{fine_tune_id}/events": {
       "get": {
+        "deprecated": true,
         "operationId": "listFineTuneEvents",
         "parameters": [
           {
@@ -2501,18 +6325,289 @@
         },
         "summary": "Get fine-grained status updates for a fine-tune job.\n",
         "tags": [
-          "OpenAI"
+          "Fine-tunes"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/fine-tunes/ft-AF1WoRqd3aJAHsqc9NY7iL8F/events \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
-            "node.js": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst response = await openai.listFineTuneEvents(\"ft-AF1WoRqd3aJAHsqc9NY7iL8F\");\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\nopenai.FineTune.list_events(id=\"ft-AF1WoRqd3aJAHsqc9NY7iL8F\")\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/fine-tunes/ft-AF1WoRqd3aJAHsqc9NY7iL8F/events \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const fineTune = await openai.fineTunes.listEvents(\"ft-AF1WoRqd3aJAHsqc9NY7iL8F\");\n\n  console.log(fineTune);\n}\nmain();",
+              "python": "# deprecated\n"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807352,\n      \"level\": \"info\",\n      \"message\": \"Job enqueued. Waiting for jobs ahead to complete. Queue number: 0.\"\n    },\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807356,\n      \"level\": \"info\",\n      \"message\": \"Job started.\"\n    },\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807861,\n      \"level\": \"info\",\n      \"message\": \"Uploaded snapshot: curie:ft-acmeco-2021-03-03-21-44-20.\"\n    },\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807864,\n      \"level\": \"info\",\n      \"message\": \"Uploaded result files: file-abc123\"\n    },\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807864,\n      \"level\": \"info\",\n      \"message\": \"Job succeeded.\"\n    }\n  ]\n}\n"
           },
-          "group": "fine-tunes",
           "name": "List fine-tune events",
-          "path": "events",
-          "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807352,\n      \"level\": \"info\",\n      \"message\": \"Job enqueued. Waiting for jobs ahead to complete. Queue number: 0.\"\n    },\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807356,\n      \"level\": \"info\",\n      \"message\": \"Job started.\"\n    },\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807861,\n      \"level\": \"info\",\n      \"message\": \"Uploaded snapshot: curie:ft-acmeco-2021-03-03-21-44-20.\"\n    },\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807864,\n      \"level\": \"info\",\n      \"message\": \"Uploaded result files: file-QQm6ZpqdNwAaVC3aSz5sWwLT.\"\n    },\n    {\n      \"object\": \"fine-tune-event\",\n      \"created_at\": 1614807864,\n      \"level\": \"info\",\n      \"message\": \"Job succeeded.\"\n    }\n  ]\n}\n"
+          "returns": "A list of fine-tune event objects."
+        }
+      }
+    },
+    "/fine_tuning/jobs": {
+      "get": {
+        "operationId": "listPaginatedFineTuningJobs",
+        "parameters": [
+          {
+            "description": "Identifier for the last job from the previous pagination request.",
+            "in": "query",
+            "name": "after",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of fine-tuning jobs to retrieve.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListPaginatedFineTuningJobsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "List your organization's fine-tuning jobs\n",
+        "tags": [
+          "Fine-tuning"
+        ],
+        "x-oaiMeta": {
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/fine_tuning/jobs?limit=2 \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const list = await openai.fineTuning.jobs.list();\n\n  for await (const fineTune of list) {\n    console.log(fineTune);\n  }\n}\n\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.fine_tuning.jobs.list()\n"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"object\": \"fine_tuning.job.event\",\n      \"id\": \"ft-event-TjX0lMfOniCZX64t9PUQT5hn\",\n      \"created_at\": 1689813489,\n      \"level\": \"warn\",\n      \"message\": \"Fine tuning process stopping due to job cancellation\",\n      \"data\": null,\n      \"type\": \"message\"\n    },\n    { ... },\n    { ... }\n  ], \"has_more\": true\n}\n"
+          },
+          "name": "List fine-tuning jobs",
+          "returns": "A list of paginated [fine-tuning job](/docs/api-reference/fine-tuning/object) objects."
+        }
+      },
+      "post": {
+        "operationId": "createFineTuningJob",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateFineTuningJobRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FineTuningJob"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Creates a job that fine-tunes a specified model from a given dataset.\n\nResponse includes details of the enqueued job including job status and the name of the fine-tuned models once complete.\n\n[Learn more about fine-tuning](/docs/guides/fine-tuning)\n",
+        "tags": [
+          "Fine-tuning"
+        ],
+        "x-oaiMeta": {
+          "examples": [
+            {
+              "request": {
+                "curl": "curl https://api.openai.com/v1/fine_tuning/jobs \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"training_file\": \"file-BK7bzQj3FfZFXr7DbL6xJwfo\",\n    \"model\": \"gpt-3.5-turbo\"\n  }'\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const fineTune = await openai.fineTuning.jobs.create({\n    training_file: \"file-abc123\"\n  });\n\n  console.log(fineTune);\n}\n\nmain();\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.fine_tuning.jobs.create(\n  training_file=\"file-abc123\", \n  model=\"gpt-3.5-turbo\"\n)\n"
+              },
+              "response": "{\n  \"object\": \"fine_tuning.job\",\n  \"id\": \"ftjob-abc123\",\n  \"model\": \"gpt-3.5-turbo-0613\",\n  \"created_at\": 1614807352,\n  \"fine_tuned_model\": null,\n  \"organization_id\": \"org-123\",\n  \"result_files\": [],\n  \"status\": \"queued\",\n  \"validation_file\": null,\n  \"training_file\": \"file-abc123\",\n}\n",
+              "title": "No hyperparameters"
+            },
+            {
+              "request": {
+                "curl": "curl https://api.openai.com/v1/fine_tuning/jobs \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"training_file\": \"file-abc123\",\n    \"model\": \"gpt-3.5-turbo\",\n    \"hyperparameters\": {\n      \"n_epochs\": 2\n    }\n  }'\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const fineTune = await openai.fineTuning.jobs.create({\n    training_file: \"file-abc123\",\n    model: \"gpt-3.5-turbo\",\n    hyperparameters: { n_epochs: 2 }\n  });\n\n  console.log(fineTune);\n}\n\nmain();\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.fine_tuning.jobs.create(\n  training_file=\"file-abc123\", \n  model=\"gpt-3.5-turbo\", \n  hyperparameters={\n    \"n_epochs\":2\n  }\n)\n"
+              },
+              "response": "{\n  \"object\": \"fine_tuning.job\",\n  \"id\": \"ftjob-abc123\",\n  \"model\": \"gpt-3.5-turbo-0613\",\n  \"created_at\": 1614807352,\n  \"fine_tuned_model\": null,\n  \"organization_id\": \"org-123\",\n  \"result_files\": [],\n  \"status\": \"queued\",\n  \"validation_file\": null,\n  \"training_file\": \"file-abc123\",\n  \"hyperparameters\": {\"n_epochs\": 2},\n}\n",
+              "title": "Hyperparameters"
+            },
+            {
+              "request": {
+                "curl": "curl https://api.openai.com/v1/fine_tuning/jobs \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"training_file\": \"file-abc123\",\n    \"validation_file\": \"file-abc123\",\n    \"model\": \"gpt-3.5-turbo\"\n  }'\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const fineTune = await openai.fineTuning.jobs.create({\n    training_file: \"file-abc123\",\n    validation_file: \"file-abc123\"\n  });\n\n  console.log(fineTune);\n}\n\nmain();\n",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.fine_tuning.jobs.create(\n  training_file=\"file-abc123\", \n  validation_file=\"file-def456\", \n  model=\"gpt-3.5-turbo\"\n)\n"
+              },
+              "response": "{\n  \"object\": \"fine_tuning.job\",\n  \"id\": \"ftjob-abc123\",\n  \"model\": \"gpt-3.5-turbo-0613\",\n  \"created_at\": 1614807352,\n  \"fine_tuned_model\": null,\n  \"organization_id\": \"org-123\",\n  \"result_files\": [],\n  \"status\": \"queued\",\n  \"validation_file\": \"file-abc123\",\n  \"training_file\": \"file-abc123\",\n}\n",
+              "title": "Validation file"
+            }
+          ],
+          "name": "Create fine-tuning job",
+          "returns": "A [fine-tuning.job](/docs/api-reference/fine-tuning/object) object."
+        }
+      }
+    },
+    "/fine_tuning/jobs/{fine_tuning_job_id}": {
+      "get": {
+        "operationId": "retrieveFineTuningJob",
+        "parameters": [
+          {
+            "description": "The ID of the fine-tuning job.\n",
+            "in": "path",
+            "name": "fine_tuning_job_id",
+            "required": true,
+            "schema": {
+              "example": "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FineTuningJob"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Get info about a fine-tuning job.\n\n[Learn more about fine-tuning](/docs/guides/fine-tuning)\n",
+        "tags": [
+          "Fine-tuning"
+        ],
+        "x-oaiMeta": {
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/fine_tuning/jobs/ft-AF1WoRqd3aJAHsqc9NY7iL8F \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const fineTune = await openai.fineTuning.jobs.retrieve(\"ftjob-abc123\");\n\n  console.log(fineTune);\n}\n\nmain();\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.fine_tuning.jobs.retrieve(\"ftjob-abc123\")\n"
+            },
+            "response": "{\n  \"object\": \"fine_tuning.job\",\n  \"id\": \"ftjob-abc123\",\n  \"model\": \"davinci-002\",\n  \"created_at\": 1692661014,\n  \"finished_at\": 1692661190,\n  \"fine_tuned_model\": \"ft:davinci-002:my-org:custom_suffix:7q8mpxmy\",\n  \"organization_id\": \"org-123\",\n  \"result_files\": [\n      \"file-abc123\"\n  ],\n  \"status\": \"succeeded\",\n  \"validation_file\": null,\n  \"training_file\": \"file-abc123\",\n  \"hyperparameters\": {\n      \"n_epochs\": 4,\n  },\n  \"trained_tokens\": 5768\n}\n"
+          },
+          "name": "Retrieve fine-tuning job",
+          "returns": "The [fine-tuning](/docs/api-reference/fine-tunes/object) object with the given ID."
+        }
+      }
+    },
+    "/fine_tuning/jobs/{fine_tuning_job_id}/cancel": {
+      "post": {
+        "operationId": "cancelFineTuningJob",
+        "parameters": [
+          {
+            "description": "The ID of the fine-tuning job to cancel.\n",
+            "in": "path",
+            "name": "fine_tuning_job_id",
+            "required": true,
+            "schema": {
+              "example": "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FineTuningJob"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Immediately cancel a fine-tune job.\n",
+        "tags": [
+          "Fine-tuning"
+        ],
+        "x-oaiMeta": {
+          "examples": {
+            "request": {
+              "curl": "curl -X POST https://api.openai.com/v1/fine_tuning/jobs/ftjob-abc123/cancel \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const fineTune = await openai.fineTuning.jobs.cancel(\"ftjob-abc123\");\n\n  console.log(fineTune);\n}\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.fine_tuning.jobs.cancel(\"ftjob-abc123\")\n"
+            },
+            "response": "{\n  \"object\": \"fine_tuning.job\",\n  \"id\": \"ftjob-abc123\",\n  \"model\": \"gpt-3.5-turbo-0613\",\n  \"created_at\": 1689376978,\n  \"fine_tuned_model\": null,\n  \"organization_id\": \"org-123\",\n  \"result_files\": [],\n  \"hyperparameters\": {\n    \"n_epochs\":  \"auto\"\n  },\n  \"status\": \"cancelled\",\n  \"validation_file\": \"file-abc123\",\n  \"training_file\": \"file-abc123\"\n}\n"
+          },
+          "name": "Cancel fine-tuning",
+          "returns": "The cancelled [fine-tuning](/docs/api-reference/fine-tuning/object) object."
+        }
+      }
+    },
+    "/fine_tuning/jobs/{fine_tuning_job_id}/events": {
+      "get": {
+        "operationId": "listFineTuningEvents",
+        "parameters": [
+          {
+            "description": "The ID of the fine-tuning job to get events for.\n",
+            "in": "path",
+            "name": "fine_tuning_job_id",
+            "required": true,
+            "schema": {
+              "example": "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Identifier for the last event from the previous pagination request.",
+            "in": "query",
+            "name": "after",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of events to retrieve.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListFineTuningJobEventsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Get status updates for a fine-tuning job.\n",
+        "tags": [
+          "Fine-tuning"
+        ],
+        "x-oaiMeta": {
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/fine_tuning/jobs/ftjob-abc123/events \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const list = await openai.fineTuning.list_events(id=\"ftjob-abc123\", limit=2);\n\n  for await (const fineTune of list) {\n    console.log(fineTune);\n  }\n}\n\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.fine_tuning.jobs.list_events(\n  fine_tuning_job_id=\"ftjob-abc123\", \n  limit=2\n)\n"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"object\": \"fine_tuning.job.event\",\n      \"id\": \"ft-event-ddTJfwuMVpfLXseO0Am0Gqjm\",\n      \"created_at\": 1692407401,\n      \"level\": \"info\",\n      \"message\": \"Fine tuning job successfully completed\",\n      \"data\": null,\n      \"type\": \"message\"\n    },\n    {\n      \"object\": \"fine_tuning.job.event\",\n      \"id\": \"ft-event-tyiGuB72evQncpH87xe505Sv\",\n      \"created_at\": 1692407400,\n      \"level\": \"info\",\n      \"message\": \"New fine-tuned model created: ft:gpt-3.5-turbo:openai::7p4lURel\",\n      \"data\": null,\n      \"type\": \"message\"\n    }\n  ],\n  \"has_more\": true\n}\n"
+          },
+          "name": "List fine-tuning events",
+          "returns": "A list of fine-tuning event objects."
         }
       }
     },
@@ -2543,18 +6638,19 @@
         },
         "summary": "Creates an edited or extended image given an original image and a prompt.",
         "tags": [
-          "OpenAI"
+          "Images"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/images/edits \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -F image=\"@otter.png\" \\\n  -F mask=\"@mask.png\" \\\n  -F prompt=\"A cute baby sea otter wearing a beret\" \\\n  -F n=2 \\\n  -F size=\"1024x1024\"\n",
-            "node.js": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst response = await openai.createImageEdit(\n  fs.createReadStream(\"otter.png\"),\n  \"A cute baby sea otter wearing a beret\",\n  fs.createReadStream(\"mask.png\"),\n  2,\n  \"1024x1024\"\n);\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\nopenai.Image.create_edit(\n  image=open(\"otter.png\", \"rb\"),\n  mask=open(\"mask.png\", \"rb\"),\n  prompt=\"A cute baby sea otter wearing a beret\",\n  n=2,\n  size=\"1024x1024\"\n)\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/images/edits \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -F image=\"@otter.png\" \\\n  -F mask=\"@mask.png\" \\\n  -F prompt=\"A cute baby sea otter wearing a beret\" \\\n  -F n=2 \\\n  -F size=\"1024x1024\"\n",
+              "node.js": "import fs from \"fs\";\nimport OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const image = await openai.images.edit({\n    image: fs.createReadStream(\"otter.png\"),\n    mask: fs.createReadStream(\"mask.png\"),\n    prompt: \"A cute baby sea otter wearing a beret\",\n  });\n\n  console.log(image.data);\n}\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.images.edit(\n  image=open(\"otter.png\", \"rb\"),\n  mask=open(\"mask.png\", \"rb\"),\n  prompt=\"A cute baby sea otter wearing a beret\",\n  n=2,\n  size=\"1024x1024\"\n)\n"
+            },
+            "response": "{\n  \"created\": 1589478378,\n  \"data\": [\n    {\n      \"url\": \"https://...\"\n    },\n    {\n      \"url\": \"https://...\"\n    }\n  ]\n}\n"
           },
-          "group": "images",
           "name": "Create image edit",
-          "path": "create-edit",
-          "response": "{\n  \"created\": 1589478378,\n  \"data\": [\n    {\n      \"url\": \"https://...\"\n    },\n    {\n      \"url\": \"https://...\"\n    }\n  ]\n}\n"
+          "returns": "Returns a list of [image](/docs/api-reference/images/object) objects."
         }
       }
     },
@@ -2585,19 +6681,19 @@
         },
         "summary": "Creates an image given a prompt.",
         "tags": [
-          "OpenAI"
+          "Images"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/images/generations \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"prompt\": \"A cute baby sea otter\",\n    \"n\": 2,\n    \"size\": \"1024x1024\"\n  }'\n",
-            "node.js": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst response = await openai.createImage({\n  prompt: \"A cute baby sea otter\",\n  n: 2,\n  size: \"1024x1024\",\n});\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\nopenai.Image.create(\n  prompt=\"A cute baby sea otter\",\n  n=2,\n  size=\"1024x1024\"\n)\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/images/generations \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"model\": \"dall-e-3\",\n    \"prompt\": \"A cute baby sea otter\",\n    \"n\": 1,\n    \"size\": \"1024x1024\"\n  }'\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const image = await openai.images.generate({ model: \"dall-e-3\", prompt: \"A cute baby sea otter\" });\n\n  console.log(image.data);\n}\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.images.generate(\n  model=\"dall-e-3\",\n  prompt=\"A cute baby sea otter\",\n  n=1,\n  size=\"1024x1024\"\n)\n"
+            },
+            "response": "{\n  \"created\": 1589478378,\n  \"data\": [\n    {\n      \"url\": \"https://...\"\n    },\n    {\n      \"url\": \"https://...\"\n    }\n  ]\n}\n"
           },
-          "group": "images",
           "name": "Create image",
-          "parameters": "{\n  \"prompt\": \"A cute baby sea otter\",\n  \"n\": 2,\n  \"size\": \"1024x1024\"\n}\n",
-          "path": "create",
-          "response": "{\n  \"created\": 1589478378,\n  \"data\": [\n    {\n      \"url\": \"https://...\"\n    },\n    {\n      \"url\": \"https://...\"\n    }\n  ]\n}\n"
+          "returns": "Returns a list of [image](/docs/api-reference/images/object) objects."
         }
       }
     },
@@ -2628,18 +6724,19 @@
         },
         "summary": "Creates a variation of a given image.",
         "tags": [
-          "OpenAI"
+          "Images"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/images/variations \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -F image=\"@otter.png\" \\\n  -F n=2 \\\n  -F size=\"1024x1024\"\n",
-            "node.js": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst response = await openai.createImageVariation(\n  fs.createReadStream(\"otter.png\"),\n  2,\n  \"1024x1024\"\n);\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\nopenai.Image.create_variation(\n  image=open(\"otter.png\", \"rb\"),\n  n=2,\n  size=\"1024x1024\"\n)\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/images/variations \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -F image=\"@otter.png\" \\\n  -F n=2 \\\n  -F size=\"1024x1024\"\n",
+              "node.js": "import fs from \"fs\";\nimport OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const image = await openai.images.createVariation({\n    image: fs.createReadStream(\"otter.png\"),\n  });\n\n  console.log(image.data);\n}\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nresponse = client.images.create_variation(\n  image=open(\"image_edit_original.png\", \"rb\"),\n  n=2,\n  size=\"1024x1024\"\n)\n"
+            },
+            "response": "{\n  \"created\": 1589478378,\n  \"data\": [\n    {\n      \"url\": \"https://...\"\n    },\n    {\n      \"url\": \"https://...\"\n    }\n  ]\n}\n"
           },
-          "group": "images",
           "name": "Create image variation",
-          "path": "create-variation",
-          "response": "{\n  \"created\": 1589478378,\n  \"data\": [\n    {\n      \"url\": \"https://...\"\n    },\n    {\n      \"url\": \"https://...\"\n    }\n  ]\n}\n"
+          "returns": "Returns a list of [image](/docs/api-reference/images/object) objects."
         }
       }
     },
@@ -2660,18 +6757,19 @@
         },
         "summary": "Lists the currently available models, and provides basic information about each one such as the owner and availability.",
         "tags": [
-          "OpenAI"
+          "Models"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/models \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
-            "node.js": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst response = await openai.listModels();\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\nopenai.Model.list()\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/models \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const list = await openai.models.list();\n\n  for await (const model of list) {\n    console.log(model);\n  }\n}\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.models.list()\n"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"id\": \"model-id-0\",\n      \"object\": \"model\",\n      \"created\": 1686935002,\n      \"owned_by\": \"organization-owner\"\n    },\n    {\n      \"id\": \"model-id-1\",\n      \"object\": \"model\",\n      \"created\": 1686935002,\n      \"owned_by\": \"organization-owner\",\n    },\n    {\n      \"id\": \"model-id-2\",\n      \"object\": \"model\",\n      \"created\": 1686935002,\n      \"owned_by\": \"openai\"\n    },\n  ],\n  \"object\": \"list\"\n}\n"
           },
-          "group": "models",
           "name": "List models",
-          "path": "list",
-          "response": "{\n  \"data\": [\n    {\n      \"id\": \"model-id-0\",\n      \"object\": \"model\",\n      \"owned_by\": \"organization-owner\",\n      \"permission\": [...]\n    },\n    {\n      \"id\": \"model-id-1\",\n      \"object\": \"model\",\n      \"owned_by\": \"organization-owner\",\n      \"permission\": [...]\n    },\n    {\n      \"id\": \"model-id-2\",\n      \"object\": \"model\",\n      \"owned_by\": \"openai\",\n      \"permission\": [...]\n    },\n  ],\n  \"object\": \"list\"\n}\n"
+          "returns": "A list of [model](/docs/api-reference/models/object) objects."
         }
       }
     },
@@ -2685,7 +6783,7 @@
             "name": "model",
             "required": true,
             "schema": {
-              "example": "curie:ft-acmeco-2021-03-03-21-44-20",
+              "example": "ft:gpt-3.5-turbo:acemeco:suffix:abc123",
               "type": "string"
             }
           }
@@ -2702,20 +6800,21 @@
             "description": "OK"
           }
         },
-        "summary": "Delete a fine-tuned model. You must have the Owner role in your organization.",
+        "summary": "Delete a fine-tuned model. You must have the Owner role in your organization to delete a model.",
         "tags": [
-          "OpenAI"
+          "Models"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/models/curie:ft-acmeco-2021-03-03-21-44-20 \\\n  -X DELETE \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
-            "node.js": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst response = await openai.deleteModel('curie:ft-acmeco-2021-03-03-21-44-20');\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\nopenai.Model.delete(\"curie:ft-acmeco-2021-03-03-21-44-20\")\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/models/ft:gpt-3.5-turbo:acemeco:suffix:abc123 \\\n  -X DELETE \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const model = await openai.models.del(\"ft:gpt-3.5-turbo:acemeco:suffix:abc123\");\n\n  console.log(model);\n}\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.models.delete(\"ft:gpt-3.5-turbo:acemeco:suffix:abc123\")\n"
+            },
+            "response": "{\n  \"id\": \"ft:gpt-3.5-turbo:acemeco:suffix:abc123\",\n  \"object\": \"model\",\n  \"deleted\": true\n}\n"
           },
-          "group": "fine-tunes",
           "name": "Delete fine-tune model",
-          "path": "delete-model",
-          "response": "{\n  \"id\": \"curie:ft-acmeco-2021-03-03-21-44-20\",\n  \"object\": \"model\",\n  \"deleted\": true\n}\n"
+          "returns": "Deletion status."
         }
       },
       "get": {
@@ -2727,7 +6826,7 @@
             "name": "model",
             "required": true,
             "schema": {
-              "example": "text-davinci-001",
+              "example": "gpt-3.5-turbo",
               "type": "string"
             }
           }
@@ -2746,18 +6845,19 @@
         },
         "summary": "Retrieves a model instance, providing basic information about the model such as the owner and permissioning.",
         "tags": [
-          "OpenAI"
+          "Models"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/models/VAR_model_id \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
-            "node.js": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst response = await openai.retrieveModel(\"VAR_model_id\");\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\nopenai.Model.retrieve(\"VAR_model_id\")\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/models/VAR_model_id \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\"\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const model = await openai.models.retrieve(\"gpt-3.5-turbo\");\n\n  console.log(model);\n}\n\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.models.retrieve(\"VAR_model_id\")\n"
+            },
+            "response": "{\n  \"id\": \"VAR_model_id\",\n  \"object\": \"model\",\n  \"created\": 1686935002,\n  \"owned_by\": \"openai\"\n}\n"
           },
-          "group": "models",
           "name": "Retrieve model",
-          "path": "retrieve",
-          "response": "{\n  \"id\": \"VAR_model_id\",\n  \"object\": \"model\",\n  \"owned_by\": \"openai\",\n  \"permission\": [...]\n}\n"
+          "returns": "The [model](/docs/api-reference/models/object) object matching the specified ID."
         }
       }
     },
@@ -2788,23 +6888,1207 @@
         },
         "summary": "Classifies if text violates OpenAI's Content Policy",
         "tags": [
-          "OpenAI"
+          "Moderations"
         ],
         "x-oaiMeta": {
           "examples": {
-            "curl": "curl https://api.openai.com/v1/moderations \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"input\": \"I want to kill them.\"\n  }'\n",
-            "node.js": "const { Configuration, OpenAIApi } = require(\"openai\");\nconst configuration = new Configuration({\n  apiKey: process.env.OPENAI_API_KEY,\n});\nconst openai = new OpenAIApi(configuration);\nconst response = await openai.createModeration({\n  input: \"I want to kill them.\",\n});\n",
-            "python": "import os\nimport openai\nopenai.api_key = os.getenv(\"OPENAI_API_KEY\")\nopenai.Moderation.create(\n  input=\"I want to kill them.\",\n)\n"
+            "request": {
+              "curl": "curl https://api.openai.com/v1/moderations \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -d '{\n    \"input\": \"I want to kill them.\"\n  }'\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const moderation = await openai.moderations.create({ input: \"I want to kill them.\" });\n\n  console.log(moderation);\n}\nmain();\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nclient.moderations.create(input=\"I want to kill them.\")\n"
+            },
+            "response": "{\n  \"id\": \"modr-XXXXX\",\n  \"model\": \"text-moderation-005\",\n  \"results\": [\n    {\n      \"flagged\": true,\n      \"categories\": {\n        \"sexual\": false,\n        \"hate\": false,\n        \"harassment\": false,\n        \"self-harm\": false,\n        \"sexual/minors\": false,\n        \"hate/threatening\": false,\n        \"violence/graphic\": false,\n        \"self-harm/intent\": false,\n        \"self-harm/instructions\": false,\n        \"harassment/threatening\": true,\n        \"violence\": true,\n      },\n      \"category_scores\": {\n        \"sexual\": 1.2282071e-06,\n        \"hate\": 0.010696256,\n        \"harassment\": 0.29842457,\n        \"self-harm\": 1.5236925e-08,\n        \"sexual/minors\": 5.7246268e-08,\n        \"hate/threatening\": 0.0060676364,\n        \"violence/graphic\": 4.435014e-06,\n        \"self-harm/intent\": 8.098441e-10,\n        \"self-harm/instructions\": 2.8498655e-11,\n        \"harassment/threatening\": 0.63055265,\n        \"violence\": 0.99011886,\n      }\n    }\n  ]\n}\n"
           },
-          "group": "moderations",
           "name": "Create moderation",
-          "parameters": "{\n  \"input\": \"I want to kill them.\"\n}\n",
-          "path": "create",
-          "response": "{\n  \"id\": \"modr-XXXXX\",\n  \"model\": \"text-moderation-005\",\n  \"results\": [\n    {\n      \"flagged\": true,\n      \"categories\": {\n        \"sexual\": false,\n        \"hate\": false,\n        \"harassment\": false,\n        \"self-harm\": false,\n        \"sexual/minors\": false,\n        \"hate/threatening\": false,\n        \"violence/graphic\": false,\n        \"self-harm/intent\": false,\n        \"self-harm/instructions\": false,\n        \"harassment/threatening\": true,\n        \"violence\": true,\n      },\n      \"category_scores\": {\n        \"sexual\": 1.2282071e-06,\n        \"hate\": 0.010696256,\n        \"harassment\": 0.29842457,\n        \"self-harm\": 1.5236925e-08,\n        \"sexual/minors\": 5.7246268e-08,\n        \"hate/threatening\": 0.0060676364,\n        \"violence/graphic\": 4.435014e-06,\n        \"self-harm/intent\": 8.098441e-10,\n        \"self-harm/instructions\": 2.8498655e-11,\n        \"harassment/threatening\": 0.63055265,\n        \"violence\": 0.99011886,\n      }\n    }\n  ]\n}\n"
+          "returns": "A [moderation](/docs/api-reference/moderations/object) object."
+        }
+      }
+    },
+    "/threads": {
+      "post": {
+        "operationId": "createThread",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateThreadRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadObject"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Create a thread.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": [
+            {
+              "request": {
+                "curl": "curl https://api.openai.com/v1/threads \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v1\" \\\n  -d ''\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const emptyThread = await openai.beta.threads.create();\n\n  console.log(emptyThread);\n}\n\nmain();",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nempty_thread = openai.beta.threads.create()\nprint(empty_thread)\n"
+              },
+              "response": "{\n  \"id\": \"thread_abc123\",\n  \"object\": \"thread\",\n  \"created_at\": 1699012949,\n  \"metadata\": {}\n}\n",
+              "title": "Empty"
+            },
+            {
+              "request": {
+                "curl": "curl https://api.openai.com/v1/threads \\\n-H \"Content-Type: application/json\" \\\n-H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n-H \"OpenAI-Beta: assistants=v1\" \\\n-d '{\n    \"messages\": [{\n      \"role\": \"user\",\n      \"content\": \"Hello, what is AI?\",\n      \"file_ids\": [\"file-abc123\"]\n    }, {\n      \"role\": \"user\",\n      \"content\": \"How does AI work? Explain it in simple terms.\"\n    }]\n  }'\n",
+                "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const messageThread = await openai.beta.threads.create({\n    messages: [\n      {\n        role: \"user\",\n        content: \"Hello, what is AI?\",\n        file_ids: [\"file-abc123\"],\n      },\n      {\n        role: \"user\",\n        content: \"How does AI work? Explain it in simple terms.\",\n      },\n    ],\n  });\n\n  console.log(messageThread);\n}\n\nmain();",
+                "python": "from openai import OpenAI\nclient = OpenAI()\n\nmessage_thread = openai.beta.threads.create(\n  messages=[\n    {\n      \"role\": \"user\",\n      \"content\": \"Hello, what is AI?\",\n      \"file_ids\": [\"file-abc123\"],\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"How does AI work? Explain it in simple terms.\"\n    },\n  ]\n)\n\nprint(message_thread)\n"
+              },
+              "response": "{\n  id: 'thread_abc123',\n  object: 'thread',\n  created_at: 1699014083,\n  metadata: {}\n}\n",
+              "title": "Messages"
+            }
+          ],
+          "name": "Create thread",
+          "returns": "A [thread](/docs/api-reference/threads) object."
+        }
+      }
+    },
+    "/threads/runs": {
+      "post": {
+        "operationId": "createThreadAndRun",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateThreadAndRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunObject"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Create a thread and run it in one request.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/runs \\\n  -H 'Authorization: Bearer $OPENAI_API_KEY' \\\n  -H 'Content-Type: application/json' \\\n  -H 'OpenAI-Beta: assistants=v1' \\\n  -d '{\n      \"assistant_id\": \"asst_IgmpQTah3ZfPHCVZjTqAY8Kv\",\n      \"thread\": {\n        \"messages\": [\n          {\"role\": \"user\", \"content\": \"Explain deep learning to a 5 year old.\"}\n        ]\n      }\n    }'\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const run = await openai.beta.threads.createAndRun({\n    assistant_id: \"asst_IgmpQTah3ZfPHCVZjTqAY8Kv\",\n    thread: {\n      messages: [\n        { role: \"user\", content: \"Explain deep learning to a 5 year old.\" },\n      ],\n    },\n  });\n\n  console.log(run);\n}\n\nmain();\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nrun = client.beta.threads.create_and_run(\n  assistant_id=\"asst_IgmpQTah3ZfPHCVZjTqAY8Kv\",\n  thread={\n    \"messages\": [\n      {\"role\": \"user\", \"content\": \"Explain deep learning to a 5 year old.\"}\n    ]\n  }\n)\n"
+            },
+            "response": "{\n  \"id\": \"run_3Qudf05GGhCleEg9ggwfJQih\",\n  \"object\": \"thread.run\",\n  \"created_at\": 1699076792,\n  \"assistant_id\": \"asst_IgmpQTah3ZfPHCVZjTqAY8Kv\",\n  \"thread_id\": \"thread_Ec3eKZcWI00WDZRC7FZci8hP\",\n  \"status\": \"queued\",\n  \"started_at\": null,\n  \"expires_at\": 1699077392,\n  \"cancelled_at\": null,\n  \"failed_at\": null,\n  \"completed_at\": null,\n  \"last_error\": null,\n  \"model\": \"gpt-4\",\n  \"instructions\": \"You are a helpful assistant.\",\n  \"tools\": [],\n  \"file_ids\": [],\n  \"metadata\": {}\n}\n"
+          },
+          "name": "Create thread and run",
+          "returns": "A [run](/docs/api-reference/runs/object) object."
+        }
+      }
+    },
+    "/threads/{thread_id}": {
+      "delete": {
+        "operationId": "deleteThread",
+        "parameters": [
+          {
+            "description": "The ID of the thread to delete.",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteThreadResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Delete a thread.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_abc123 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v1\" \\\n  -X DELETE\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const response = await openai.beta.threads.del(\"thread_abc123\");\n\n  console.log(response);\n}\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nresponse = openai.beta.threads.delete(\"thread_abc123\")\nprint(response)\n"
+            },
+            "response": "{\n  \"id\": \"thread_abc123\",\n  \"object\": \"thread.deleted\",\n  \"deleted\": true\n}\n"
+          },
+          "name": "Delete thread",
+          "returns": "Deletion status"
+        }
+      },
+      "get": {
+        "operationId": "getThread",
+        "parameters": [
+          {
+            "description": "The ID of the thread to retrieve.",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadObject"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Retrieves a thread.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_abc123 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v1\"\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const myThread = await openai.beta.threads.retrieve(\n    \"thread_abc123\"\n  );\n\n  console.log(myThread);\n}\n\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nmy_thread = openai.beta.threads.retrieve(\"thread_abc123\")\nprint(my_thread)\n"
+            },
+            "response": "{\n  \"id\": \"thread_abc123\",\n  \"object\": \"thread\",\n  \"created_at\": 1699014083,\n  \"metadata\": {}\n}\n"
+          },
+          "name": "Retrieve thread",
+          "returns": "The [thread](/docs/api-reference/threads/object) object matching the specified ID."
+        }
+      },
+      "post": {
+        "operationId": "modifyThread",
+        "parameters": [
+          {
+            "description": "The ID of the thread to modify. Only the `metadata` can be modified.",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModifyThreadRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadObject"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Modifies a thread.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_abc123 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v1\" \\\n  -d '{\n      \"metadata\": {\n        \"modified\": \"true\",\n        \"user\": \"abc123\"\n      }\n    }'\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const updatedThread = await openai.beta.threads.update(\n    \"thread_abc123\",\n    {\n      metadata: { modified: \"true\", user: \"abc123\" },\n    }\n  );\n\n  console.log(updatedThread);\n}\n\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nmy_updated_thread = openai.beta.threads.update(\n  \"thread_abc123\", \n  metadata={\n    \"modified\": \"true\", \n    \"user\": \"abc123\"\n  }\n)\nprint(my_updated_thread)\n"
+            },
+            "response": "{\n  \"id\": \"thread_abc123\",\n  \"object\": \"thread\",\n  \"created_at\": 1699014083,\n  \"metadata\": {\n    \"modified\": \"true\",\n    \"user\": \"abc123\"\n  }\n}\n"
+          },
+          "name": "Modify thread",
+          "returns": "The modified [thread](/docs/api-reference/threads/object) object matching the specified ID."
+        }
+      }
+    },
+    "/threads/{thread_id}/messages": {
+      "get": {
+        "operationId": "listMessages",
+        "parameters": [
+          {
+            "description": "The ID of the [thread](/docs/api-reference/threads) the messages belong to.",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.\n",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and `desc` for descending order.\n",
+            "in": "query",
+            "name": "order",
+            "schema": {
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.\n",
+            "in": "query",
+            "name": "after",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.\n",
+            "in": "query",
+            "name": "before",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListMessagesResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Returns a list of messages for a given thread.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_abc123/messages \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v1\"\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const threadMessages = await openai.beta.threads.messages.list(\n    \"thread_1OWaSqVIxJdy3KYnJLbXEWhy\"\n  );\n\n  console.log(threadMessages.data);\n}\n\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nthread_messages = openai.beta.threads.messages.list(\"thread_1OWaSqVIxJdy3KYnJLbXEWhy\")\nprint(thread_messages.data)\n"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"id\": \"msg_abc123\",\n      \"object\": \"thread.message\",\n      \"created_at\": 1699016383,\n      \"thread_id\": \"thread_abc123\",\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": {\n            \"value\": \"How does AI work? Explain it in simple terms.\",\n            \"annotations\": []\n          }\n        }\n      ],\n      \"file_ids\": [],\n      \"assistant_id\": null,\n      \"run_id\": null,\n      \"metadata\": {}\n    },\n    {\n      \"id\": \"msg_abc456\",\n      \"object\": \"thread.message\",\n      \"created_at\": 1699016383,\n      \"thread_id\": \"thread_abc123\",\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": {\n            \"value\": \"Hello, what is AI?\",\n            \"annotations\": []\n          }\n        }\n      ],\n      \"file_ids\": [\n        \"file-abc123\"\n      ],\n      \"assistant_id\": null,\n      \"run_id\": null,\n      \"metadata\": {}\n    }\n  ],\n  \"first_id\": \"msg_abc123\",\n  \"last_id\": \"msg_abc456\",\n  \"has_more\": false\n}\n"
+          },
+          "name": "List messages",
+          "returns": "A list of [message](/docs/api-reference/messages) objects."
+        }
+      },
+      "post": {
+        "operationId": "createMessage",
+        "parameters": [
+          {
+            "description": "The ID of the [thread](/docs/api-reference/threads) to create a message for.",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateMessageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageObject"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Create a message.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_abc123/messages \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v1\" \\\n  -d '{\n      \"role\": \"user\",\n      \"content\": \"How does AI work? Explain it in simple terms.\"\n    }'\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const threadMessages = await openai.beta.threads.messages.create(\n    \"thread_abc123\",\n    { role: \"user\", content: \"How does AI work? Explain it in simple terms.\" }\n  );\n\n  console.log(threadMessages);\n}\n\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nthread_message = openai.beta.threads.messages.create(\n  \"thread_abc123\",\n  role=\"user\",\n  content=\"How does AI work? Explain it in simple terms.\",\n)\nprint(thread_message)\n"
+            },
+            "response": "{\n  \"id\": \"msg_abc123\",\n  \"object\": \"thread.message\",\n  \"created_at\": 1699017614,\n  \"thread_id\": \"thread_abc123\",\n  \"role\": \"user\",\n  \"content\": [\n    {\n      \"type\": \"text\",\n      \"text\": {\n        \"value\": \"How does AI work? Explain it in simple terms.\",\n        \"annotations\": []\n      }\n    }\n  ],\n  \"file_ids\": [],\n  \"assistant_id\": null,\n  \"run_id\": null,\n  \"metadata\": {}\n}\n"
+          },
+          "name": "Create message",
+          "returns": "A [message](/docs/api-reference/messages/object) object."
+        }
+      }
+    },
+    "/threads/{thread_id}/messages/{message_id}": {
+      "get": {
+        "operationId": "getMessage",
+        "parameters": [
+          {
+            "description": "The ID of the [thread](/docs/api-reference/threads) to which this message belongs.",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the message to retrieve.",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageObject"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Retrieve a message.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_abc123/messages/msg_abc123 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v1\"\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const message = await openai.beta.threads.messages.retrieve(\n    \"thread_abc123\",\n    \"msg_abc123\"\n  );\n\n  console.log(message);\n}\n\nmain();",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nmessage = openai.beta.threads.messages.retrieve(\n  message_id=\"msg_abc123\",\n  thread_id=\"thread_abc123\",\n)\nprint(message)\n"
+            },
+            "response": "{\n  \"id\": \"msg_abc123\",\n  \"object\": \"thread.message\",\n  \"created_at\": 1699017614,\n  \"thread_id\": \"thread_abc123\",\n  \"role\": \"user\",\n  \"content\": [\n    {\n      \"type\": \"text\",\n      \"text\": {\n        \"value\": \"How does AI work? Explain it in simple terms.\",\n        \"annotations\": []\n      }\n    }\n  ],\n  \"file_ids\": [],\n  \"assistant_id\": null,\n  \"run_id\": null,\n  \"metadata\": {}\n}\n"
+          },
+          "name": "Retrieve message",
+          "returns": "The [message](/docs/api-reference/threads/messages/object) object matching the specified ID."
+        }
+      },
+      "post": {
+        "operationId": "modifyMessage",
+        "parameters": [
+          {
+            "description": "The ID of the thread to which this message belongs.",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the message to modify.",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModifyMessageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageObject"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Modifies a message.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_abc123/messages/msg_abc123 \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"OpenAI-Beta: assistants=v1\" \\\n  -d '{\n      \"metadata\": {\n        \"modified\": \"true\",\n        \"user\": \"abc123\"\n      }\n    }'\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const message = await openai.beta.threads.messages.update(\n    \"thread_abc123\",\n    \"msg_abc123\",\n    {\n      metadata: {\n        modified: \"true\",\n        user: \"abc123\",\n      },\n    }\n  }'",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nmessage = openai.beta.threads.messages.update(\n  message_id=\"msg_abc12\",\n  thread_id=\"thread_abc123\",\n  metadata={\n    \"modified\": \"true\",\n    \"user\": \"abc123\",\n  },\n)\nprint(message)\n"
+            },
+            "response": "{\n  \"id\": \"msg_abc123\",\n  \"object\": \"thread.message\",\n  \"created_at\": 1699017614,\n  \"thread_id\": \"thread_abc123\",\n  \"role\": \"user\",\n  \"content\": [\n    {\n      \"type\": \"text\",\n      \"text\": {\n        \"value\": \"How does AI work? Explain it in simple terms.\",\n        \"annotations\": []\n      }\n    }\n  ],\n  \"file_ids\": [],\n  \"assistant_id\": null,\n  \"run_id\": null,\n  \"metadata\": {\n    \"modified\": \"true\",\n    \"user\": \"abc123\"\n  }\n}\n"
+          },
+          "name": "Modify message",
+          "returns": "The modified [message](/docs/api-reference/threads/messages/object) object."
+        }
+      }
+    },
+    "/threads/{thread_id}/messages/{message_id}/files": {
+      "get": {
+        "operationId": "listMessageFiles",
+        "parameters": [
+          {
+            "description": "The ID of the thread that the message and files belong to.",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the message that the files belongs to.",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.\n",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and `desc` for descending order.\n",
+            "in": "query",
+            "name": "order",
+            "schema": {
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.\n",
+            "in": "query",
+            "name": "after",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.\n",
+            "in": "query",
+            "name": "before",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListMessageFilesResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Returns a list of message files.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_RGUhOuO9b2nrktrmsQ2uSR6I/messages/msg_q3XhbGmMzsqEFa81gMLBDAVU/files \\\n  -H 'Authorization: Bearer $OPENAI_API_KEY' \\\n  -H 'Content-Type: application/json' \\\n  -H 'OpenAI-Beta: assistants=v1'\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const messageFiles = await openai.beta.threads.messages.files.list(\n    \"thread_RGUhOuO9b2nrktrmsQ2uSR6I\",\n    \"msg_q3XhbGmMzsqEFa81gMLBDAVU\"\n  );\n  console.log(messageFiles);\n}\n\nmain();\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nmessage_files = client.beta.threads.messages.files.list(\n  thread_id=\"thread_RGUhOuO9b2nrktrmsQ2uSR6I\",\n  message_id=\"msg_q3XhbGmMzsqEFa81gMLBDAVU\"\n)\nprint(message_files)\n"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"id\": \"file-dEWwUbt2UGHp3v0e0DpCzemP\",\n      \"object\": \"thread.message.file\",\n      \"created_at\": 1699061776,\n      \"message_id\": \"msg_q3XhbGmMzsqEFa81gMLBDAVU\"\n    },\n    {\n      \"id\": \"file-dEWwUbt2UGHp3v0e0DpCzemP\",\n      \"object\": \"thread.message.file\",\n      \"created_at\": 1699061776,\n      \"message_id\": \"msg_q3XhbGmMzsqEFa81gMLBDAVU\"\n    }\n  ],\n  \"first_id\": \"file-dEWwUbt2UGHp3v0e0DpCzemP\",\n  \"last_id\": \"file-dEWwUbt2UGHp3v0e0DpCzemP\",\n  \"has_more\": false\n}\n"
+          },
+          "name": "List message files",
+          "returns": "A list of [message file](/docs/api-reference/messages/file-object) objects."
+        }
+      }
+    },
+    "/threads/{thread_id}/messages/{message_id}/files/{file_id}": {
+      "get": {
+        "operationId": "getMessageFile",
+        "parameters": [
+          {
+            "description": "The ID of the thread to which the message and File belong.",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "example": "thread_AF1WoRqd3aJAHsqc9NY7iL8F",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the message the file belongs to.",
+            "in": "path",
+            "name": "message_id",
+            "required": true,
+            "schema": {
+              "example": "msg_AF1WoRqd3aJAHsqc9NY7iL8F",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the file being retrieved.",
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "example": "file-AF1WoRqd3aJAHsqc9NY7iL8F",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageFileObject"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Retrieves a message file.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_RGUhOuO9b2nrktrmsQ2uSR6I/messages/msg_q3XhbGmMzsqEFa81gMLBDAVU/files/file-dEWwUbt2UGHp3v0e0DpCzemP \\\n  -H 'Authorization: Bearer $OPENAI_API_KEY' \\\n  -H 'Content-Type: application/json' \\\n  -H 'OpenAI-Beta: assistants=v1'\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const messageFile = await openai.beta.threads.messages.files.retrieve(\n    \"thread_RGUhOuO9b2nrktrmsQ2uSR6I\",\n    \"msg_q3XhbGmMzsqEFa81gMLBDAVU\",\n    \"file-dEWwUbt2UGHp3v0e0DpCzemP\"\n  );\n  console.log(messageFile);\n}\n\nmain();\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nmessage_files = client.beta.threads.messages.files.retrieve(\n    thread_id=\"thread_RGUhOuO9b2nrktrmsQ2uSR6I\",\n    message_id=\"msg_q3XhbGmMzsqEFa81gMLBDAVU\",\n    file_id=\"file-dEWwUbt2UGHp3v0e0DpCzemP\"\n)\nprint(message_files)\n"
+            },
+            "response": "{\n  \"id\": \"file-dEWwUbt2UGHp3v0e0DpCzemP\",\n  \"object\": \"thread.message.file\",\n  \"created_at\": 1699061776,\n  \"message_id\": \"msg_q3XhbGmMzsqEFa81gMLBDAVU\"\n}\n"
+          },
+          "name": "Retrieve message file",
+          "returns": "The [message file](/docs/api-reference/messages/file-object) object."
+        }
+      }
+    },
+    "/threads/{thread_id}/runs": {
+      "get": {
+        "operationId": "listRuns",
+        "parameters": [
+          {
+            "description": "The ID of the thread the run belongs to.",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.\n",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and `desc` for descending order.\n",
+            "in": "query",
+            "name": "order",
+            "schema": {
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.\n",
+            "in": "query",
+            "name": "after",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.\n",
+            "in": "query",
+            "name": "before",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListRunsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Returns a list of runs belonging to a thread.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_BDDwIqM4KgHibXX3mqmN3Lgs/runs \\\n  -H 'Authorization: Bearer $OPENAI_API_KEY' \\\n  -H 'Content-Type: application/json' \\\n  -H 'OpenAI-Beta: assistants=v1'\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const runs = await openai.beta.threads.runs.list(\n    \"thread_BDDwIqM4KgHibXX3mqmN3Lgs\"\n  );\n\n  console.log(runs);\n}\n\nmain();\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nruns = client.beta.threads.runs.list(\n  \"thread_BDDwIqM4KgHibXX3mqmN3Lgs\"\n)\nprint(runs)\n"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"id\": \"run_5pyUEwhaPk11vCKiDneUWXXY\",\n      \"object\": \"thread.run\",\n      \"created_at\": 1699075072,\n      \"assistant_id\": \"asst_nGl00s4xa9zmVY6Fvuvz9wwQ\",\n      \"thread_id\": \"thread_BDDwIqM4KgHibXX3mqmN3Lgs\",\n      \"status\": \"completed\",\n      \"started_at\": 1699075072,\n      \"expires_at\": null,\n      \"cancelled_at\": null,\n      \"failed_at\": null,\n      \"completed_at\": 1699075073,\n      \"last_error\": null,\n      \"model\": \"gpt-3.5-turbo\",\n      \"instructions\": null,\n      \"tools\": [\n        {\n          \"type\": \"code_interpreter\"\n        }\n      ],\n      \"file_ids\": [\n        \"file-9F1ex49ipEnKzyLUNnCA0Yzx\",\n        \"file-dEWwUbt2UGHp3v0e0DpCzemP\"\n      ],\n      \"metadata\": {}\n    },\n    {\n      \"id\": \"run_UWvV94U0FQYiT2rlbBrdEVmC\",\n      \"object\": \"thread.run\",\n      \"created_at\": 1699063290,\n      \"assistant_id\": \"asst_nGl00s4xa9zmVY6Fvuvz9wwQ\",\n      \"thread_id\": \"thread_BDDwIqM4KgHibXX3mqmN3Lgs\",\n      \"status\": \"completed\",\n      \"started_at\": 1699063290,\n      \"expires_at\": null,\n      \"cancelled_at\": null,\n      \"failed_at\": null,\n      \"completed_at\": 1699063291,\n      \"last_error\": null,\n      \"model\": \"gpt-3.5-turbo\",\n      \"instructions\": null,\n      \"tools\": [\n        {\n          \"type\": \"code_interpreter\"\n        }\n      ],\n      \"file_ids\": [\n        \"file-9F1ex49ipEnKzyLUNnCA0Yzx\",\n        \"file-dEWwUbt2UGHp3v0e0DpCzemP\"\n      ],\n      \"metadata\": {}\n    }\n  ],\n  \"first_id\": \"run_5pyUEwhaPk11vCKiDneUWXXY\",\n  \"last_id\": \"run_UWvV94U0FQYiT2rlbBrdEVmC\",\n  \"has_more\": false\n}\n"
+          },
+          "name": "List runs",
+          "returns": "A list of [run](/docs/api-reference/runs/object) objects."
+        }
+      },
+      "post": {
+        "operationId": "createRun",
+        "parameters": [
+          {
+            "description": "The ID of the thread to run.",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunObject"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Create a run.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_BDDwIqM4KgHibXX3mqmN3Lgs/runs \\\n  -H 'Authorization: Bearer $OPENAI_API_KEY' \\\n  -H 'Content-Type: application/json' \\\n  -H 'OpenAI-Beta: assistants=v1' \\\n  -d '{\n    \"assistant_id\": \"asst_nGl00s4xa9zmVY6Fvuvz9wwQ\"\n  }'\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const run = await openai.beta.threads.runs.create(\n    \"thread_BDDwIqM4KgHibXX3mqmN3Lgs\",\n    { assistant_id: \"asst_nGl00s4xa9zmVY6Fvuvz9wwQ\" }\n  );\n\n  console.log(run);\n}\n\nmain();\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nrun = client.beta.threads.runs.create(\n  thread_id=\"thread_BDDwIqM4KgHibXX3mqmN3Lgs\",\n  assistant_id=\"asst_nGl00s4xa9zmVY6Fvuvz9wwQ\"\n)\nprint(run)\n"
+            },
+            "response": "{\n  \"id\": \"run_UWvV94U0FQYiT2rlbBrdEVmC\",\n  \"object\": \"thread.run\",\n  \"created_at\": 1699063290,\n  \"assistant_id\": \"asst_nGl00s4xa9zmVY6Fvuvz9wwQ\",\n  \"thread_id\": \"thread_BDDwIqM4KgHibXX3mqmN3Lgs\",\n  \"status\": \"queued\",\n  \"started_at\": 1699063290,\n  \"expires_at\": null,\n  \"cancelled_at\": null,\n  \"failed_at\": null,\n  \"completed_at\": 1699063291,\n  \"last_error\": null,\n  \"model\": \"gpt-4\",\n  \"instructions\": null,\n  \"tools\": [\n    {\n      \"type\": \"code_interpreter\"\n    }\n  ],\n  \"file_ids\": [\n    \"file-9F1ex49ipEnKzyLUNnCA0Yzx\",\n    \"file-dEWwUbt2UGHp3v0e0DpCzemP\"\n  ],\n  \"metadata\": {}\n}\n"
+          },
+          "name": "Create run",
+          "returns": "A [run](/docs/api-reference/runs/object) object."
+        }
+      }
+    },
+    "/threads/{thread_id}/runs/{run_id}": {
+      "get": {
+        "operationId": "getRun",
+        "parameters": [
+          {
+            "description": "The ID of the [thread](/docs/api-reference/threads) that was run.",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the run to retrieve.",
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunObject"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Retrieves a run.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_BDDwIqM4KgHibXX3mqmN3Lgs/runs/run_5pyUEwhaPk11vCKiDneUWXXY \\\n  -H 'Authorization: Bearer $OPENAI_API_KEY' \\\n  -H 'OpenAI-Beta: assistants=v1'\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const run = await openai.beta.threads.runs.retrieve(\n    \"thread_BDDwIqM4KgHibXX3mqmN3Lgs\",\n    \"run_5pyUEwhaPk11vCKiDneUWXXY\"\n  );\n\n  console.log(run);\n}\n\nmain();\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nrun = client.beta.threads.runs.retrieve(\n  thread_id=\"thread_BDDwIqM4KgHibXX3mqmN3Lgs\",\n  run_id=\"run_5pyUEwhaPk11vCKiDneUWXXY\"\n)\nprint(run)\n"
+            },
+            "response": "{\n  \"id\": \"run_5pyUEwhaPk11vCKiDneUWXXY\",\n  \"object\": \"thread.run\",\n  \"created_at\": 1699075072,\n  \"assistant_id\": \"asst_nGl00s4xa9zmVY6Fvuvz9wwQ\",\n  \"thread_id\": \"thread_BDDwIqM4KgHibXX3mqmN3Lgs\",\n  \"status\": \"completed\",\n  \"started_at\": 1699075072,\n  \"expires_at\": null,\n  \"cancelled_at\": null,\n  \"failed_at\": null,\n  \"completed_at\": 1699075073,\n  \"last_error\": null,\n  \"model\": \"gpt-3.5-turbo\",\n  \"instructions\": null,\n  \"tools\": [\n    {\n      \"type\": \"code_interpreter\"\n    }\n  ],\n  \"file_ids\": [\n    \"file-9F1ex49ipEnKzyLUNnCA0Yzx\",\n    \"file-dEWwUbt2UGHp3v0e0DpCzemP\"\n  ],\n  \"metadata\": {}\n}\n"
+          },
+          "name": "Retrieve run",
+          "returns": "The [run](/docs/api-reference/runs/object) object matching the specified ID."
+        }
+      },
+      "post": {
+        "operationId": "modifyRun",
+        "parameters": [
+          {
+            "description": "The ID of the [thread](/docs/api-reference/threads) that was run.",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the run to modify.",
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModifyRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunObject"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Modifies a run.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_BDDwIqM4KgHibXX3mqmN3Lgs/runs/run_5pyUEwhaPk11vCKiDneUWXXY \\\n  -H 'Authorization: Bearer $OPENAI_API_KEY' \\\n  -H 'Content-Type: application/json' \\\n  -H 'OpenAI-Beta: assistants=v1' \\\n  -d '{\n    \"metadata\": {\n      \"user_id\": \"user_zmVY6FvuBDDwIqM4KgH\"\n    }\n  }'\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const run = await openai.beta.threads.runs.update(\n    \"thread_BDDwIqM4KgHibXX3mqmN3Lgs\",\n    \"run_5pyUEwhaPk11vCKiDneUWXXY\",\n    {\n      metadata: {\n        user_id: \"user_zmVY6FvuBDDwIqM4KgH\",\n      },\n    }\n  );\n\n  console.log(run);\n}\n\nmain();\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nrun = client.beta.threads.runs.update(\n  thread_id=\"thread_BDDwIqM4KgHibXX3mqmN3Lgs\",\n  run_id=\"run_5pyUEwhaPk11vCKiDneUWXXY\",\n  metadata={\"user_id\": \"user_zmVY6FvuBDDwIqM4KgH\"},\n)\nprint(run)\n"
+            },
+            "response": "{\n  \"id\": \"run_5pyUEwhaPk11vCKiDneUWXXY\",\n  \"object\": \"thread.run\",\n  \"created_at\": 1699075072,\n  \"assistant_id\": \"asst_nGl00s4xa9zmVY6Fvuvz9wwQ\",\n  \"thread_id\": \"thread_BDDwIqM4KgHibXX3mqmN3Lgs\",\n  \"status\": \"completed\",\n  \"started_at\": 1699075072,\n  \"expires_at\": null,\n  \"cancelled_at\": null,\n  \"failed_at\": null,\n  \"completed_at\": 1699075073,\n  \"last_error\": null,\n  \"model\": \"gpt-3.5-turbo\",\n  \"instructions\": null,\n  \"tools\": [\n    {\n      \"type\": \"code_interpreter\"\n    }\n  ],\n  \"file_ids\": [\n    \"file-9F1ex49ipEnKzyLUNnCA0Yzx\",\n    \"file-dEWwUbt2UGHp3v0e0DpCzemP\"\n  ],\n  \"metadata\": {\n    \"user_id\": \"user_zmVY6FvuBDDwIqM4KgH\"\n  }\n}\n"
+          },
+          "name": "Modify run",
+          "returns": "The modified [run](/docs/api-reference/runs/object) object matching the specified ID."
+        }
+      }
+    },
+    "/threads/{thread_id}/runs/{run_id}/cancel": {
+      "post": {
+        "operationId": "cancelRun",
+        "parameters": [
+          {
+            "description": "The ID of the thread to which this run belongs.",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the run to cancel.",
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunObject"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Cancels a run that is `in_progress`.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_1cjnJPXj8MFiqTx58jU9TivC/runs/run_BeRGmpGt2wb1VI22ZRniOkrR/cancel \\\n  -H 'Authorization: Bearer $OPENAI_API_KEY' \\\n  -H 'OpenAI-Beta: assistants=v1' \\\n  -X POST\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const run = await openai.beta.threads.runs.cancel(\n    \"thread_1cjnJPXj8MFiqTx58jU9TivC\",\n    \"run_BeRGmpGt2wb1VI22ZRniOkrR\"\n  );\n\n  console.log(run);\n}\n\nmain();\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nrun = client.beta.threads.runs.cancel(\n  thread_id=\"thread_1cjnJPXj8MFiqTx58jU9TivC\",\n  run_id=\"run_BeRGmpGt2wb1VI22ZRniOkrR\"\n)\nprint(run)\n"
+            },
+            "response": "{\n  \"id\": \"run_BeRGmpGt2wb1VI22ZRniOkrR\",\n  \"object\": \"thread.run\",\n  \"created_at\": 1699076126,\n  \"assistant_id\": \"asst_IgmpQTah3ZfPHCVZjTqAY8Kv\",\n  \"thread_id\": \"thread_1cjnJPXj8MFiqTx58jU9TivC\",\n  \"status\": \"cancelling\",\n  \"started_at\": 1699076126,\n  \"expires_at\": 1699076726,\n  \"cancelled_at\": null,\n  \"failed_at\": null,\n  \"completed_at\": null,\n  \"last_error\": null,\n  \"model\": \"gpt-4\",\n  \"instructions\": \"You summarize books.\",\n  \"tools\": [\n    {\n      \"type\": \"retrieval\"\n    }\n  ],\n  \"file_ids\": [],\n  \"metadata\": {}\n}\n"
+          },
+          "name": "Cancel a run",
+          "returns": "The modified [run](/docs/api-reference/runs/object) object matching the specified ID."
+        }
+      }
+    },
+    "/threads/{thread_id}/runs/{run_id}/steps": {
+      "get": {
+        "operationId": "listRunSteps",
+        "parameters": [
+          {
+            "description": "The ID of the thread the run and run steps belong to.",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the run the run steps belong to.",
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20.\n",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort order by the `created_at` timestamp of the objects. `asc` for ascending order and `desc` for descending order.\n",
+            "in": "query",
+            "name": "order",
+            "schema": {
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "A cursor for use in pagination. `after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list.\n",
+            "in": "query",
+            "name": "after",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "A cursor for use in pagination. `before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list.\n",
+            "in": "query",
+            "name": "before",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListRunStepsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Returns a list of run steps belonging to a run.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_BDDwIqM4KgHibXX3mqmN3Lgs/runs/run_UWvV94U0FQYiT2rlbBrdEVmC/steps \\\n  -H 'Authorization: Bearer $OPENAI_API_KEY' \\\n  -H 'Content-Type: application/json' \\\n  -H 'OpenAI-Beta: assistants=v1'\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const runStep = await openai.beta.threads.runs.steps.list(\n    \"thread_BDDwIqM4KgHibXX3mqmN3Lgs\",\n    \"run_UWvV94U0FQYiT2rlbBrdEVmC\"\n  );\n  console.log(runStep);\n}\n\nmain();\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nrun_steps = client.beta.threads.runs.steps.list(\n    thread_id=\"thread_BDDwIqM4KgHibXX3mqmN3Lgs\",\n    run_id=\"run_UWvV94U0FQYiT2rlbBrdEVmC\"\n)\nprint(run_steps)\n"
+            },
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"id\": \"step_QyjyrsVsysd7F4K894BZHG97\",\n      \"object\": \"thread.run.step\",\n      \"created_at\": 1699063291,\n      \"run_id\": \"run_UWvV94U0FQYiT2rlbBrdEVmC\",\n      \"assistant_id\": \"asst_nGl00s4xa9zmVY6Fvuvz9wwQ\",\n      \"thread_id\": \"thread_BDDwIqM4KgHibXX3mqmN3Lgs\",\n      \"type\": \"message_creation\",\n      \"status\": \"completed\",\n      \"cancelled_at\": null,\n      \"completed_at\": 1699063291,\n      \"expired_at\": null,\n      \"failed_at\": null,\n      \"last_error\": null,\n      \"step_details\": {\n        \"type\": \"message_creation\",\n        \"message_creation\": {\n          \"message_id\": \"msg_6YmiCRmMbbE6FALYNePPHqwm\"\n        }\n      }\n    }\n  ],\n  \"first_id\": \"step_QyjyrsVsysd7F4K894BZHG97\",\n  \"last_id\": \"step_QyjyrsVsysd7F4K894BZHG97\",\n  \"has_more\": false\n}\n"
+          },
+          "name": "List run steps",
+          "returns": "A list of [run step](/docs/api-reference/runs/step-object) objects."
+        }
+      }
+    },
+    "/threads/{thread_id}/runs/{run_id}/steps/{step_id}": {
+      "get": {
+        "operationId": "getRunStep",
+        "parameters": [
+          {
+            "description": "The ID of the thread to which the run and run step belongs.",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the run to which the run step belongs.",
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the run step to retrieve.",
+            "in": "path",
+            "name": "step_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunStepObject"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Retrieves a run step.",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_BDDwIqM4KgHibXX3mqmN3Lgs/runs/run_UWvV94U0FQYiT2rlbBrdEVmC/steps/step_QyjyrsVsysd7F4K894BZHG97 \\\n  -H 'Authorization: Bearer $OPENAI_API_KEY' \\\n  -H 'Content-Type: application/json' \\\n  -H 'OpenAI-Beta: assistants=v1'\n",
+              "node.js": "import OpenAI from \"openai\";\nconst openai = new OpenAI();\n\nasync function main() {\n  const runStep = await openai.beta.threads.runs.steps.retrieve(\n    \"thread_BDDwIqM4KgHibXX3mqmN3Lgs\",\n    \"run_UWvV94U0FQYiT2rlbBrdEVmC\",\n    \"step_QyjyrsVsysd7F4K894BZHG97\"\n  );\n  console.log(runStep);\n}\n\nmain();\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nrun_step = client.beta.threads.runs.steps.retrieve(\n    thread_id=\"thread_BDDwIqM4KgHibXX3mqmN3Lgs\",\n    run_id=\"run_UWvV94U0FQYiT2rlbBrdEVmC\",\n    step_id=\"step_QyjyrsVsysd7F4K894BZHG97\"\n)\nprint(run_step)\n"
+            },
+            "response": "{\n  \"id\": \"step_QyjyrsVsysd7F4K894BZHG97\",\n  \"object\": \"thread.run.step\",\n  \"created_at\": 1699063291,\n  \"run_id\": \"run_UWvV94U0FQYiT2rlbBrdEVmC\",\n  \"assistant_id\": \"asst_nGl00s4xa9zmVY6Fvuvz9wwQ\",\n  \"thread_id\": \"thread_BDDwIqM4KgHibXX3mqmN3Lgs\",\n  \"type\": \"message_creation\",\n  \"status\": \"completed\",\n  \"cancelled_at\": null,\n  \"completed_at\": 1699063291,\n  \"expired_at\": null,\n  \"failed_at\": null,\n  \"last_error\": null,\n  \"step_details\": {\n    \"type\": \"message_creation\",\n    \"message_creation\": {\n      \"message_id\": \"msg_6YmiCRmMbbE6FALYNePPHqwm\"\n    }\n  }\n}\n"
+          },
+          "name": "Retrieve run step",
+          "returns": "The [run step](/docs/api-reference/runs/step-object) object matching the specified ID."
+        }
+      }
+    },
+    "/threads/{thread_id}/runs/{run_id}/submit_tool_outputs": {
+      "post": {
+        "operationId": "submitToolOuputsToRun",
+        "parameters": [
+          {
+            "description": "The ID of the [thread](/docs/api-reference/threads) to which this run belongs.",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the run that requires the tool output submission.",
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubmitToolOutputsRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunObject"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "When a run has the `status: \"requires_action\"` and `required_action.type` is `submit_tool_outputs`, this endpoint can be used to submit the outputs from the tool calls once they're all completed. All outputs must be submitted in a single request.\n",
+        "tags": [
+          "Assistants"
+        ],
+        "x-oaiMeta": {
+          "beta": true,
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/threads/thread_EdR8UvCDJ035LFEJZMt3AxCd/runs/run_PHLyHQYIQn4F7JrSXslEYWwh/submit_tool_outputs \\\n  -H 'Authorization: Bearer $OPENAI_API_KEY' \\\n  -H 'Content-Type: application/json' \\\n  -H 'OpenAI-Beta: assistants=v1' \\\n  -d '{\n    \"tool_outputs\": [\n      {\n        \"tool_call_id\": \"call_MbELIQcB72cq35Yzo2MRw5qs\",\n        \"output\": \"28C\"\n      }\n    ]\n  }'\n",
+              "node.js": "import OpenAI from \"openai\";\n\nconst openai = new OpenAI();\n\nasync function main() {\n  const run = await openai.beta.threads.runs.submitToolOutputs(\n    \"thread_EdR8UvCDJ035LFEJZMt3AxCd\",\n    \"run_PHLyHQYIQn4F7JrSXslEYWwh\",\n    {\n      tool_outputs: [\n        {\n          tool_call_id: \"call_MbELIQcB72cq35Yzo2MRw5qs\",\n          output: \"28C\",\n        },\n      ],\n    }\n  );\n\n  console.log(run);\n}\n\nmain();\n",
+              "python": "from openai import OpenAI\nclient = OpenAI()\n\nrun = client.beta.threads.runs.submit_tool_outputs(\n  thread_id=\"thread_EdR8UvCDJ035LFEJZMt3AxCd\",\n  run_id=\"run_PHLyHQYIQn4F7JrSXslEYWwh\",\n  tool_outputs=[\n    {\n      \"tool_call_id\": \"call_MbELIQcB72cq35Yzo2MRw5qs\",\n      \"output\": \"28C\"\n    }\n  ]\n)\nprint(run)\n"
+            },
+            "response": "{\n  \"id\": \"run_PHLyHQYIQn4F7JrSXslEYWwh\",\n  \"object\": \"thread.run\",\n  \"created_at\": 1699075592,\n  \"assistant_id\": \"asst_IgmpQTah3ZfPHCVZjTqAY8Kv\",\n  \"thread_id\": \"thread_EdR8UvCDJ035LFEJZMt3AxCd\",\n  \"status\": \"queued\",\n  \"started_at\": 1699075592,\n  \"expires_at\": 1699076192,\n  \"cancelled_at\": null,\n  \"failed_at\": null,\n  \"completed_at\": null,\n  \"last_error\": null,\n  \"model\": \"gpt-4\",\n  \"instructions\": \"You tell the weather.\",\n  \"tools\": [\n    {\n      \"type\": \"function\",\n      \"function\": {\n        \"name\": \"get_weather\",\n        \"description\": \"Determine weather in my location\",\n        \"parameters\": {\n          \"type\": \"object\",\n          \"properties\": {\n            \"location\": {\n              \"type\": \"string\",\n              \"description\": \"The city and state e.g. San Francisco, CA\"\n            },\n            \"unit\": {\n              \"type\": \"string\",\n              \"enum\": [\n                \"c\",\n                \"f\"\n              ]\n            }\n          },\n          \"required\": [\n            \"location\"\n          ]\n        }\n      }\n    }\n  ],\n  \"file_ids\": [],\n  \"metadata\": {}\n}\n"
+          },
+          "name": "Submit tool outputs to run",
+          "returns": "The modified [run](/docs/api-reference/runs/object) object matching the specified ID."
         }
       }
     }
   },
+  "security": [
+    {
+      "ApiKeyAuth": []
+    }
+  ],
   "servers": [
     {
       "url": "https://api.openai.com/v1"
@@ -2812,60 +8096,551 @@
   ],
   "tags": [
     {
-      "description": "The OpenAI REST API",
-      "name": "OpenAI"
+      "description": "Build Assistants that can call models and use tools.",
+      "name": "Assistants"
+    },
+    {
+      "description": "Learn how to turn audio into text or text into audio.",
+      "name": "Audio"
+    },
+    {
+      "description": "Given a list of messages comprising a conversation, the model will return a response.",
+      "name": "Chat"
+    },
+    {
+      "description": "Given a prompt, the model will return one or more predicted completions, and can also return the probabilities of alternative tokens at each position.",
+      "name": "Completions"
+    },
+    {
+      "description": "Get a vector representation of a given input that can be easily consumed by machine learning models and algorithms.",
+      "name": "Embeddings"
+    },
+    {
+      "description": "Manage fine-tuning jobs to tailor a model to your specific training data.",
+      "name": "Fine-tuning"
+    },
+    {
+      "description": "Files are used to upload documents that can be used with features like Assistants and Fine-tuning.",
+      "name": "Files"
+    },
+    {
+      "description": "Given a prompt and/or an input image, the model will generate a new image.",
+      "name": "Images"
+    },
+    {
+      "description": "List and describe the various models available in the API.",
+      "name": "Models"
+    },
+    {
+      "description": "Given a input text, outputs if the model classifies it as violating OpenAI's content policy.",
+      "name": "Moderations"
+    },
+    {
+      "description": "Manage legacy fine-tuning jobs to tailor a model to your specific training data.",
+      "name": "Fine-tunes"
+    },
+    {
+      "description": "Given a prompt and an instruction, the model will return an edited version of the prompt.",
+      "name": "Edits"
     }
   ],
   "x-oaiMeta": {
     "groups": [
       {
-        "description": "List and describe the various models available in the API. You can refer to the [Models](https://platform.openai.com/docs/models) documentation to understand what models are available and the differences between them.\n",
-        "id": "models",
-        "title": "Models"
-      },
-      {
-        "description": "Given a list of messages comprising a conversation, the model will return a response.\n",
-        "id": "chat",
-        "title": "Chat"
-      },
-      {
-        "description": "Given a prompt, the model will return one or more predicted completions, and can also return the probabilities of alternative tokens at each position. Note: We recommend most users use our Chat Completions API. [Learn more](https://platform.openai.com/docs/deprecations/2023-07-06-gpt-and-embeddings)\n",
-        "id": "completions",
-        "title": "Completions"
-      },
-      {
-        "description": "Given a prompt and/or an input image, the model will generate a new image.\n\nRelated guide: [Image generation](https://platform.openai.com/docs/guides/images)\n",
-        "id": "images",
-        "title": "Images"
-      },
-      {
-        "description": "Get a vector representation of a given input that can be easily consumed by machine learning models and algorithms.\n\nRelated guide: [Embeddings](https://platform.openai.com/docs/guides/embeddings)\n",
-        "id": "embeddings",
-        "title": "Embeddings"
-      },
-      {
-        "description": "Learn how to turn audio into text.\n\nRelated guide: [Speech to text](https://platform.openai.com/docs/guides/speech-to-text)\n",
+        "description": "Learn how to turn audio into text or text into audio.\n\nRelated guide: [Speech to text](/docs/guides/speech-to-text)\n",
         "id": "audio",
+        "sections": [
+          {
+            "key": "createSpeech",
+            "path": "createSpeech",
+            "type": "endpoint"
+          },
+          {
+            "key": "createTranscription",
+            "path": "createTranscription",
+            "type": "endpoint"
+          },
+          {
+            "key": "createTranslation",
+            "path": "createTranslation",
+            "type": "endpoint"
+          }
+        ],
         "title": "Audio"
       },
       {
-        "description": "Files are used to upload documents that can be used with features like [Fine-tuning](https://platform.openai.com/docs/api-reference/fine-tunes).\n",
+        "description": "Given a list of messages comprising a conversation, the model will return a response.\n\nRelated guide: [Chat Completions](/docs/guides/gpt)\n",
+        "id": "chat",
+        "sections": [
+          {
+            "key": "CreateChatCompletionResponse",
+            "path": "object",
+            "type": "object"
+          },
+          {
+            "key": "CreateChatCompletionStreamResponse",
+            "path": "streaming",
+            "type": "object"
+          },
+          {
+            "key": "createChatCompletion",
+            "path": "create",
+            "type": "endpoint"
+          }
+        ],
+        "title": "Chat"
+      },
+      {
+        "description": "Given a prompt, the model will return one or more predicted completions, and can also return the probabilities of alternative tokens at each position. We recommend most users use our Chat Completions API. [Learn more](/docs/deprecations/2023-07-06-gpt-and-embeddings)\n\nRelated guide: [Legacy Completions](/docs/guides/gpt/completions-api)\n",
+        "id": "completions",
+        "legacy": true,
+        "sections": [
+          {
+            "key": "CreateCompletionResponse",
+            "path": "object",
+            "type": "object"
+          },
+          {
+            "key": "createCompletion",
+            "path": "create",
+            "type": "endpoint"
+          }
+        ],
+        "title": "Completions"
+      },
+      {
+        "description": "Get a vector representation of a given input that can be easily consumed by machine learning models and algorithms.\n\nRelated guide: [Embeddings](/docs/guides/embeddings)\n",
+        "id": "embeddings",
+        "sections": [
+          {
+            "key": "Embedding",
+            "path": "object",
+            "type": "object"
+          },
+          {
+            "key": "createEmbedding",
+            "path": "create",
+            "type": "endpoint"
+          }
+        ],
+        "title": "Embeddings"
+      },
+      {
+        "description": "Manage fine-tuning jobs to tailor a model to your specific training data.\n\nRelated guide: [Fine-tune models](/docs/guides/fine-tuning)\n",
+        "id": "fine-tuning",
+        "sections": [
+          {
+            "key": "FineTuningJob",
+            "path": "object",
+            "type": "object"
+          },
+          {
+            "key": "createFineTuningJob",
+            "path": "create",
+            "type": "endpoint"
+          },
+          {
+            "key": "listPaginatedFineTuningJobs",
+            "path": "list",
+            "type": "endpoint"
+          },
+          {
+            "key": "retrieveFineTuningJob",
+            "path": "retrieve",
+            "type": "endpoint"
+          },
+          {
+            "key": "cancelFineTuningJob",
+            "path": "cancel",
+            "type": "endpoint"
+          },
+          {
+            "key": "FineTuningJobEvent",
+            "path": "event-object",
+            "type": "object"
+          },
+          {
+            "key": "listFineTuningEvents",
+            "path": "list-events",
+            "type": "endpoint"
+          }
+        ],
+        "title": "Fine-tuning"
+      },
+      {
+        "description": "Files are used to upload documents that can be used with features like [Assistants](/docs/api-reference/assistants) and [Fine-tuning](/docs/api-reference/fine-tuning).\n",
         "id": "files",
+        "sections": [
+          {
+            "key": "OpenAIFile",
+            "path": "object",
+            "type": "object"
+          },
+          {
+            "key": "listFiles",
+            "path": "list",
+            "type": "endpoint"
+          },
+          {
+            "key": "createFile",
+            "path": "create",
+            "type": "endpoint"
+          },
+          {
+            "key": "deleteFile",
+            "path": "delete",
+            "type": "endpoint"
+          },
+          {
+            "key": "retrieveFile",
+            "path": "retrieve",
+            "type": "endpoint"
+          },
+          {
+            "key": "downloadFile",
+            "path": "retrieve-contents",
+            "type": "endpoint"
+          }
+        ],
         "title": "Files"
       },
       {
-        "description": "Manage fine-tuning jobs to tailor a model to your specific training data.\n\nRelated guide: [Fine-tune models](https://platform.openai.com/docs/guides/fine-tuning)\n",
-        "id": "fine-tunes",
-        "title": "Fine-tunes"
+        "description": "Given a prompt and/or an input image, the model will generate a new image.\n\nRelated guide: [Image generation](/docs/guides/images)\n",
+        "id": "images",
+        "sections": [
+          {
+            "key": "Image",
+            "path": "object",
+            "type": "object"
+          },
+          {
+            "key": "createImage",
+            "path": "create",
+            "type": "endpoint"
+          },
+          {
+            "key": "createImageEdit",
+            "path": "createEdit",
+            "type": "endpoint"
+          },
+          {
+            "key": "createImageVariation",
+            "path": "createVariation",
+            "type": "endpoint"
+          }
+        ],
+        "title": "Images"
       },
       {
-        "description": "Given a input text, outputs if the model classifies it as violating OpenAI's content policy.\n\nRelated guide: [Moderations](https://platform.openai.com/docs/guides/moderation)\n",
+        "description": "List and describe the various models available in the API. You can refer to the [Models](/docs/models) documentation to understand what models are available and the differences between them.\n",
+        "id": "models",
+        "sections": [
+          {
+            "key": "Model",
+            "path": "object",
+            "type": "object"
+          },
+          {
+            "key": "listModels",
+            "path": "list",
+            "type": "endpoint"
+          },
+          {
+            "key": "retrieveModel",
+            "path": "retrieve",
+            "type": "endpoint"
+          },
+          {
+            "key": "deleteModel",
+            "path": "delete",
+            "type": "endpoint"
+          }
+        ],
+        "title": "Models"
+      },
+      {
+        "description": "Given a input text, outputs if the model classifies it as violating OpenAI's content policy.\n\nRelated guide: [Moderations](/docs/guides/moderation)\n",
         "id": "moderations",
+        "sections": [
+          {
+            "key": "CreateModerationResponse",
+            "path": "object",
+            "type": "object"
+          },
+          {
+            "key": "createModeration",
+            "path": "create",
+            "type": "endpoint"
+          }
+        ],
         "title": "Moderations"
       },
       {
+        "beta": true,
+        "description": "Build assistants that can call models and use tools to perform tasks.\n\n[Get started with the Assistants API](/docs/assistants)\n",
+        "id": "assistants",
+        "sections": [
+          {
+            "key": "AssistantObject",
+            "path": "object",
+            "type": "object"
+          },
+          {
+            "key": "createAssistant",
+            "path": "createAssistant",
+            "type": "endpoint"
+          },
+          {
+            "key": "getAssistant",
+            "path": "getAssistant",
+            "type": "endpoint"
+          },
+          {
+            "key": "modifyAssistant",
+            "path": "modifyAssistant",
+            "type": "endpoint"
+          },
+          {
+            "key": "deleteAssistant",
+            "path": "deleteAssistant",
+            "type": "endpoint"
+          },
+          {
+            "key": "listAssistants",
+            "path": "listAssistants",
+            "type": "endpoint"
+          },
+          {
+            "key": "AssistantFileObject",
+            "path": "file-object",
+            "type": "object"
+          },
+          {
+            "key": "createAssistantFile",
+            "path": "createAssistantFile",
+            "type": "endpoint"
+          },
+          {
+            "key": "getAssistantFile",
+            "path": "getAssistantFile",
+            "type": "endpoint"
+          },
+          {
+            "key": "deleteAssistantFile",
+            "path": "deleteAssistantFile",
+            "type": "endpoint"
+          },
+          {
+            "key": "listAssistantFiles",
+            "path": "listAssistantFiles",
+            "type": "endpoint"
+          }
+        ],
+        "title": "Assistants"
+      },
+      {
+        "beta": true,
+        "description": "Create threads that assistants can interact with.\n\nRelated guide: [Assistants](/docs/assistants/overview)\n",
+        "id": "threads",
+        "sections": [
+          {
+            "key": "ThreadObject",
+            "path": "object",
+            "type": "object"
+          },
+          {
+            "key": "createThread",
+            "path": "createThread",
+            "type": "endpoint"
+          },
+          {
+            "key": "getThread",
+            "path": "getThread",
+            "type": "endpoint"
+          },
+          {
+            "key": "modifyThread",
+            "path": "modifyThread",
+            "type": "endpoint"
+          },
+          {
+            "key": "deleteThread",
+            "path": "deleteThread",
+            "type": "endpoint"
+          }
+        ],
+        "title": "Threads"
+      },
+      {
+        "beta": true,
+        "description": "Create messages within threads\n\nRelated guide: [Assistants](/docs/assistants/overview)\n",
+        "id": "messages",
+        "sections": [
+          {
+            "key": "MessageObject",
+            "path": "object",
+            "type": "object"
+          },
+          {
+            "key": "createMessage",
+            "path": "createMessage",
+            "type": "endpoint"
+          },
+          {
+            "key": "getMessage",
+            "path": "getMessage",
+            "type": "endpoint"
+          },
+          {
+            "key": "modifyMessage",
+            "path": "modifyMessage",
+            "type": "endpoint"
+          },
+          {
+            "key": "listMessages",
+            "path": "listMessages",
+            "type": "endpoint"
+          },
+          {
+            "key": "MessageFileObject",
+            "path": "file-object",
+            "type": "object"
+          },
+          {
+            "key": "getMessageFile",
+            "path": "getMessageFile",
+            "type": "endpoint"
+          },
+          {
+            "key": "listMessageFiles",
+            "path": "listMessageFiles",
+            "type": "endpoint"
+          }
+        ],
+        "title": "Messages"
+      },
+      {
+        "beta": true,
+        "description": "Represents an execution run on a thread.\n\nRelated guide: [Assistants](/docs/assistants/overview)\n",
+        "id": "runs",
+        "sections": [
+          {
+            "key": "RunObject",
+            "path": "object",
+            "type": "object"
+          },
+          {
+            "key": "createRun",
+            "path": "createRun",
+            "type": "endpoint"
+          },
+          {
+            "key": "getRun",
+            "path": "getRun",
+            "type": "endpoint"
+          },
+          {
+            "key": "modifyRun",
+            "path": "modifyRun",
+            "type": "endpoint"
+          },
+          {
+            "key": "listRuns",
+            "path": "listRuns",
+            "type": "endpoint"
+          },
+          {
+            "key": "submitToolOuputsToRun",
+            "path": "submitToolOutputs",
+            "type": "endpoint"
+          },
+          {
+            "key": "cancelRun",
+            "path": "cancelRun",
+            "type": "endpoint"
+          },
+          {
+            "key": "createThreadAndRun",
+            "path": "createThreadAndRun",
+            "type": "endpoint"
+          },
+          {
+            "key": "RunStepObject",
+            "path": "step-object",
+            "type": "object"
+          },
+          {
+            "key": "getRunStep",
+            "path": "getRunStep",
+            "type": "endpoint"
+          },
+          {
+            "key": "listRunSteps",
+            "path": "listRunSteps",
+            "type": "endpoint"
+          }
+        ],
+        "title": "Runs"
+      },
+      {
+        "deprecated": true,
+        "description": "Manage legacy fine-tuning jobs to tailor a model to your specific training data.\n\nWe recommend transitioning to the updating [fine-tuning API](/docs/guides/fine-tuning)\n",
+        "id": "fine-tunes",
+        "sections": [
+          {
+            "key": "FineTune",
+            "path": "object",
+            "type": "object"
+          },
+          {
+            "key": "createFineTune",
+            "path": "create",
+            "type": "endpoint"
+          },
+          {
+            "key": "listFineTunes",
+            "path": "list",
+            "type": "endpoint"
+          },
+          {
+            "key": "retrieveFineTune",
+            "path": "retrieve",
+            "type": "endpoint"
+          },
+          {
+            "key": "cancelFineTune",
+            "path": "cancel",
+            "type": "endpoint"
+          },
+          {
+            "key": "FineTuneEvent",
+            "path": "event-object",
+            "type": "object"
+          },
+          {
+            "key": "listFineTuneEvents",
+            "path": "list-events",
+            "type": "endpoint"
+          }
+        ],
+        "title": "Fine-tunes"
+      },
+      {
+        "deprecated": true,
         "description": "Given a prompt and an instruction, the model will return an edited version of the prompt.\n",
         "id": "edits",
+        "sections": [
+          {
+            "key": "CreateEditResponse",
+            "path": "object",
+            "type": "object"
+          },
+          {
+            "key": "createEdit",
+            "path": "create",
+            "type": "endpoint"
+          }
+        ],
         "title": "Edits"
       }
     ]

--- a/pkg/openai/config/tasks.json
+++ b/pkg/openai/config/tasks.json
@@ -95,6 +95,131 @@
       "type": "object"
     }
   },
+  "TASK_TEXT_TO_IMAGE": {
+    "input": {
+      "instillUIOrder": 0,
+      "properties": {
+        "model": {
+          "$ref": "openai.json#/components/schemas/CreateImageRequest/properties/model",
+          "instillAcceptFormats": [
+            "string"
+          ],
+          "instillShortDescription": "ID of the model to use",
+          "instillUIOrder": 0,
+          "instillUpstreamTypes": [
+            "value",
+            "reference",
+            "template"
+          ],
+          "title": "Model"
+        },
+        "prompt": {
+          "$ref": "openai.json#/components/schemas/CreateImageRequest/properties/prompt",
+          "instillAcceptFormats": [
+            "string"
+          ],
+          "instillShortDescription": "A text description of the desired image(s).",
+          "instillUIOrder": 1,
+          "instillUpstreamTypes": [
+            "value",
+            "reference",
+            "template"
+          ],
+          "title": "Prompt"
+        },
+        "n": {
+          "$ref": "openai.json#/components/schemas/CreateImageRequest/properties/n",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUIOrder": 2,
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "title": "N"
+        },
+        "quality": {
+          "$ref": "openai.json#/components/schemas/CreateImageRequest/properties/quality",
+          "instillAcceptFormats": [
+            "string"
+          ],
+          "instillShortDescription": "The quality of the image that will be generated.",
+          "instillUIOrder": 3,
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "title": "Quality"
+        },
+        "size": {
+          "$ref": "openai.json#/components/schemas/CreateImageRequest/properties/size",
+          "instillShortDescription": "The size of the generated images.",
+          "instillAcceptFormats": [
+            "string"
+          ],
+          "instillUIOrder": 4,
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "title": "Size"
+        },
+        "style": {
+          "$ref": "openai.json#/components/schemas/CreateImageRequest/properties/style",
+          "instillAcceptFormats": [
+            "string"
+          ],
+          "instillShortDescription": "The style of the generated images.",
+          "instillUIOrder": 5,
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "title": "N"
+        }
+      },
+      "required": [
+        "prompt",
+        "model"
+      ],
+      "title": "Input",
+      "type": "object"
+    },
+    "output": {
+      "instillUIOrder": 0,
+      "properties": {
+        "results": {
+          "description": "Generated results",
+          "instillUIOrder": 0,
+          "items": {
+            "properties": {
+              "image": {
+                "instillFormat": "image/webp",
+                "description": "Generated image",
+                "type": "string"    
+              },
+              "revised_prompt": {
+                "instillFormat": "string",
+                "description": "Revised prompt",
+                "type": "string"    
+              }
+            },
+            "description": "Generated result",
+            "required": ["image", "revised_prompt"],
+            "type": "object"
+          },
+          "title": "Images",
+          "type": "array"
+        }
+      },
+      "required": [
+        "results"
+      ],
+      "title": "Output",
+      "type": "object"
+    }
+  },
   "TASK_TEXT_EMBEDDINGS": {
     "input": {
       "instillUIOrder": 0,
@@ -207,6 +332,42 @@
           ],
           "title": "Prompt",
           "type": "string"
+        },
+        "images": {
+          "description": "The images",
+          "instillAcceptFormats": [
+            "array:image/*"
+          ],
+          "instillUIOrder": 1,
+          "instillUpstreamTypes": [
+            "reference"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "title": "Image",
+          "type": "array"
+        },
+        "response_format": {
+          "description": "An object specifying the format that the model must output. Used to enable JSON mode.",
+          "properties": {
+            "type": {
+              "$ref": "openai.json#/components/schemas/CreateChatCompletionRequest/properties/response_format/properties/type",
+              "instillAcceptFormats": [
+                "string"
+              ],
+              "instillShortDescription":"Setting to `json_object` enables JSON mode. ",
+              "instillUIOrder": 0,
+              "instillUpstreamTypes": [
+                "value",
+                "reference"
+              ]
+            }
+          },
+          "instillUIOrder": 10,
+          "required": ["type"],
+          "title": "Response Format",
+          "type": "object"
         },
         "system_message": {
           "default": "You are a helpful assistant.",

--- a/pkg/openai/text_generation.go
+++ b/pkg/openai/text_generation.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 )
 
@@ -12,6 +13,7 @@ const (
 
 type TextCompletionInput struct {
 	Prompt        string   `json:"prompt"`
+	Images        []string `json:"images"`
 	Model         string   `json:"model"`
 	SystemMessage *string  `json:"system_message,omitempty"`
 	Temperature   *float32 `json:"temperature,omitempty"`
@@ -37,8 +39,17 @@ type TextCompletionReq struct {
 }
 
 type Message struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role    string    `json:"role"`
+	Content []Content `json:"content"`
+}
+
+type ImageUrl struct {
+	Url string `json:"url"`
+}
+type Content struct {
+	Type     string    `json:"type"`
+	Text     *string   `json:"text,omitempty"`
+	ImageUrl *ImageUrl `json:"image_url,omitempty"`
 }
 
 type TextCompletionResp struct {
@@ -49,10 +60,15 @@ type TextCompletionResp struct {
 	Usage   Usage     `json:"usage"`
 }
 
+type OutputMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
 type Choices struct {
-	Index        int     `json:"index"`
-	FinishReason string  `json:"finish_reason"`
-	Message      Message `json:"message"`
+	Index        int           `json:"index"`
+	FinishReason string        `json:"finish_reason"`
+	Message      OutputMessage `json:"message"`
 }
 
 type Usage struct {
@@ -65,6 +81,8 @@ type Usage struct {
 // https://platform.openai.com/docs/api-reference/completions
 func (c *Client) GenerateTextCompletion(req TextCompletionReq) (result TextCompletionResp, err error) {
 	data, _ := json.Marshal(req)
+	fmt.Println()
+	fmt.Println(string(data))
 	err = c.sendReq(completionsURL, http.MethodPost, jsonMimeType, bytes.NewBuffer(data), &result)
 	return result, err
 }

--- a/pkg/openai/text_to_image.go
+++ b/pkg/openai/text_to_image.go
@@ -1,0 +1,54 @@
+package openai
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+const (
+	generationURL = host + "/v1/images/generations"
+)
+
+type ImagesGenerationInput struct {
+	Prompt  string  `json:"prompt"`
+	Model   string  `json:"model"`
+	N       *int    `json:"n,omitempty"`
+	Quality *string `json:"quality,omitempty"`
+	Size    *string `json:"size,omitempty"`
+	Style   *string `json:"style,omitempty"`
+}
+
+type ImageGenerationsOutputResult struct {
+	Image         string `json:"image"`
+	RevisedPrompt string `json:"revised_prompt"`
+}
+type ImageGenerationsOutput struct {
+	Results []ImageGenerationsOutputResult `json:"results"`
+}
+
+type ImageGenerationsReq struct {
+	Prompt         string  `json:"prompt"`
+	Model          string  `json:"model"`
+	N              *int    `json:"n,omitempty"`
+	Quality        *string `json:"quality,omitempty"`
+	Size           *string `json:"size,omitempty"`
+	Style          *string `json:"style,omitempty"`
+	ResponseFormat string  `json:"response_format"`
+}
+
+type ImageGenerationsRespData struct {
+	Image         string `json:"b64_json"`
+	RevisedPrompt string `json:"revised_prompt"`
+}
+type ImageGenerationsResp struct {
+	Data []ImageGenerationsRespData `json:"data"`
+}
+
+func (c *Client) GenerateImagesGenerations(req ImageGenerationsReq) (result ImageGenerationsResp, err error) {
+	data, _ := json.Marshal(req)
+	fmt.Println("datra", string(data))
+	err = c.sendReq(generationURL, http.MethodPost, jsonMimeType, bytes.NewBuffer(data), &result)
+	return result, err
+}

--- a/pkg/stabilityai/main.go
+++ b/pkg/stabilityai/main.go
@@ -253,5 +253,5 @@ func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.
 
 // decode if the string is base64 encoded
 func DecodeBase64(input string) ([]byte, error) {
-	return base64.StdEncoding.DecodeString(input)
+	return base64.StdEncoding.DecodeString(base.TrimBase64Mime(input))
 }


### PR DESCRIPTION
Because

- the OpenAI announced new models, we need to update the connector to catch up with latest updates.

This commit

- Update model list
- Support image inputs for text generation task
- Support new task `TASK_TEXT_TO_IMAGE`
- Support json-object output
- Trim base64 string mime prefix