### PR TITLE
feat(restapi): add REST API connector

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -119,10 +119,10 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
-github.com/instill-ai/component v0.7.0-alpha.0.20231122064543-8b9a044908e4 h1:8g8PlWWDLFaS5oJKqswInbLrvmj9ojlE26UeN7Gk2Zg=
-github.com/instill-ai/component v0.7.0-alpha.0.20231122064543-8b9a044908e4/go.mod h1:GgpdzmunwTzpZh4Fxrb8MPpBRm1Yl7kdCED2ph2O3tA=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231121163720-206d6eff20a7 h1:vhMCJLPhVvhINR31VgOyq5ct8f7TZx2ZteQXpjGwaEc=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231121163720-206d6eff20a7/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
+github.com/instill-ai/component v0.7.0-alpha h1:kuiIrPFutxhosq6XohkKAg5svAfLtYoBD0KGvM5bt0c=
+github.com/instill-ai/component v0.7.0-alpha/go.mod h1:JDVDbZby6njJS2ioy2ptD3RhC4CuKWJKsWBg0PtQWK4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231107112239-e910edf62911 h1:8ywlej8tx+TVKO13T/v9zuaNoqQi7ZMIGG4/wB58xYs=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231107112239-e910edf62911/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/asmfmt v1.3.2 h1:4Ri7ox3EwapiOjCki+hw14RyKk201CN4rzyCJRFLpK4=

--- a/go.sum
+++ b/go.sum
@@ -119,10 +119,10 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
-github.com/instill-ai/component v0.7.0-alpha h1:kuiIrPFutxhosq6XohkKAg5svAfLtYoBD0KGvM5bt0c=
-github.com/instill-ai/component v0.7.0-alpha/go.mod h1:JDVDbZby6njJS2ioy2ptD3RhC4CuKWJKsWBg0PtQWK4=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231107112239-e910edf62911 h1:8ywlej8tx+TVKO13T/v9zuaNoqQi7ZMIGG4/wB58xYs=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231107112239-e910edf62911/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
+github.com/instill-ai/component v0.7.0-alpha.0.20231122064543-8b9a044908e4 h1:8g8PlWWDLFaS5oJKqswInbLrvmj9ojlE26UeN7Gk2Zg=
+github.com/instill-ai/component v0.7.0-alpha.0.20231122064543-8b9a044908e4/go.mod h1:GgpdzmunwTzpZh4Fxrb8MPpBRm1Yl7kdCED2ph2O3tA=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231121163720-206d6eff20a7 h1:vhMCJLPhVvhINR31VgOyq5ct8f7TZx2ZteQXpjGwaEc=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231121163720-206d6eff20a7/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/asmfmt v1.3.2 h1:4Ri7ox3EwapiOjCki+hw14RyKk201CN4rzyCJRFLpK4=

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/instill-ai/connector/pkg/numbers"
 	"github.com/instill-ai/connector/pkg/openai"
 	"github.com/instill-ai/connector/pkg/pinecone"
+	"github.com/instill-ai/connector/pkg/redis"
 	"github.com/instill-ai/connector/pkg/restapi"
 	"github.com/instill-ai/connector/pkg/stabilityai"
 
@@ -53,6 +54,7 @@ func Init(logger *zap.Logger, options ConnectorOptions) base.IConnector {
 		connector.(*Connector).ImportDefinitions(googlecloudstorage.Init(logger))
 		connector.(*Connector).ImportDefinitions(googlesearch.Init(logger))
 		connector.(*Connector).ImportDefinitions(pinecone.Init(logger))
+		connector.(*Connector).ImportDefinitions(redis.Init(logger))
 		connector.(*Connector).ImportDefinitions(restapi.Init(logger))
 
 	})

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/instill-ai/connector/pkg/numbers"
 	"github.com/instill-ai/connector/pkg/openai"
 	"github.com/instill-ai/connector/pkg/pinecone"
-	"github.com/instill-ai/connector/pkg/redis"
+	"github.com/instill-ai/connector/pkg/restapi"
 	"github.com/instill-ai/connector/pkg/stabilityai"
 
 	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
