### PR TITLE
fix(stability-ai): add default weight for stable-diffusion-xl-1024-v1-0

### DIFF
--- a/pkg/stabilityai/config/tasks.json
+++ b/pkg/stabilityai/config/tasks.json
@@ -210,7 +210,7 @@
           "title": "Style Preset"
         },
         "weights": {
-          "description": "An array of weights to use for generation.",
+          "description": "An array of weights to use for generation. If unspecified, the model will automatically assign a default weight of 1.0 to each prompt.",
           "instillAcceptFormats": [
             "array:number",
             "array:integer"

--- a/pkg/stabilityai/main.go
+++ b/pkg/stabilityai/main.go
@@ -153,6 +153,9 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 			for index, t := range inputStruct.Prompts {
 				if inputStruct.Weights != nil && len(*inputStruct.Weights) > index {
 					w = (*inputStruct.Weights)[index]
+				} else {
+					// If weights are not provided, set all weights to 1.0
+					w = 1.0
 				}
 				req.TextPrompts = append(req.TextPrompts, TextPrompt{Text: t, Weight: &w})
 			}


### PR DESCRIPTION
Because

The usage of the `stable-diffusion-xl-1024-v1-0` engine without specifying weights for the prompts results in nonsensical image generation, stemming from the prompt weights defaulting to 0.

This commit

- assign a default weight of `1.0` when no weights are specified.
