### PR TITLE
chore(deps): adopt latest proto and component pkgs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/h2non/filetype v1.1.3
-	github.com/instill-ai/component v0.7.0-alpha
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231107112239-e910edf62911
+	github.com/instill-ai/component v0.7.0-alpha.0.20231121165153-d69c0e07286c
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231121163720-206d6eff20a7
 	github.com/redis/go-redis/v9 v9.3.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -121,10 +121,10 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
-github.com/instill-ai/component v0.7.0-alpha h1:kuiIrPFutxhosq6XohkKAg5svAfLtYoBD0KGvM5bt0c=
-github.com/instill-ai/component v0.7.0-alpha/go.mod h1:JDVDbZby6njJS2ioy2ptD3RhC4CuKWJKsWBg0PtQWK4=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231107112239-e910edf62911 h1:8ywlej8tx+TVKO13T/v9zuaNoqQi7ZMIGG4/wB58xYs=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231107112239-e910edf62911/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
+github.com/instill-ai/component v0.7.0-alpha.0.20231121165153-d69c0e07286c h1:FFxkE1197A3LF4mu++VjHEnOKLCk6Qx8S9B5lgpHPN0=
+github.com/instill-ai/component v0.7.0-alpha.0.20231121165153-d69c0e07286c/go.mod h1:GgpdzmunwTzpZh4Fxrb8MPpBRm1Yl7kdCED2ph2O3tA=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231121163720-206d6eff20a7 h1:vhMCJLPhVvhINR31VgOyq5ct8f7TZx2ZteQXpjGwaEc=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231121163720-206d6eff20a7/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/asmfmt v1.3.2 h1:4Ri7ox3EwapiOjCki+hw14RyKk201CN4rzyCJRFLpK4=

--- a/pkg/bigquery/main.go
+++ b/pkg/bigquery/main.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 
-	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
 )
 
 const (
@@ -114,15 +114,15 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (connectorPB.ConnectorResource_State, error) {
+func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 
 	client, err := NewClient(getJSONKey(config), getProjectID(config))
 	if err != nil || client == nil {
-		return connectorPB.ConnectorResource_STATE_ERROR, fmt.Errorf("error creating BigQuery client: %v", err)
+		return pipelinePB.Connector_STATE_ERROR, fmt.Errorf("error creating BigQuery client: %v", err)
 	}
 	defer client.Close()
 	if client.Project() == getProjectID(config) {
-		return connectorPB.ConnectorResource_STATE_CONNECTED, nil
+		return pipelinePB.Connector_STATE_CONNECTED, nil
 	}
-	return connectorPB.ConnectorResource_STATE_DISCONNECTED, errors.New("project ID does not match")
+	return pipelinePB.Connector_STATE_DISCONNECTED, errors.New("project ID does not match")
 }

--- a/pkg/googlecloudstorage/main.go
+++ b/pkg/googlecloudstorage/main.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 
-	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
 )
 
 const (
@@ -115,15 +115,15 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (connectorPB.ConnectorResource_State, error) {
+func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 
 	client, err := NewClient(getJSONKey(config))
 	if err != nil {
-		return connectorPB.ConnectorResource_STATE_ERROR, fmt.Errorf("error creating GCS client: %v", err)
+		return pipelinePB.Connector_STATE_ERROR, fmt.Errorf("error creating GCS client: %v", err)
 	}
 	if client == nil {
-		return connectorPB.ConnectorResource_STATE_DISCONNECTED, fmt.Errorf("GCS client is nil")
+		return pipelinePB.Connector_STATE_DISCONNECTED, fmt.Errorf("GCS client is nil")
 	}
 	defer client.Close()
-	return connectorPB.ConnectorResource_STATE_CONNECTED, nil
+	return pipelinePB.Connector_STATE_CONNECTED, nil
 }

--- a/pkg/googlesearch/main.go
+++ b/pkg/googlesearch/main.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 
-	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
 )
 
 const (
@@ -119,14 +119,14 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (connectorPB.ConnectorResource_State, error) {
+func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 
 	service, err := NewService(getAPIKey(config))
 	if err != nil || service == nil {
-		return connectorPB.ConnectorResource_STATE_ERROR, fmt.Errorf("error creating Google custom search service: %v", err)
+		return pipelinePB.Connector_STATE_ERROR, fmt.Errorf("error creating Google custom search service: %v", err)
 	}
 	if service == nil {
-		return connectorPB.ConnectorResource_STATE_ERROR, fmt.Errorf("error creating Google custom search service: %v", err)
+		return pipelinePB.Connector_STATE_ERROR, fmt.Errorf("error creating Google custom search service: %v", err)
 	}
-	return connectorPB.ConnectorResource_STATE_CONNECTED, nil
+	return pipelinePB.Connector_STATE_CONNECTED, nil
 }

--- a/pkg/huggingface/common.go
+++ b/pkg/huggingface/common.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
 )
 
 const (
@@ -94,15 +94,15 @@ func checkRespForError(respJSON []byte) error {
 	return nil
 }
 
-func (c *Client) GetConnectionState() (connectorPB.ConnectorResource_State, error) {
+func (c *Client) GetConnectionState() (pipelinePB.Connector_State, error) {
 	req, _ := http.NewRequest(http.MethodGet, c.BaseURL, nil)
 	req.Header.Set(AuthHeaderKey, AuthHeaderPrefix+c.APIKey)
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return connectorPB.ConnectorResource_STATE_ERROR, err
+		return pipelinePB.Connector_STATE_ERROR, err
 	}
 	if resp != nil && resp.StatusCode == http.StatusOK {
-		return connectorPB.ConnectorResource_STATE_CONNECTED, nil
+		return pipelinePB.Connector_STATE_CONNECTED, nil
 	}
-	return connectorPB.ConnectorResource_STATE_DISCONNECTED, nil
+	return pipelinePB.Connector_STATE_DISCONNECTED, nil
 }

--- a/pkg/huggingface/main.go
+++ b/pkg/huggingface/main.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 
-	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
 )
 
 const (
@@ -633,7 +633,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (connectorPB.ConnectorResource_State, error) {
+func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 	client := NewClient(getAPIKey(config), getBaseURL(config), isCustomEndpoint(config))
 	return client.GetConnectionState()
 }

--- a/pkg/instill/config/tasks.json
+++ b/pkg/instill/config/tasks.json
@@ -175,6 +175,7 @@
           "type": "string"
         },
         "max_new_tokens": {
+          "default": 50,
           "description": "The maximum number of tokens for model to generate",
           "instillAcceptFormats": [
             "integer"
@@ -184,7 +185,6 @@
             "value",
             "reference"
           ],
-          "default": 50,
           "title": "Max new tokens",
           "type": "integer"
         },