@@ -53,7 +53,7 @@ func Init(logger *zap.Logger, options ConnectorOptions) base.IConnector {
 		connector.(*Connector).ImportDefinitions(googlecloudstorage.Init(logger))
 		connector.(*Connector).ImportDefinitions(googlesearch.Init(logger))
 		connector.(*Connector).ImportDefinitions(pinecone.Init(logger))
-		connector.(*Connector).ImportDefinitions(redis.Init(logger))
+		connector.(*Connector).ImportDefinitions(restapi.Init(logger))
 
 	})
 	return connector

--- a/pkg/restapi/auth.go
+++ b/pkg/restapi/auth.go
@@ -1,0 +1,123 @@
+package restapi
+
+import (
+	"encoding/base64"
+	"errors"
+)
+
+type AuthType string
+
+const (
+	NoAuthType      AuthType = "NO_AUTH"
+	BasicAuthType   AuthType = "BASIC_AUTH"
+	APIKeyType      AuthType = "API_KEY"
+	BearerTokenType AuthType = "BEARER_TOKEN"
+)
+
+// Authentication authentication interface
+type Authentication interface {
+	// GetAuthLocation returns the location of the authentication string, it can be "header" or "query"
+	GetAuthLocation() AuthLocation
+	// GenAuthHeader generates the authentication header key and value
+	GenAuthHeader() (key, value string, err error)
+	// GenAuthQuery generates the authentication key and value for query parameter
+	GenAuthQuery() (key, value string, err error)
+}
+
+// NoAuth is the no authentication method
+type NoAuth struct {
+	AuthType AuthType `json:"auth_type"`
+}
+
+func (na NoAuth) GetAuthLocation() AuthLocation {
+	return Header
+}
+
+func (na NoAuth) GenAuthHeader() (string, string, error) {
+	return "", "", nil
+}
+
+func (na NoAuth) GenAuthQuery() (string, string, error) {
+	return "", "", nil
+}
+
+// BasicAuth is the basic authentication method
+type BasicAuth struct {
+	AuthType AuthType `json:"auth_type"`
+	Username string   `json:"username"`
+	Password string   `json:"password"`
+}
+
+func (ba BasicAuth) GetAuthLocation() AuthLocation {
+	return Header
+}
+
+func (ba BasicAuth) GenAuthHeader() (string, string, error) {
+	if ba.Username == "" || ba.Password == "" {
+		return "", "", errors.New("Basic Auth error: username or password is empty")
+	}
+	key := "Authorization"
+	value := "Basic " + base64.StdEncoding.EncodeToString([]byte(ba.Username+":"+ba.Password))
+	return key, value, nil
+}
+
+func (ba BasicAuth) GenAuthQuery() (string, string, error) {
+	return "", "", errors.New("Basic Auth error: Basic Auth does not support query parameter")
+}
+
+// AuthLocation is the enum for AuthLocation field in ApiKeyAuth struct, which represents the location of the authentication string, it can be "header" or "query"
+type AuthLocation string
+
+const (
+	Header AuthLocation = "header"
+	Query  AuthLocation = "query"
+)
+
+// ApiKeyAuth is the API key authentication method
+type APIKeyAuth struct {
+	AuthType     AuthType     `json:"auth_type"`
+	Key          string       `json:"key"`
+	Value        string       `json:"value"`
+	AuthLocation AuthLocation `json:"auth_location"`
+}
+
+func (aka APIKeyAuth) GetAuthLocation() AuthLocation {
+	return aka.AuthLocation
+}
+
+func (aka APIKeyAuth) GenAuthHeader() (string, string, error) {
+	if aka.Key == "" || aka.Value == "" {
+		return "", "", errors.New("API Key Auth error: key or value is empty")
+	}
+	return aka.Key, aka.Value, nil
+}
+
+func (aka APIKeyAuth) GenAuthQuery() (string, string, error) {
+	if aka.Key == "" || aka.Value == "" {
+		return "", "", errors.New("API Key Auth error: key or value is empty")
+	}
+	return aka.Key, aka.Value, nil
+}
+
+// BearerTokenAuth is the bearer token authentication method
+type BearerTokenAuth struct {
+	AuthType AuthType `json:"auth_type"`
+	Token    string   `json:"token"`
+}
+
+func (bta BearerTokenAuth) GetAuthLocation() AuthLocation {
+	return Header
+}
+
+func (bta BearerTokenAuth) GenAuthHeader() (string, string, error) {
+	if bta.Token == "" {
+		return "", "", errors.New("Bearer Token Auth error: token is empty")
+	}
+	key := "Authorization"
+	value := "Bearer " + bta.Token
+	return key, value, nil
+}
+
+func (bta BearerTokenAuth) GenAuthQuery() (string, string, error) {
+	return "", "", errors.New("Bearer Token Auth error: Bearer Token Auth does not support query parameter")
+}

