### PR TITLE
chore(restapi): disable POST/PATCH/PUT/DELETE/OPTIONS methods

### DIFF
--- a/pkg/restapi/config/definitions.json
+++ b/pkg/restapi/config/definitions.json
@@ -2,12 +2,7 @@
   {
     "available_tasks": [
       "TASK_GET",
-      "TASK_POST",
-      "TASK_PATCH",
-      "TASK_PUT",
-      "TASK_DELETE",
-      "TASK_HEAD",
-      "TASK_OPTIONS"
+      "TASK_HEAD"
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/data-connectors/restapi",

--- a/pkg/restapi/config/tasks.json
+++ b/pkg/restapi/config/tasks.json
@@ -81,7 +81,7 @@
           "type": "string"
         }
       },
-      "required": [],
+      "required": ["endpoint_path"],
       "title": "Input",
       "type": "object"
     },
@@ -104,7 +104,7 @@
           "type": "string"
         }
       },
-      "required": [],
+      "required": ["endpoint_path"],
       "title": "Input",
       "type": "object"
     },


### PR DESCRIPTION
Because

- we haven't coordinated the JSON data format in other components yet.

This commit

- disable POST/PATCH/PUT/DELETE/OPTIONS methods temporarily
