### PR TITLE
chore(all): use snake_case for all input variable naming style

### DIFF
--- a/pkg/airbyte/config/tasks.json
+++ b/pkg/airbyte/config/tasks.json
@@ -8,7 +8,7 @@
           "instillShortDescription": "The data to be written into the destination",
           "instillUIOrder": 0,
           "patternProperties": {
-            "^[a-zA-Z_][a-zA-Z_0-9]*$": {
+            "^[a-z_][a-z_0-9]{0,31}$": {
               "instillAcceptFormats": [
                 "*"
               ],

--- a/pkg/bigquery/config/tasks.json
+++ b/pkg/bigquery/config/tasks.json
@@ -8,7 +8,7 @@
           "instillShortDescription": "The data to be inserted to BigQuery",
           "instillUIOrder": 0,
           "patternProperties": {
-            "^[a-zA-Z_][a-zA-Z_0-9]*$": {
+            "^[a-z_][a-z_0-9]{0,31}$": {
               "instillAcceptFormats": [
                 "*"
               ],


### PR DESCRIPTION
Because

- we need to standardize the naming style of all ID

This commit

- use snake_case for all input variable naming style