--- a/pkg/restapi/body.go
+++ b/pkg/restapi/body.go
@@ -1,0 +1,44 @@
+package restapi
+
+type BodyType string
+
+const (
+	NoneBodyType BodyType = "NONE"
+	RawJSONType  BodyType = "RAW_JSON"
+	// TODO: add more body types
+	// FormDataType BodyType = "FORM_DATA"
+	// XWWWFORMURLENCODEDType BodyType = "X_WWW_FORM_URLENCODED"
+	// BinaryType   BodyType = "BINARY"
+)
+
+type Body interface {
+	GetBodyType() BodyType
+	GetBody() map[string]interface{}
+}
+
+// NoneBody: body is none
+type NoneBody struct {
+	BodyType BodyType `json:"body_type"`
+}
+
+func (nb NoneBody) GetBodyType() BodyType {
+	return NoneBodyType
+}
+
+func (nb NoneBody) GetBody() map[string]interface{} {
+	return nil
+}
+
+// RawJSONBody: body is raw JSON
+type RawJSONBody struct {
+	BodyType BodyType               `json:"body_type"`
+	BodyData map[string]interface{} `json:"data,omitempty"`
+}
+
+func (rjb RawJSONBody) GetBodyType() BodyType {
+	return RawJSONType
+}
+
+func (rjb RawJSONBody) GetBody() map[string]interface{} {
+	return rjb.BodyData
+}

--- a/pkg/restapi/client.go
+++ b/pkg/restapi/client.go
@@ -1,0 +1,153 @@
+package restapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const (
+	reqTimeout = time.Second * 60 * 5
+)
+
+type TaskInput struct {
+	EndpointPath *string `json:"endpoint_path,omitempty"`
+	Body         Body    `json:"body,omitempty"`
+}
+
+type TaskOutput struct {
+	StatusCode int                    `json:"status_code"`
+	Body       map[string]interface{} `json:"body"`
+	Header     map[string][]string    `json:"header"`
+}
+
+type Client struct {
+	BaseURL        string         `json:"base_url"`
+	Authentication Authentication `json:"authentication"`
+	HTTPClient     HTTPClient
+}
+
+// HTTPClient interface
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+func NewClient(config *structpb.Struct) (Client, error) {
+	baseURL := getBaseURL(config)
+	auth, err := getAuthentication(config)
+	if err != nil {
+		return Client{}, err
+	}
+
+	tr := &http.Transport{
+		DisableKeepAlives: true,
+	}
+
+	return Client{
+		BaseURL:        baseURL,
+		Authentication: auth,
+		HTTPClient: &http.Client{
+			Timeout:   reqTimeout,
+			Transport: tr,
+		},
+	}, nil
+}
+
+func (c *Client) sendRequest(method string, input TaskInput) (TaskOutput, error) {
+	resp := TaskOutput{}
+
+	http.DefaultClient.Timeout = reqTimeout
+
+	reqURL := c.BaseURL
+	if input.EndpointPath != nil {
+		reqURL += *input.EndpointPath
+	}
+
+	var req *http.Request
+	var err error
+
+	switch method {
+	case http.MethodGet, http.MethodHead:
+		// Ignore body
+		req, err = http.NewRequest(method, reqURL, nil)
+		if err != nil {
+			return resp, err
+		}
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		if input.Body == nil || input.Body.GetBodyType() == NoneBodyType || input.Body.GetBody() == nil || len(input.Body.GetBody()) == 0 {
+			req, err = http.NewRequest(method, reqURL, nil)
+			if err != nil {
+				return resp, err
+			}
+		} else {
+			// Convert body to JSON
+			jsonBody, err := json.Marshal(input.Body.GetBody())
+			if err != nil {
+				return resp, err
+			}
+			req, err = http.NewRequest(method, reqURL, bytes.NewBuffer(jsonBody))
+			if err != nil {
+				return resp, err
+			}
+		}
+	default:
+		return resp, fmt.Errorf("not supported method: %s", method)
+	}
+
+	// Add authentication
+	switch c.Authentication.GetAuthLocation() {
+	case Header:
+		key, value, err := c.Authentication.GenAuthHeader()
+		if err != nil {
+			return resp, err
+		}
+		if key != "" {
+			req.Header.Add(key, value)
+		}
+	case Query:
+		key, value, err := c.Authentication.GenAuthQuery()
+		if err != nil {
+			return resp, err
+		}
+		if key != "" {
+			// Append the query parameter to the URL
+			extraParams := url.Values{}
+			extraParams.Add(key, value)
+			if req.URL.RawQuery != "" {
+				req.URL.RawQuery += "&" + extraParams.Encode()
+			} else {
+				req.URL.RawQuery = extraParams.Encode()
+			}
+		}
+	default:
+		return resp, nil
+	}
+
+	// Send request
+	res, err := c.HTTPClient.Do(req)
+	if res != nil && res.Body != nil {
+		defer res.Body.Close()
+	}
+	if err != nil {
+		return resp, err
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return resp, err
+	}
+
+	resp.StatusCode = res.StatusCode
+	resp.Header = res.Header
+	err = json.Unmarshal(body, &resp.Body)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}

