### PR TITLE
chore(openai): remove system message maxLength limitation

### DIFF
--- a/pkg/openai/config/tasks.json
+++ b/pkg/openai/config/tasks.json
@@ -336,7 +336,6 @@
             "reference",
             "template"
           ],
-          "maxLength": 2048,
           "title": "System message",
           "type": "string"
         },


### PR DESCRIPTION
Because

- we don't need to set message maxLength in OpenAI connector

This commit

- remove system message maxLength limitation