@@ -260,11 +260,11 @@
           "type": "string"
         },
         "temperature": {
+          "default": 0.7,
           "description": "The temperature for sampling",
           "instillAcceptFormats": [
             "number"
           ],
-          "default": 0.7,
           "instillUIOrder": 5,
           "instillUpstreamTypes": [
             "value",
@@ -274,11 +274,11 @@
           "type": "number"
         },
         "top_k": {
+          "default": 10,
           "description": "Top k for sampling",
           "instillAcceptFormats": [
             "integer"
           ],
-          "default": 10,
           "instillUIOrder": 5,
           "instillUpstreamTypes": [
             "value",

--- a/pkg/instill/main.go
+++ b/pkg/instill/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/instill-ai/component/pkg/base"
 
 	commonPB "github.com/instill-ai/protogen-go/common/task/v1alpha"
-	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
 )
 
 const (
@@ -184,10 +184,10 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return result, err
 }
 
-func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (connectorPB.ConnectorResource_State, error) {
+func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 	err := getModels(config)
 	if err != nil {
-		return connectorPB.ConnectorResource_STATE_ERROR, err
+		return pipelinePB.Connector_STATE_ERROR, err
 	}
-	return connectorPB.ConnectorResource_STATE_CONNECTED, nil
+	return pipelinePB.Connector_STATE_CONNECTED, nil
 }

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -20,7 +20,7 @@ import (
 	"github.com/instill-ai/connector/pkg/redis"
 	"github.com/instill-ai/connector/pkg/stabilityai"
 
-	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
 )
 
 var once sync.Once
@@ -72,6 +72,6 @@ func (c *Connector) CreateExecution(defUID uuid.UUID, task string, config *struc
 	return c.connectorUIDMap[defUID].CreateExecution(defUID, task, config, logger)
 }
 
-func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (connectorPB.ConnectorResource_State, error) {
+func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 	return c.connectorUIDMap[defUid].Test(defUid, config, logger)
 }

--- a/pkg/numbers/main.go
+++ b/pkg/numbers/main.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 
-	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
 )
 
 const ApiUrlPin = "https://eoqctv92ahgrcif.m.pipedream.net"
@@ -335,11 +335,11 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 
 }
 