--- a/pkg/restapi/config/definitions.json
+++ b/pkg/restapi/config/definitions.json
@@ -1,0 +1,175 @@
+[
+  {
+    "available_tasks": [
+      "TASK_GET",
+      "TASK_POST",
+      "TASK_PATCH",
+      "TASK_PUT",
+      "TASK_DELETE",
+      "TASK_HEAD",
+      "TASK_OPTIONS"
+    ],
+    "custom": false,
+    "documentation_url": "https://www.instill.tech/docs/latest/vdp/data-connectors/restapi",
+    "icon": "restapi.svg",
+    "icon_url": "",
+    "id": "data-restapi",
+    "public": true,
+    "spec": {
+      "resource_specification": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "authentication": {
+            "description": "Authentication method to use for the REST API",
+            "instillUIOrder": 1,
+            "oneOf": [
+              {
+                "properties": {
+                  "auth_type": {
+                    "const": "NO_AUTH",
+                    "description": "No Authentication",
+                    "instillUIOrder": 0,
+                    "order": 0,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "auth_type"
+                ],
+                "title": "No Auth"
+              },
+              {
+                "properties": {
+                  "auth_type": {
+                    "const": "BASIC_AUTH",
+                    "description": "Basic auth",
+                    "instillUIOrder": 0,
+                    "order": 0,
+                    "type": "string"
+                  },
+                  "password": {
+                    "description": "Password for Basic auth",
+                    "instillCredentialField": true,
+                    "instillUIOrder": 2,
+                    "order": 2,
+                    "title": "Password",
+                    "type": "string"
+                  },
+                  "username": {
+                    "description": "Username for Basic Auth",
+                    "instillUIOrder": 1,
+                    "order": 1,
+                    "title": "Username",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "auth_type",
+                  "username",
+                  "password"
+                ],
+                "title": "Basic Auth"
+              },
+              {
+                "properties": {
+                  "auth_location": {
+                    "default": "header",
+                    "description": "Add the API key to the header or query params",
+                    "enum": [
+                      "header",
+                      "query"
+                    ],
+                    "instillUIOrder": 3,
+                    "order": 3,
+                    "title": "Where to Add API Key to",
+                    "type": "string"
+                  },
+                  "auth_type": {
+                    "const": "API_KEY",
+                    "description": "API key authentication",
+                    "instillUIOrder": 0,
+                    "order": 0,
+                    "type": "string"
+                  },
+                  "key": {
+                    "default": "X-API-Key",
+                    "description": "Key name for API key authentication",
+                    "instillUIOrder": 1,
+                    "order": 1,
+                    "title": "Key Name",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Key value for API key authentication",
+                    "instillCredentialField": true,
+                    "instillUIOrder": 2,
+                    "order": 2,
+                    "title": "Key Value",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "auth_type",
+                  "key",
+                  "value",
+                  "auth_location"
+                ],
+                "title": "API Key"
+              },
+              {
+                "properties": {
+                  "auth_type": {
+                    "const": "BEARER_TOKEN",
+                    "description": "Bearer token authentication",
+                    "instillUIOrder": 0,
+                    "order": 0,
+                    "type": "string"
+                  },
+                  "token": {
+                    "description": "Bearer token",
+                    "instillCredentialField": true,
+                    "instillUIOrder": 1,
+                    "order": 1,
+                    "title": "Token",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "auth_type",
+                  "token"
+                ],
+                "title": "Bearer Token"
+              }
+            ],
+            "order": 1,
+            "title": "Authentication",
+            "type": "object"
+          },
+          "base_url": {
+            "description": "Base URL of the REST API",
+            "examples": [
+              "https://api.example.com/v1"
+            ],
+            "instillUIOrder": 0,
+            "order": 0,
+            "title": "Base URL",
+            "type": "string"
+          }
+        },
+        "required": [
+          "base_url",
+          "authentication"
+        ],
+        "title": "REST API Connector Spec",
+        "type": "object"
+      }
+    },
+    "title": "REST API",
+    "tombstone": false,
+    "type": "CONNECTOR_TYPE_DATA",
+    "uid": "5ee55a5c-6e30-4c7a-80e8-90165a729e0a",
+    "vendor": "",
+    "vendor_attributes": {}
+  }
+]

--- a/pkg/restapi/config/tasks.json
+++ b/pkg/restapi/config/tasks.json
@@ -1,0 +1,204 @@
+{
+  "$defs": {
+    "inputWithBody": {
+      "instillUIOrder": 0,
+      "properties": {
+        "body": {
+          "description": "The request body",
+          "instillShortDescription": "The request body",
+          "instillUIOrder": 1,
+          "oneOf": [
+            {
+              "properties": {
+                "body_type": {
+                  "const": "NONE",
+                  "description": "No request body",
+                  "instillUIOrder": 0,
+                  "order": 0,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "body_type"
+              ],
+              "title": "None",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "body_data": {
+                  "description": "The request body data",
+                  "instillAcceptFormats": [
+                    "*/*"
+                  ],
+                  "instillShortDescription": "The request body data",
+                  "instillUIOrder": 1,
+                  "instillUpstreamTypes": [
+                    "value",
+                    "reference"
+                  ],
+                  "order": 1,
+                  "required": [],
+                  "title": "Body Data",
+                  "type": "object"
+                },
+                "body_type": {
+                  "const": "RAW_JSON",
+                  "description": "Raw JSON Request body",
+                  "instillUIOrder": 0,
+                  "order": 0,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "body_type",
+                "body_data"
+              ],
+              "title": "Raw JSON",
+              "type": "object"
+            }
+          ],
+          "order": 1,
+          "required": [
+            "body_type"
+          ],
+          "title": "Body",
+          "type": "object"
+        },
+        "endpoint_path": {
+          "description": "The API endpoint path relative to the base URL",
+          "instillAcceptFormats": [
+            "string",
+            "text/*"
+          ],
+          "instillUIOrder": 0,
+          "instillUpstreamTypes": [
+            "value",
+            "reference",
+            "template"
+          ],
+          "title": "Endpoint Path",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "Input",
+      "type": "object"
+    },
+    "inputWithoutBody": {
+      "instillUIOrder": 0,
+      "properties": {
+        "endpoint_path": {
+          "description": "The API endpoint path relative to the base URL",
+          "instillAcceptFormats": [
+            "string",
+            "text/*"
+          ],
+          "instillUIOrder": 0,
+          "instillUpstreamTypes": [
+            "value",
+            "reference",
+            "template"
+          ],
+          "title": "Endpoint Path",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "Input",
+      "type": "object"
+    },
+    "output": {
+      "description": "The HTTP response from the API",
+      "instillUIOrder": 0,
+      "properties": {
+        "body": {
+          "description": "The body of the response",
+          "instillFormat": "*/*",
+          "instillUIOrder": 1,
+          "required": [],
+          "title": "Body",
+          "type": "object"
+        },
+        "header": {
+          "description": "The HTTP header of the response",
+          "instillFormat": "*/*",
+          "instillUIOrder": 2,
+          "required": [],
+          "title": "Header",
+          "type": "object"
+        },
+        "status_code": {
+          "description": "The HTTP status code of the response",
+          "instillFormat": "integer",
+          "instillUIOrder": 0,
+          "title": "Status Code",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "status_code",
+        "body",
+        "header"
+      ],
+      "title": "Output",
+      "type": "object"
+    }
+  },
+  "TASK_DELETE": {
+    "input": {
+      "$ref": "#/$defs/inputWithBody"
+    },
+    "output": {
+      "$ref": "#/$defs/output"
+    }
+  },
+  "TASK_GET": {
+    "input": {
+      "$ref": "#/$defs/inputWithoutBody"
+    },
+    "output": {
+      "$ref": "#/$defs/output"
+    }
+  },
+  "TASK_HEAD": {
+    "input": {
+      "$ref": "#/$defs/inputWithoutBody"
+    },
+    "output": {
+      "$ref": "#/$defs/output"
+    }
+  },
+  "TASK_OPTIONS": {
+    "input": {
+      "$ref": "#/$defs/inputWithBody"
+    },
+    "output": {
+      "$ref": "#/$defs/output"
+    }
+  },
+  "TASK_PATCH": {
+    "input": {
+      "$ref": "#/$defs/inputWithBody"
+    },
+    "output": {
+      "$ref": "#/$defs/output"
+    }
+  },
+  "TASK_POST": {
+    "input": {
+      "$ref": "#/$defs/inputWithBody"
+    },
+    "output": {
+      "$ref": "#/$defs/output"
+    }
+  },
+  "TASK_PUT": {
+    "input": {
+      "$ref": "#/$defs/inputWithBody"
+    },
+    "output": {
+      "$ref": "#/$defs/output"
+    }
+  }
+}

--- a/pkg/restapi/main.go
+++ b/pkg/restapi/main.go
@@ -1,0 +1,166 @@
+package restapi
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/gofrs/uuid"
+	"github.com/instill-ai/component/pkg/base"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
+)
+
+const (
+	taskGet     = "TASK_GET"
+	taskPost    = "TASK_POST"
+	taskPatch   = "TASK_PATCH"
+	taskPut     = "TASK_PUT"
+	taskDelete  = "TASK_DELETE"
+	taskHead    = "TASK_HEAD"
+	taskOptions = "TASK_OPTIONS"
+)
+
+//go:embed config/definitions.json
+var definitionsJSON []byte
+
+//go:embed config/tasks.json
+var tasksJSON []byte
+
+var once sync.Once
+var connector base.IConnector
+
+type Connector struct {
+	base.Connector
+}
+
+type Execution struct {
+	base.Execution
+}
+
+func Init(logger *zap.Logger) base.IConnector {
+	once.Do(func() {
+		connector = &Connector{
+			Connector: base.Connector{
+				Component: base.Component{Logger: logger},
+			},
+		}
+		err := connector.LoadConnectorDefinitions(definitionsJSON, tasksJSON, nil)
+		if err != nil {
+			logger.Fatal(err.Error())
+		}
+	})
+	return connector
+}
+
+func (c *Connector) CreateExecution(defUID uuid.UUID, task string, config *structpb.Struct, logger *zap.Logger) (base.IExecution, error) {
+	e := &Execution{}
+	e.Execution = base.CreateExecutionHelper(e, c, defUID, task, config, logger)
+	return e, nil
+}
+
+func getBaseURL(config *structpb.Struct) string {
+	return config.GetFields()["base_url"].GetStringValue()
+}
+
+func getAuthentication(config *structpb.Struct) (Authentication, error) {
+	auth := config.GetFields()["authentication"].GetStructValue()
+	authType := auth.GetFields()["auth_type"].GetStringValue()
+
+	switch authType {
+	case string(NoAuthType):
+		authStruct := NoAuth{}
+		err := base.ConvertFromStructpb(auth, &authStruct)
+		if err != nil {
+			return nil, err
+		}
+		return authStruct, nil
+	case string(BasicAuthType):
+		authStruct := BasicAuth{}
+		err := base.ConvertFromStructpb(auth, &authStruct)
+		if err != nil {
+			return nil, err
+		}
+		return authStruct, nil
+	case string(APIKeyType):
+		authStruct := APIKeyAuth{}
+		err := base.ConvertFromStructpb(auth, &authStruct)
+		if err != nil {
+			return nil, err
+		}
+		return authStruct, nil
+	case string(BearerTokenType):
+		authStruct := BearerTokenAuth{}
+		err := base.ConvertFromStructpb(auth, &authStruct)
+		if err != nil {
+			return nil, err
+		}
+		return authStruct, nil
+	default:
+		return nil, errors.New("invalid authentication type")
+	}
+}
+
+func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+
+	client, err := NewClient(e.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	outputs := []*structpb.Struct{}
+	for _, input := range inputs {
+		var method string
+		inputStruct := TaskInput{}
+		switch e.Task {
+		case taskGet:
+			method = http.MethodGet
+		case taskPost:
+			method = http.MethodPost
+		case taskPatch:
+			method = http.MethodPatch
+		case taskPut:
+			method = http.MethodPut
+		case taskDelete:
+			method = http.MethodDelete
+		case taskHead:
+			method = http.MethodHead
+		case taskOptions:
+			method = http.MethodOptions
+		default:
+			return nil, fmt.Errorf("not supported task: %s", e.Task)
+		}
+
+		err := base.ConvertFromStructpb(input, &inputStruct)
+		if err != nil {
+			return nil, err
+		}
+		outputStruct, err := client.sendRequest(method, inputStruct)
+		if err != nil {
+			return nil, err
+		}
+		output, err := base.ConvertToStructpb(outputStruct)
+		if err != nil {
+			return nil, err
+		}
+		outputs = append(outputs, output)
+	}
+	return outputs, nil
+}
+
+func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (connectorPB.ConnectorResource_State, error) {
+	client, err := NewClient(config)
+	if err != nil {
+		return connectorPB.ConnectorResource_STATE_ERROR, err
+	}
+	_, err = client.sendRequest(http.MethodGet, TaskInput{})
+	if err != nil {
+		return connectorPB.ConnectorResource_STATE_ERROR, err
+	}
+	return connectorPB.ConnectorResource_STATE_CONNECTED, nil
+
+}

--- a/pkg/restapi/main.go
+++ b/pkg/restapi/main.go
@@ -12,7 +12,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
-	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
 )
 
 const (
@@ -152,15 +152,15 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (connectorPB.ConnectorResource_State, error) {
+func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 	client, err := NewClient(config)
 	if err != nil {
-		return connectorPB.ConnectorResource_STATE_ERROR, err
+		return pipelinePB.Connector_STATE_ERROR, err
 	}
 	_, err = client.sendRequest(http.MethodGet, TaskInput{})
 	if err != nil {
-		return connectorPB.ConnectorResource_STATE_ERROR, err
+		return pipelinePB.Connector_STATE_ERROR, err
 	}
-	return connectorPB.ConnectorResource_STATE_CONNECTED, nil
+	return pipelinePB.Connector_STATE_CONNECTED, nil
 
 }


### PR DESCRIPTION
Because

A REST API connector has been introduced to enable users to connect to their APIs and retrieve data.

This commit

- add REST API connector
  - support `raw JSON` body type
  - support `GET`/`POST`/`PATCH`/`PUT`/`DELETE`/`HEAD`/`OPTIONS` operations

However, please be aware of the following limitations in the current component configuration:

- it does not support `form-data`, `x-www-form-urlencoded`, `binary`, or `GraphQL` body types
- headers, cookies, and query parameters in the request are not supported.
- the response body must be a JSON object `{}`. Otherwise, triggering the pipeline will result in an error.
