### PR TITLE
chore(ai-instill): update default value for text generation

### DIFF
--- a/pkg/instill/config/tasks.json
+++ b/pkg/instill/config/tasks.json
@@ -184,6 +184,7 @@
             "value",
             "reference"
           ],
+          "default": 50,
           "title": "Max new tokens",
           "type": "integer"
         },
@@ -263,6 +264,7 @@
           "instillAcceptFormats": [
             "number"
           ],
+          "default": 0.7,
           "instillUIOrder": 5,
           "instillUpstreamTypes": [
             "value",
@@ -276,6 +278,7 @@
           "instillAcceptFormats": [
             "integer"
           ],
+          "default": 10,
           "instillUIOrder": 5,
           "instillUpstreamTypes": [
             "value",

--- a/pkg/instill/text_generation.go
+++ b/pkg/instill/text_generation.go
@@ -74,7 +74,7 @@ func (c *Execution) executeTextGeneration(grpcClient modelPB.ModelPublicServiceC
 		}
 
 		textGenOutput := taskOutputs[0].GetTextGeneration()
-		if textGenOutput == nil || len(textGenOutput.GetText()) <= 0 {
+		if textGenOutput == nil {
 			return nil, fmt.Errorf("invalid output: %v for model: %s", textGenOutput, modelName)
 		}
 		outputJson, err := protojson.MarshalOptions{


### PR DESCRIPTION
Because

- need to set default value for text generation task to help user configuring the component

This commit

- update default value for text generation
