### PR TITLE
refactor(schema): refactor `structured/*` and `semi-structured/*`

### DIFF
--- a/pkg/googlesearch/config/tasks.json
+++ b/pkg/googlesearch/config/tasks.json
@@ -86,8 +86,7 @@
         "query": {
           "description": "The search query for Google",
           "instillAcceptFormats": [
-            "string",
-            "text/*"
+            "string"
           ],
           "instillUIMultiline": true,
           "instillUIOrder": 0,

--- a/pkg/instill/config/tasks.json
+++ b/pkg/instill/config/tasks.json
@@ -65,7 +65,7 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/6032b6ce48ed84f907578f4a3d3aa1223680f10d/schema.json#/$defs/instill_types/classification",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/cdccadb78d0cd4551a43379924824c2b1b2bdfb9/schema.json#/$defs/instill_types/classification",
       "description": "Output",
       "instillUIOrder": 0,
       "title": "Output",
@@ -78,7 +78,7 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/6032b6ce48ed84f907578f4a3d3aa1223680f10d/schema.json#/$defs/instill_types/detection",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/cdccadb78d0cd4551a43379924824c2b1b2bdfb9/schema.json#/$defs/instill_types/detection",
       "description": "Output",
       "instillUIOrder": 0,
       "title": "Output",
@@ -91,7 +91,7 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/6032b6ce48ed84f907578f4a3d3aa1223680f10d/schema.json#/$defs/instill_types/instance_segmentation",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/cdccadb78d0cd4551a43379924824c2b1b2bdfb9/schema.json#/$defs/instill_types/instance_segmentation",
       "description": "Output",
       "instillUIOrder": 0,
       "title": "Output",
@@ -104,7 +104,7 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/6032b6ce48ed84f907578f4a3d3aa1223680f10d/schema.json#/$defs/instill_types/keypoint",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/cdccadb78d0cd4551a43379924824c2b1b2bdfb9/schema.json#/$defs/instill_types/keypoint",
       "description": "Output",
       "instillUIOrder": 0,
       "title": "Output",
@@ -117,7 +117,7 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/6032b6ce48ed84f907578f4a3d3aa1223680f10d/schema.json#/$defs/instill_types/ocr",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/cdccadb78d0cd4551a43379924824c2b1b2bdfb9/schema.json#/$defs/instill_types/ocr",
       "description": "Output",
       "instillUIOrder": 0,
       "title": "Output",
@@ -130,7 +130,7 @@
       "type": "object"
     },
     "output": {
-      "$ref": "https://raw.githubusercontent.com/instill-ai/component/6032b6ce48ed84f907578f4a3d3aa1223680f10d/schema.json#/$defs/instill_types/semantic_segmentation",
+      "$ref": "https://raw.githubusercontent.com/instill-ai/component/cdccadb78d0cd4551a43379924824c2b1b2bdfb9/schema.json#/$defs/instill_types/semantic_segmentation",
       "description": "Output",
       "instillUIOrder": 0,
       "title": "Output",

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/instill-ai/connector/pkg/openai"
 	"github.com/instill-ai/connector/pkg/pinecone"
 	"github.com/instill-ai/connector/pkg/redis"
+	"github.com/instill-ai/connector/pkg/restapi"
 	"github.com/instill-ai/connector/pkg/stabilityai"
 	"github.com/instill-ai/connector/pkg/website"
 
@@ -55,7 +56,7 @@ func Init(logger *zap.Logger, options ConnectorOptions) base.IConnector {
 		connector.(*Connector).ImportDefinitions(googlesearch.Init(logger))
 		connector.(*Connector).ImportDefinitions(pinecone.Init(logger))
 		connector.(*Connector).ImportDefinitions(redis.Init(logger))
-		// connector.(*Connector).ImportDefinitions(restapi.Init(logger))
+		connector.(*Connector).ImportDefinitions(restapi.Init(logger))
 		connector.(*Connector).ImportDefinitions(website.Init(logger))
 
 	})

--- a/pkg/redis/config/tasks.json
+++ b/pkg/redis/config/tasks.json
@@ -56,8 +56,7 @@
         "session_id": {
           "description": "A unique identifier for the chat session",
           "instillAcceptFormats": [
-            "string",
-            "text/*"
+            "string"
           ],
           "instillUIOrder": 0,
           "instillUpstreamTypes": [
@@ -102,8 +101,7 @@
         "content": {
           "description": "The message content",
           "instillAcceptFormats": [
-            "string",
-            "text/*"
+            "string"
           ],
           "instillUIMultiline": true,
           "instillUIOrder": 2,
@@ -126,8 +124,7 @@
         "role": {
           "description": "The message role, i.e. 'system', 'user' or 'assistant'",
           "instillAcceptFormats": [
-            "string",
-            "text/*"
+            "string"
           ],
           "instillUIOrder": 1,
           "instillUpstreamTypes": [
@@ -141,8 +138,7 @@
         "session_id": {
           "description": "A unique identifier for the chat session",
           "instillAcceptFormats": [
-            "string",
-            "text/*"
+            "string"
           ],
           "instillUIOrder": 0,
           "instillUpstreamTypes": [

--- a/pkg/restapi/config/definitions.json
+++ b/pkg/restapi/config/definitions.json
@@ -2,13 +2,18 @@
   {
     "available_tasks": [
       "TASK_GET",
-      "TASK_HEAD"
+      "TASK_POST",
+      "TASK_PATCH",
+      "TASK_PUT",
+      "TASK_DELETE",
+      "TASK_HEAD",
+      "TASK_OPTIONS"
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/data-connectors/restapi",
     "icon": "restapi.svg",
     "icon_url": "",
-    "id": "data-restapi",
+    "id": "restapi",
     "public": true,
     "spec": {
       "resource_specification": {

--- a/pkg/restapi/config/tasks.json
+++ b/pkg/restapi/config/tasks.json
@@ -68,8 +68,7 @@
         "endpoint_path": {
           "description": "The API endpoint path relative to the base URL",
           "instillAcceptFormats": [
-            "string",
-            "text/*"
+            "string"
           ],
           "instillUIOrder": 0,
           "instillUpstreamTypes": [
@@ -91,8 +90,7 @@
         "endpoint_path": {
           "description": "The API endpoint path relative to the base URL",
           "instillAcceptFormats": [
-            "string",
-            "text/*"
+            "string"
           ],
           "instillUIOrder": 0,
           "instillUpstreamTypes": [
@@ -114,7 +112,7 @@
       "properties": {
         "body": {
           "description": "The body of the response",
-          "instillFormat": "*/*",
+          "instillFormat": "semi-structured/object",
           "instillUIOrder": 1,
           "required": [],
           "title": "Body",
@@ -122,7 +120,7 @@
         },
         "header": {
           "description": "The HTTP header of the response",
-          "instillFormat": "*/*",
+          "instillFormat": "semi-structured/object",
           "instillUIOrder": 2,
           "required": [],
           "title": "Header",

--- a/pkg/website/config/tasks.json
+++ b/pkg/website/config/tasks.json
@@ -108,8 +108,7 @@
         "target_url": {
           "description": "The root URL to scrape. All links on this page will be scraped, and all links on those pages, and so on.",
           "instillAcceptFormats": [
-            "string",
-            "text/*"
+            "string"
           ],
           "instillUIMultiline": true,
           "instillUIOrder": 0,


### PR DESCRIPTION
Because

- we need to mark instillFormat in the array item as well
- we need a new instillFormat for object type data

This commit

- refactor instillFormat `structured/*`
- add `semi-structured/object` format for json object data