-func (con *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (connectorPB.ConnectorResource_State, error) {
+func (con *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 
 	req, err := http.NewRequest("GET", ApiUrlMe, nil)
 	if err != nil {
-		return connectorPB.ConnectorResource_STATE_ERROR, nil
+		return pipelinePB.Connector_STATE_ERROR, nil
 	}
 	req.Header.Set("Authorization", getToken(config))
 
@@ -352,10 +352,10 @@ func (con *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *za
 		defer res.Body.Close()
 	}
 	if err != nil {
-		return connectorPB.ConnectorResource_STATE_ERROR, nil
+		return pipelinePB.Connector_STATE_ERROR, nil
 	}
 	if res.StatusCode == http.StatusOK {
-		return connectorPB.ConnectorResource_STATE_CONNECTED, nil
+		return pipelinePB.Connector_STATE_CONNECTED, nil
 	}
-	return connectorPB.ConnectorResource_STATE_ERROR, nil
+	return pipelinePB.Connector_STATE_ERROR, nil
 }

--- a/pkg/openai/main.go
+++ b/pkg/openai/main.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 
-	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
 )
 
 const (
@@ -357,14 +357,14 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (connectorPB.ConnectorResource_State, error) {
+func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 	client := NewClient(getAPIKey(config), getOrg(config))
 	models, err := client.ListModels()
 	if err != nil {
-		return connectorPB.ConnectorResource_STATE_ERROR, err
+		return pipelinePB.Connector_STATE_ERROR, err
 	}
 	if len(models.Data) == 0 {
-		return connectorPB.ConnectorResource_STATE_DISCONNECTED, nil
+		return pipelinePB.Connector_STATE_DISCONNECTED, nil
 	}
-	return connectorPB.ConnectorResource_STATE_CONNECTED, nil
+	return pipelinePB.Connector_STATE_CONNECTED, nil
 }

--- a/pkg/pinecone/main.go
+++ b/pkg/pinecone/main.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 
-	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
 )
 
 const (
@@ -171,7 +171,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (connectorPB.ConnectorResource_State, error) {
+func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 	//TODO: change this
-	return connectorPB.ConnectorResource_STATE_CONNECTED, nil
+	return pipelinePB.Connector_STATE_CONNECTED, nil
 }

--- a/pkg/redis/main.go
+++ b/pkg/redis/main.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 
-	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
 )
 
 const (
@@ -138,14 +138,14 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (connectorPB.ConnectorResource_State, error) {
+func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 	client := NewClient(getHost(config), getPort(config), getUsername(config), getPassword(config))
 	defer client.Close()
 
 	// Ping the Redis server to check the connection
 	_, err := client.Ping(context.Background()).Result()
 	if err != nil {
-		return connectorPB.ConnectorResource_STATE_DISCONNECTED, err
+		return pipelinePB.Connector_STATE_DISCONNECTED, err
 	}
-	return connectorPB.ConnectorResource_STATE_CONNECTED, nil
+	return pipelinePB.Connector_STATE_CONNECTED, nil
 }

--- a/pkg/stabilityai/main.go
+++ b/pkg/stabilityai/main.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 
-	connectorPB "github.com/instill-ai/protogen-go/vdp/connector/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
 )
 
 const (
@@ -239,16 +239,16 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (connectorPB.ConnectorResource_State, error) {
+func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 	client := NewClient(getAPIKey(config))
 	engines, err := client.ListEngines()
 	if err != nil {
-		return connectorPB.ConnectorResource_STATE_ERROR, err
+		return pipelinePB.Connector_STATE_ERROR, err
 	}
 	if len(engines) == 0 {
-		return connectorPB.ConnectorResource_STATE_DISCONNECTED, nil
+		return pipelinePB.Connector_STATE_DISCONNECTED, nil
 	}
-	return connectorPB.ConnectorResource_STATE_CONNECTED, nil
+	return pipelinePB.Connector_STATE_CONNECTED, nil
 }
 
 // decode if the string is base64 encoded


### PR DESCRIPTION
Because

- we are going to retire the connector-backend

This commit

- adopt latest protos and component pkgs for retiring connector-backend
