### PR TITLE
chore(ai-openai): fix bugs when using `gpt-4-vision-preview` model

### DIFF
--- a/pkg/openai/main.go
+++ b/pkg/openai/main.go
@@ -173,11 +173,17 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 				MaxTokens:        inputStruct.MaxTokens,
 				Temperature:      inputStruct.Temperature,
 				N:                inputStruct.N,
-				ResponseFormat:   inputStruct.ResponseFormat,
 				TopP:             inputStruct.TopP,
 				PresencePenalty:  inputStruct.PresencePenalty,
 				FrequencyPenalty: inputStruct.FrequencyPenalty,
 			}
+
+			// workaround, the OpenAI service can not accept this param
+			if inputStruct.Model != "gpt-4-vision-preview" {
+				fmt.Println(1111, inputStruct.Model)
+				req.ResponseFormat = inputStruct.ResponseFormat
+			}
+
 			resp, err := client.GenerateTextCompletion(req)
 			if err != nil {
 				return inputs, err

--- a/pkg/openai/text_generation.go
+++ b/pkg/openai/text_generation.go
@@ -22,11 +22,11 @@ type TextCompletionInput struct {
 	MaxTokens        *int                  `json:"max_tokens,omitempty"`
 	PresencePenalty  *float32              `json:"presence_penalty,omitempty"`
 	FrequencyPenalty *float32              `json:"frequency_penalty,omitempty"`
-	ResponseFormat   *ResponseFormatStruct `json:"response_format"`
+	ResponseFormat   *ResponseFormatStruct `json:"response_format,omitempty"`
 }
 
 type ResponseFormatStruct struct {
-	Type string `json:"type"`
+	Type string `json:"type,omitempty"`
 }
 
 type TextCompletionOutput struct {
@@ -43,7 +43,7 @@ type TextCompletionReq struct {
 	MaxTokens        *int                  `json:"max_tokens,omitempty"`
 	PresencePenalty  *float32              `json:"presence_penalty,omitempty"`
 	FrequencyPenalty *float32              `json:"frequency_penalty,omitempty"`
-	ResponseFormat   *ResponseFormatStruct `json:"response_format"`
+	ResponseFormat   *ResponseFormatStruct `json:"response_format,omitempty"`
 }
 
 type Message struct {


### PR DESCRIPTION
Because

- the `gpt-4-vision-preview` model can not accept `response_format` param

This commit

- fix bugs when using `gpt-4-vision-preview` model
