### PR TITLE
refactor: update documentation urls

### DIFF
--- a/pkg/bigquery/config/definitions.json
+++ b/pkg/bigquery/config/definitions.json
@@ -4,7 +4,7 @@
       "TASK_INSERT"
     ],
     "custom": false,
-    "documentation_url": "https://www.instill.tech/docs/vdp/data-connectors/bigquery",
+    "documentation_url": "https://www.instill.tech/docs/latest/vdp/data-connectors/bigquery",
     "icon": "bigquery.svg",
     "icon_url": "",
     "id": "data-bigquery",

--- a/pkg/googlecloudstorage/config/definitions.json
+++ b/pkg/googlecloudstorage/config/definitions.json
@@ -4,7 +4,7 @@
       "TASK_UPLOAD"
     ],
     "custom": false,
-    "documentation_url": "https://www.instill.tech/docs/vdp/data-connectors/gcs",
+    "documentation_url": "https://www.instill.tech/docs/latest/vdp/data-connectors/gcs",
     "icon": "gcs.svg",
     "icon_url": "",
     "id": "data-gcs",

--- a/pkg/googlesearch/config/definitions.json
+++ b/pkg/googlesearch/config/definitions.json
@@ -4,7 +4,7 @@
       "TASK_SEARCH"
     ],
     "custom": false,
-    "documentation_url": "https://www.instill.tech/docs/vdp/data-connectors/google-search",
+    "documentation_url": "https://www.instill.tech/docs/latest/vdp/data-connectors/google-search",
     "icon": "google-search.svg",
     "icon_url": "",
     "id": "data-google-search",

--- a/pkg/huggingface/config/definitions.json
+++ b/pkg/huggingface/config/definitions.json
@@ -20,7 +20,7 @@
       "TASK_AUDIO_CLASSIFICATION"
     ],
     "custom": false,
-    "documentation_url": "https://www.instill.tech/docs/vdp/ai-connectors/hugging-face",
+    "documentation_url": "https://www.instill.tech/docs/latest/vdp/ai-connectors/hugging-face",
     "icon": "huggingface.svg",
     "icon_url": "",
     "id": "ai-hugging-face",

--- a/pkg/instill/config/definitions.json
+++ b/pkg/instill/config/definitions.json
@@ -11,7 +11,7 @@
       "TASK_TEXT_TO_IMAGE"
     ],
     "custom": false,
-    "documentation_url": "https://www.instill.tech/docs/vdp/ai-connectors/instill-model",
+    "documentation_url": "https://www.instill.tech/docs/latest/vdp/ai-connectors/instill-model",
     "icon": "instillmodel.svg",
     "icon_url": "",
     "id": "ai-instill-model",

--- a/pkg/numbers/config/definitions.json
+++ b/pkg/numbers/config/definitions.json
@@ -4,7 +4,7 @@
       "TASK_COMMIT"
     ],
     "custom": false,
-    "documentation_url": "https://www.instill.tech/docs/vdp/blockchain-connectors/numbers",
+    "documentation_url": "https://www.instill.tech/docs/latest/vdp/app-connectors/numbers-protocol",
     "icon": "numbers.svg",
     "icon_url": "",
     "id": "blockchain-numbers",

--- a/pkg/openai/config/definitions.json
+++ b/pkg/openai/config/definitions.json
@@ -7,7 +7,7 @@
       "TASK_TEXT_TO_IMAGE"
     ],
     "custom": false,
-    "documentation_url": "https://www.instill.tech/docs/vdp/ai-connectors/openai",
+    "documentation_url": "https://www.instill.tech/docs/latest/vdp/ai-connectors/openai",
     "icon": "openai.svg",
     "icon_url": "",
     "id": "ai-openai",
@@ -27,7 +27,7 @@
           "organization": {
             "description": "Specify which organization is used for the requests. Usage will count against the specified organization's subscription quota.",
             "instillUIOrder": 1,
-            "title": "Organization",
+            "title": "Organization ID",
             "type": "string"
           }
         },

--- a/pkg/pinecone/config/definitions.json
+++ b/pkg/pinecone/config/definitions.json
@@ -5,7 +5,7 @@
       "TASK_UPSERT"
     ],
     "custom": false,
-    "documentation_url": "https://www.instill.tech/docs/vdp/data-connectors/pinecone",
+    "documentation_url": "https://www.instill.tech/docs/latest/vdp/data-connectors/pinecone",
     "icon": "pinecone.svg",
     "icon_url": "https://www.pinecone.io/favicon.ico",
     "id": "data-pinecone",

--- a/pkg/stabilityai/config/definitions.json
+++ b/pkg/stabilityai/config/definitions.json
@@ -5,7 +5,7 @@
       "TASK_IMAGE_TO_IMAGE"
     ],
     "custom": false,
-    "documentation_url": "https://www.instill.tech/docs/vdp/ai-connectors/stability-ai",
+    "documentation_url": "https://www.instill.tech/docs/latest/vdp/ai-connectors/stability-ai",
     "icon": "stabilityai.svg",
     "icon_url": "",
     "id": "ai-stability-ai",


### PR DESCRIPTION
Because

- the documentation URLs are out dated

This commit

- update documentation URLs of connectors
