### PR TITLE
feat: Improve error messages in connector execution #311 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@
 *.DS_STORE
 #Goland
 .idea
-#Test files
-pkg/test_artifacts/

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/h2non/filetype v1.1.3
 	github.com/instill-ai/component v0.8.0-beta
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231212091117-ca798a0535d1
+	github.com/instill-ai/x v0.3.0-alpha.0.20231219052200-6230a89e386c
 	github.com/redis/go-redis/v9 v9.3.0
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.26.0

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/allegro/bigcache v1.2.1
 	github.com/docker/docker v24.0.7+incompatible
+	github.com/frankban/quicktest v1.14.6
 	github.com/gabriel-vasile/mimetype v1.4.3
 	github.com/gocolly/colly/v2 v2.1.0
 	github.com/gofrs/uuid v4.4.0+incompatible
@@ -51,6 +52,7 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/flatbuffers v2.0.8+incompatible // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/google/uuid v1.4.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
@@ -60,6 +62,8 @@ require (
 	github.com/klauspost/asmfmt v1.3.2 // indirect
 	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lestrrat-go/jspointer v0.0.0-20181205001929-82fadba7561c // indirect
 	github.com/lestrrat-go/jsref v0.0.0-20211028120858-c0bcbb5abf20 // indirect
 	github.com/lestrrat-go/option v1.0.0 // indirect
@@ -74,6 +78,7 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/temoto/robotstxt v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,8 @@ github.com/instill-ai/component v0.8.0-beta h1:xXePzuaKhh9RjSnmo6mZE4QD8OkaAuWVx
 github.com/instill-ai/component v0.8.0-beta/go.mod h1:fWyVPJVJ4WyFSQMgWCc7KvcS7m9QpdS3VXCL2CZE8OY=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231212091117-ca798a0535d1 h1:3UyjuBjas7U7aTtuEWdSB/xp8E2ec2FHH2WNwzD/chE=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231212091117-ca798a0535d1/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
+github.com/instill-ai/x v0.3.0-alpha.0.20231219052200-6230a89e386c h1:a2RVkpIV2QcrGnSHAou+t/L+vBsaIfFvk5inVg5Uh4s=
+github.com/instill-ai/x v0.3.0-alpha.0.20231219052200-6230a89e386c/go.mod h1:L6jmDPrUou6XskaLXZuK/gDeitdoPa9yE8ONKt1ZwCw=
 github.com/jawher/mow.cli v1.1.0/go.mod h1:aNaQlc7ozF3vw6IJ2dHjp2ZFiA4ozMIYY6PyuRJwlUg=
 github.com/kennygrant/sanitize v1.2.4 h1:gN25/otpP5vAsO2djbMhF/LQX6R7+O1TB4yv8NzpJ3o=
 github.com/kennygrant/sanitize v1.2.4/go.mod h1:LGsjYYtgxbetdg5owWB2mpgUL6e2nfw2eObZ0u0qvak=

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,7 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -76,6 +77,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
+github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
@@ -122,6 +125,7 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/martian/v3 v3.3.2 h1:IqNFLAmvJOgVlpdEBiQbDc2EwKW77amAycfTuWKdfvw=
@@ -155,8 +159,8 @@ github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHU
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
-github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -185,6 +189,7 @@ github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrB
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/pierrec/lz4/v4 v4.1.15 h1:MO0/ucJhngq7299dKLwIMtgTfbkoSPF6AoMYDd8Q4q0=
 github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/huggingface/main.go
+++ b/pkg/huggingface/main.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/pkg/base"
+	"github.com/instill-ai/connector/pkg/util"
 
 	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
@@ -69,12 +70,7 @@ type Client struct {
 	APIKey           string
 	BaseURL          string
 	IsCustomEndpoint bool
-	HTTPClient       HTTPClient
-}
-
-// HTTPClient interface
-type HTTPClient interface {
-	Do(req *http.Request) (*http.Response, error)
+	HTTPClient       util.HTTPClient
 }
 
 func Init(logger *zap.Logger) base.IConnector {

--- a/pkg/instill/main.go
+++ b/pkg/instill/main.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/pkg/base"
+	"github.com/instill-ai/connector/pkg/util"
 
 	commonPB "github.com/instill-ai/protogen-go/common/task/v1alpha"
 	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
@@ -49,12 +50,7 @@ type Execution struct {
 type Client struct {
 	APIKey     string
 	JwtSub     string
-	HTTPClient HTTPClient
-}
-
-// HTTPClient interface
-type HTTPClient interface {
-	Do(req *http.Request) (*http.Response, error)
+	HTTPClient util.HTTPClient
 }
 
 func Init(logger *zap.Logger) base.IConnector {

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -4,468 +4,63 @@
 package pkg
 
 import (
-	"encoding/base64"
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"net/http"
 	"testing"
 
+	qt "github.com/frankban/quicktest"
+	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/pkg/base"
-	"github.com/instill-ai/connector/pkg/huggingface"
 	"github.com/instill-ai/connector/pkg/openai"
-	"github.com/instill-ai/connector/pkg/stabilityai"
+	"github.com/instill-ai/x/errmsg"
 )
 
 var (
-	stabilityAIKey = "<valid api key>"
-	openAIKey      = "<valid api key>"
-	huggingFaceKey = "<valid api key>"
-	hfCon          base.IExecution
-	hfConfig       *structpb.Struct
-	jsonKey        []byte
-	gcsCon         base.IExecution
+	// TODO read keys from env variables and check for valid response.
+	openAIKey = "invalid-key"
+	openAIOrg = "no-such-org"
+
+	emptyOptions = ConnectorOptions{}
 )
 
-func init() {
-
-	b, _ := ioutil.ReadFile("test_artifacts/open_ai.txt")
-	openAIKey = string(b)
-	b, _ = ioutil.ReadFile("test_artifacts/stability_ai.txt")
-	stabilityAIKey = string(b)
-	b, _ = ioutil.ReadFile("test_artifacts/hugging_face.txt")
-	huggingFaceKey = string(b)
-	hfConfig = &structpb.Struct{
-		Fields: map[string]*structpb.Value{
-			"api_key":            {Kind: &structpb.Value_StringValue{StringValue: huggingFaceKey}},
-			"base_url":           {Kind: &structpb.Value_StringValue{StringValue: "https://api-inference.huggingface.co"}},
-			"is_custom_endpoint": {Kind: &structpb.Value_BoolValue{BoolValue: false}},
-		}}
-	c := Init(nil)
-	hfCon, _ = c.CreateExecution(c.ListDefinitionUids()[3], hfConfig, nil)
-
-	jsonKey, _ = ioutil.ReadFile("test_artifacts/gcp_key.json")
-	gcsConfig := &structpb.Struct{
-		Fields: map[string]*structpb.Value{
-			"json_key":    {Kind: &structpb.Value_StringValue{StringValue: string(jsonKey)}},
-			"bucket_name": {Kind: &structpb.Value_StringValue{StringValue: "gcs-connector-sjne"}},
-		}}
-	logger, _ = zap.NewDevelopment()
-	c := Init(logger, ConnectorOptions{})
-	uuid := c.ListDefinitionUids()
-	gcsCon, _ = c.CreateExecution(uuid[len(uuid)-1], gcsConfig, nil)
-
-}
-
-func TestStabilityAITextToImage(t *testing.T) {
-	config := &structpb.Struct{
-		Fields: map[string]*structpb.Value{
-			"api_key": {Kind: &structpb.Value_StringValue{StringValue: stabilityAIKey}},
-		},
-	}
-	inputStruct := stabilityai.TextToImageInput{
-		Task:    "TASK_TEXT_TO_IMAGE",
-		Prompts: []string{"black", "dog"},
-		Engine:  "stable-diffusion-v1-5",
-	}
-	in, err := base.ConvertToStructpb(inputStruct)
-	fmt.Printf("err:%s", err)
-	c := Init(nil)
-	con, err := c.CreateExecution(c.ListDefinitionUids()[0], config, nil)
-	fmt.Printf("err:%s", err)
-	op, err := con.Execute([]*structpb.Struct{in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
-
-func Test_ListEngines(t *testing.T) {
-	client := stabilityai.NewClient(stabilityAIKey)
-	engines, err := client.ListEngines()
-	fmt.Printf("engines: %v, err: %v", engines, err)
-}
-
-func TestStabilityAIImageToImage(t *testing.T) {
-	config := &structpb.Struct{
-		Fields: map[string]*structpb.Value{
-			"api_key": {Kind: &structpb.Value_StringValue{StringValue: stabilityAIKey}},
-		},
-	}
-	b, _ := ioutil.ReadFile("test_artifacts/image.jpg")
-	inputStruct := stabilityai.ImageToImageInput{
-		Task:      "TASK_IMAGE_TO_IMAGE",
-		Engine:    "stable-diffusion-v1",
-		Prompts:   []string{"invert colors"},
-		InitImage: base64.StdEncoding.EncodeToString(b),
-	}
-	in, err := base.ConvertToStructpb(inputStruct)
-	fmt.Printf("err:%s", err)
-	c := Init(nil)
-	con, err := c.CreateExecution(c.ListDefinitionUids()[0], config, nil)
-	fmt.Printf("\n err: %s", err)
-	op, err := con.Execute([]*structpb.Struct{in})
-	fmt.Printf("\n op: %v, err: %s", op, err)
-	l := op[0].Fields["images"].GetListValue()
-	b, _ = stabilityai.DecodeBase64(l.Values[0].GetStringValue())
-	err = ioutil.WriteFile("test_artifacts/image_op.png", b, 0644)
-}
-
 func TestOpenAITextGeneration(t *testing.T) {
-	config := &structpb.Struct{Fields: map[string]*structpb.Value{"api_key": {Kind: &structpb.Value_StringValue{StringValue: openAIKey}}}}
-	inputStruct := openai.TextCompletionInput{Prompt: "how are you doing?", Model: "gpt-3.5-turbo"}
-	in, err := base.ConvertToStructpb(inputStruct)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "TASK_TEXT_GENERATION"}}
-	fmt.Printf("err:%s", err)
-	c := Init(nil)
-	con, err := c.CreateExecution(c.ListDefinitionUids()[2], config, nil)
-	fmt.Printf("err:%s", err)
-	op, err := con.Execute([]*structpb.Struct{in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
+	c := qt.New(t)
 
-func Test_ListModels(t *testing.T) {
-	c := openai.Client{
-		APIKey:     openAIKey,
-		HTTPClient: &http.Client{},
-	}
-	res, err := c.ListModels()
-	fmt.Printf("res: %v, err: %v", res, err)
-}
+	config, err := structpb.NewStruct(map[string]any{
+		"api_key":      openAIKey,
+		"organization": openAIOrg,
+	})
+	c.Assert(err, qt.IsNil)
 
-func TestOpenAIAudioTranscription(t *testing.T) {
-	config := &structpb.Struct{
-		Fields: map[string]*structpb.Value{
-			"api_key": {Kind: &structpb.Value_StringValue{StringValue: openAIKey}},
-		},
-	}
-	b, _ := ioutil.ReadFile("test_artifacts/recording.m4a")
-	inputStruct := openai.AudioTranscriptionInput{
-		Audio: base64.StdEncoding.EncodeToString(b),
-		Model: "whisper-1",
-	}
-	in, err := base.ConvertToStructpb(inputStruct)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "TASK_SPEECH_RECOGNITION"}}
-	fmt.Printf("err:%s", err)
-	c := Init(nil)
-	con, err := c.CreateExecution(c.ListDefinitionUids()[2], config, nil)
-	fmt.Printf("err:%s", err)
-	op, err := con.Execute([]*structpb.Struct{in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
+	in, err := base.ConvertToStructpb(openai.TextCompletionInput{
+		Prompt: "how are you doing?",
+		Model:  "gpt-3.5-turbo",
+	})
+	c.Assert(err, qt.IsNil)
 
-func TestGetConnectionState(t *testing.T) {
-	c := Init(nil)
-	state, err := c.Test(c.ListDefinitionUids()[3], hfConfig, nil)
-	fmt.Printf("\n state: %v, err: %v", state, err)
-}
+	logger := zap.NewNop()
+	conn := Init(logger, emptyOptions)
 
-func TestHuggingFaceTextToImage(t *testing.T) {
-	req := huggingface.TextToImageRequest{Inputs: "a black dog"}
-	var in structpb.Struct
-	b, _ := json.Marshal(req)
-	protojson.Unmarshal(b, &in)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "TEXT_TO_IMAGE"}}
-	in.Fields["model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "runwayml/stable-diffusion-v1-5"}}
-	op, err := hfCon.Execute([]*structpb.Struct{&in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
+	def, err := conn.GetConnectorDefinitionByID("openai")
+	c.Assert(err, qt.IsNil)
 
-func TestHuggingFaceFillMask(t *testing.T) {
-	req := huggingface.FillMaskRequest{Inputs: "The answer to the universe is [MASK]."}
-	var in structpb.Struct
-	b, _ := json.Marshal(req)
-	protojson.Unmarshal(b, &in)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "FILL_MASK"}}
-	in.Fields["model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "bert-base-uncased"}}
-	op, err := hfCon.Execute([]*structpb.Struct{&in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
+	uid, err := uuid.FromString(def.GetUid())
+	c.Assert(err, qt.IsNil)
 
-func TestHuggingFaceSummarization(t *testing.T) {
-	req := huggingface.SummarizationRequest{Inputs: "The tower is 324 metres (1,063 ft) tall, about the same height as an 81-storey building, and the tallest structure in Paris. Its base is square, measuring 125 metres (410 ft) on each side. During its construction, the Eiffel Tower surpassed the Washington Monument to become the tallest man-made structure in the world, a title it held for 41 years until the Chrysler Building in New York City was finished in 1930. It was the first structure to reach a height of 300 metres. Due to the addition of a broadcasting aerial at the top of the tower in 1957, it is now taller than the Chrysler Building by 5.2 metres (17 ft). Excluding transmitters, the Eiffel Tower is the second tallest free-standing structure in France after the Millau Viaduct."}
-	var in structpb.Struct
-	b, _ := json.Marshal(req)
-	protojson.Unmarshal(b, &in)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "SUMMARIZATION"}}
-	in.Fields["model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "facebook/bart-large-cnn"}}
-	op, err := hfCon.Execute([]*structpb.Struct{&in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
+	exec, err := conn.CreateExecution(uid, "TASK_TEXT_GENERATION", config, logger)
+	c.Assert(err, qt.IsNil)
 
-func TestHuggingFaceTextClassification(t *testing.T) {
-	req := huggingface.TextClassificationRequest{Inputs: "I like you. I love you"}
-	var in structpb.Struct
-	b, _ := json.Marshal(req)
-	protojson.Unmarshal(b, &in)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "TEXT_CLASSIFICATION"}}
-	in.Fields["model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "distilbert-base-uncased-finetuned-sst-2-english"}}
-	op, err := hfCon.Execute([]*structpb.Struct{&in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
+	op, err := exec.Execute([]*structpb.Struct{in})
 
-func TestHuggingFaceTextGeneration(t *testing.T) {
-	req := huggingface.TextClassificationRequest{Inputs: "The answer to the universe is"}
-	var in structpb.Struct
-	b, _ := json.Marshal(req)
-	protojson.Unmarshal(b, &in)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "TEXT_GENERATION"}}
-	in.Fields["model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "gpt2"}}
-	op, err := hfCon.Execute([]*structpb.Struct{&in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
+	// This assumes invalid API credentials that trigger a 401 API error. We
+	// should check for valid behaviour in integration tests, although
+	// validating the format of error messages can also be useful to detect
+	// breaking changes in the API.
+	c.Check(err, qt.ErrorMatches, "unsuccessful response from openAI")
+	c.Check(errmsg.Message(err), qt.Matches, ".*Incorrect API key provided.*")
 
-func TestHuggingFaceTokenClassification(t *testing.T) {
-	req := huggingface.TextClassificationRequest{Inputs: "My name is Sarah Jessica Parker but you can call me Jessica"}
-	var in structpb.Struct
-	b, _ := json.Marshal(req)
-	protojson.Unmarshal(b, &in)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "TOKEN_CLASSIFICATION"}}
-	in.Fields["model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "dbmdz/bert-large-cased-finetuned-conll03-english"}}
-	op, err := hfCon.Execute([]*structpb.Struct{&in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
-
-func TestHuggingFaceTranslation(t *testing.T) {
-	req := huggingface.TranslationRequest{Inputs: "Меня зовут Вольфганг и я живу в Берлине"}
-	var in structpb.Struct
-	b, _ := json.Marshal(req)
-	protojson.Unmarshal(b, &in)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "TRANSLATION"}}
-	in.Fields["model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "Helsinki-NLP/opus-mt-ru-en"}}
-	op, err := hfCon.Execute([]*structpb.Struct{&in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
-
-func TestHuggingFaceZeroShotClassification(t *testing.T) {
-	req := huggingface.ZeroShotRequest{
-		Inputs:     "Hi, I recently bought a device from your company but it is not working as advertised and I would like to get reimbursed!",
-		Parameters: huggingface.ZeroShotParameters{CandidateLabels: []string{"refund", "legal", "faq"}},
-	}
-	var in structpb.Struct
-	b, _ := json.Marshal(req)
-	protojson.Unmarshal(b, &in)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "ZERO_SHOT_CLASSIFICATION"}}
-	in.Fields["model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "facebook/bart-large-mnli"}}
-	op, err := hfCon.Execute([]*structpb.Struct{&in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
-
-func TestHuggingFaceFeatureExtraction(t *testing.T) {
-	req := huggingface.FeatureExtractionRequest{Inputs: "I love programming"}
-	var in structpb.Struct
-	b, _ := json.Marshal(req)
-	protojson.Unmarshal(b, &in)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "FEATURE_EXTRACTION"}}
-	in.Fields["model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "facebook/bart-large"}}
-	op, err := hfCon.Execute([]*structpb.Struct{&in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
-
-func TestHuggingFaceQuestionAnswering(t *testing.T) {
-	req := huggingface.QuestionAnsweringRequest{
-		Inputs: huggingface.QuestionAnsweringInputs{
-			Question: "What is my name?",
-			Context:  "My name is Clara and I live in Berkeley.",
-		}}
-	var in structpb.Struct
-	b, _ := json.Marshal(req)
-	protojson.Unmarshal(b, &in)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "QUESTION_ANSWERING"}}
-	in.Fields["model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "deepset/roberta-base-squad2"}}
-	op, err := hfCon.Execute([]*structpb.Struct{&in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
-
-func TestHuggingFaceTableQuestionAnswering(t *testing.T) {
-	req := huggingface.TableQuestionAnsweringRequest{
-		Inputs: huggingface.TableQuestionAnsweringInputs{
-			Query: "How many stars does the transformers repository have?",
-			Table: map[string][]string{
-				"Repository":           {"Transformers", "Datasets", "Tokenizers"},
-				"Stars":                {"36542", "4512", "3934"},
-				"Contributors":         {"651", "77", "34"},
-				"Programming language": {"Python", "Python", "Rust, Python and NodeJS"},
-			},
-		}}
-	var in structpb.Struct
-	b, _ := json.Marshal(req)
-	protojson.Unmarshal(b, &in)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "TABLE_QUESTION_ANSWERING"}}
-	in.Fields["model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "google/tapas-base-finetuned-wtq"}}
-	op, err := hfCon.Execute([]*structpb.Struct{&in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
-
-func TestHuggingFaceSentenceSimilarity(t *testing.T) {
-	req := huggingface.SentenceSimilarityRequest{
-		Inputs: huggingface.SentenceSimilarityInputs{
-			SourceSentence: "That is a happy person",
-			Sentences:      []string{"That is a happy dog", "That is a very happy person", "Today is a sunny day"},
-		},
-	}
-	var in structpb.Struct
-	b, _ := json.Marshal(req)
-	protojson.Unmarshal(b, &in)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "SENTENCE_SIMILARITY"}}
-	in.Fields["model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "sentence-transformers/all-MiniLM-L6-v2"}}
-	op, err := hfCon.Execute([]*structpb.Struct{&in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
-
-func TestHuggingFaceConversational(t *testing.T) {
-	req := huggingface.ConversationalRequest{
-		Inputs: huggingface.ConverstationalInputs{
-			Text:               "Can you explain why ?",
-			GeneratedResponses: []string{"It is Die Hard for sure."},
-			PastUserInputs:     []string{"Which movie is the best ?"},
-		},
-	}
-	var in structpb.Struct
-	b, _ := json.Marshal(req)
-	protojson.Unmarshal(b, &in)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "CONVERSATIONAL"}}
-	in.Fields["model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "microsoft/DialoGPT-large"}}
-	op, err := hfCon.Execute([]*structpb.Struct{&in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
-
-func TestHuggingFaceImageClassification(t *testing.T) {
-	b, _ := ioutil.ReadFile("test_artifacts/image.jpg")
-	req := huggingface.ImageRequest{Image: base64.StdEncoding.EncodeToString(b)}
-	var in structpb.Struct
-	b, _ = json.Marshal(req)
-	protojson.Unmarshal(b, &in)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "IMAGE_CLASSIFICATION"}}
-	in.Fields["model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "google/vit-base-patch16-224"}}
-	op, err := hfCon.Execute([]*structpb.Struct{&in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
-
-func TestHuggingFaceImageSegmentation(t *testing.T) {
-	b, _ := ioutil.ReadFile("test_artifacts/image.jpg")
-	req := huggingface.ImageRequest{Image: base64.StdEncoding.EncodeToString(b)}
-	var in structpb.Struct
-	b, _ = json.Marshal(req)
-	protojson.Unmarshal(b, &in)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "IMAGE_SEGMENTATION"}}
-	in.Fields["model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "facebook/detr-resnet-50-panoptic"}}
-	op, err := hfCon.Execute([]*structpb.Struct{&in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
-
-func TestHuggingFaceObjectDetection(t *testing.T) {
-	b, _ := ioutil.ReadFile("test_artifacts/image.jpg")
-	req := huggingface.ImageRequest{Image: base64.StdEncoding.EncodeToString(b)}
-	var in structpb.Struct
-	b, _ = json.Marshal(req)
-	protojson.Unmarshal(b, &in)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "OBJECT_DETECTION"}}
-	in.Fields["model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "facebook/detr-resnet-50"}}
-	op, err := hfCon.Execute([]*structpb.Struct{&in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
-
-func TestHuggingFaceImageToText(t *testing.T) {
-	b, _ := ioutil.ReadFile("test_artifacts/image.jpg")
-	req := huggingface.ImageRequest{Image: base64.StdEncoding.EncodeToString(b)}
-	var in structpb.Struct
-	b, _ = json.Marshal(req)
-	protojson.Unmarshal(b, &in)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "IMAGE_TO_TEXT"}}
-	in.Fields["model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "nlpconnect/vit-gpt2-image-captioning"}}
-	op, err := hfCon.Execute([]*structpb.Struct{&in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
-
-func TestHuggingFaceSpeechRecognition(t *testing.T) {
-	b, _ := ioutil.ReadFile("test_artifacts/recording.m4a")
-	req := huggingface.AudioRequest{Audio: base64.StdEncoding.EncodeToString(b)}
-	var in structpb.Struct
-	b, _ = json.Marshal(req)
-	protojson.Unmarshal(b, &in)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "SPEECH_RECOGNITION"}}
-	in.Fields["model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "facebook/wav2vec2-base-960h"}}
-	op, err := hfCon.Execute([]*structpb.Struct{&in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
-
-func TestHuggingFaceAudioClassification(t *testing.T) {
-	b, _ := ioutil.ReadFile("test_artifacts/recording.m4a")
-	req := huggingface.AudioRequest{Audio: base64.StdEncoding.EncodeToString(b)}
-	var in structpb.Struct
-	b, _ = json.Marshal(req)
-	protojson.Unmarshal(b, &in)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "AUDIO_CLASSIFICATION"}}
-	in.Fields["model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "superb/hubert-large-superb-er"}}
-	op, err := hfCon.Execute([]*structpb.Struct{&in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
-
-func TestHuggingFaceCustomEndpointImageClassification(t *testing.T) {
-	hfCustomConfig := &structpb.Struct{
-		Fields: map[string]*structpb.Value{
-			"api_key":            {Kind: &structpb.Value_StringValue{StringValue: huggingFaceKey}},
-			"base_url":           {Kind: &structpb.Value_StringValue{StringValue: "valid URL here"}},
-			"is_custom_endpoint": {Kind: &structpb.Value_BoolValue{BoolValue: true}},
-		}}
-	c := Init(nil)
-	hfCustomCon, _ := c.CreateExecution(c.ListDefinitionUids()[3], hfCustomConfig, nil)
-
-	b, _ := ioutil.ReadFile("test_artifacts/image.jpg")
-	req := huggingface.ImageRequest{Image: base64.StdEncoding.EncodeToString(b)}
-	var in structpb.Struct
-	b, _ = json.Marshal(req)
-	protojson.Unmarshal(b, &in)
-	in.Fields["task"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "IMAGE_CLASSIFICATION"}}
-	in.Fields["model"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: ""}}
-	op, err := hfCustomCon.Execute([]*structpb.Struct{&in})
-	fmt.Printf("\n op :%v, err:%s", op, err)
-}
-
-func TestGCSUpload(*testing.T) {
-	objectName := "test_dog_img.jpg"
-	fileContents, _ := ioutil.ReadFile("test_artifacts/dog.jpg")
-	base64Str := base64.StdEncoding.EncodeToString(fileContents)
-	input := []*structpb.Struct{{
-		Fields: map[string]*structpb.Value{
-			"task":        {Kind: &structpb.Value_StringValue{StringValue: "TASK_UPLOAD"}},
-			"object_name": {Kind: &structpb.Value_StringValue{StringValue: objectName}},
-			"data":        {Kind: &structpb.Value_StringValue{StringValue: base64Str}},
-		}}}
-	op, err := gcsCon.Execute(input)
-	fmt.Printf("op: %v, err: %v", op, err)
-}
-
-func TestBigQueryInsert(*testing.T) {
-	bigQueryConfig := &structpb.Struct{
-		Fields: map[string]*structpb.Value{
-			"json_key":   {Kind: &structpb.Value_StringValue{StringValue: string(jsonKey)}},
-			"project_id": {Kind: &structpb.Value_StringValue{StringValue: "prj-c-connector-879a"}},
-			"dataset_id": {Kind: &structpb.Value_StringValue{StringValue: "test_data_set"}},
-			"table_name": {Kind: &structpb.Value_StringValue{StringValue: "test_table"}},
-		}}
-
-	logger, _ = zap.NewDevelopment()
-	c := Init(logger, ConnectorOptions{})
-	uuids := c.ListDefinitionUids()
-	uuid := uuids[len(uuids)-2]
-	bigQueryCon, _ := c.CreateExecution(uuid, bigQueryConfig, nil)
-	state, err := c.Test(uuid, bigQueryConfig, nil)
-	fmt.Printf("state: %v, err: %v", state, err)
-	input := []*structpb.Struct{{
-		Fields: map[string]*structpb.Value{
-			"task": {Kind: &structpb.Value_StringValue{StringValue: "TASK_INSERT"}},
-			"input": {Kind: &structpb.Value_StructValue{
-				StructValue: &structpb.Struct{
-					Fields: map[string]*structpb.Value{
-						"id":   {Kind: &structpb.Value_NumberValue{NumberValue: 5}},
-						"name": {Kind: &structpb.Value_StringValue{StringValue: "Tobias"}},
-					},
-				},
-			}},
-		}}}
-	op, err := bigQueryCon.Execute(input)
-	fmt.Printf("op: %v, err: %v", op, err)
+	c.Logf("op: %v", op)
+	c.Logf("err: %v", err)
+	c.Log("end-user err:", errmsg.MessageOrErr(err))
 }

--- a/pkg/openai/main.go
+++ b/pkg/openai/main.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/pkg/base"
+	"github.com/instill-ai/connector/pkg/util"
 
 	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
@@ -57,12 +58,7 @@ type Execution struct {
 type Client struct {
 	APIKey     string
 	Org        string
-	HTTPClient HTTPClient
-}
-
-// HTTPClient interface
-type HTTPClient interface {
-	Do(req *http.Request) (*http.Response, error)
+	HTTPClient util.HTTPClient
 }
 
 func Init(logger *zap.Logger) base.IConnector {

--- a/pkg/openai/text_generation_test.go
+++ b/pkg/openai/text_generation_test.go
@@ -1,0 +1,114 @@
+package openai
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/instill-ai/connector/pkg/util/mock"
+)
+
+func TestClient_GenerateTextCompletion(t *testing.T) {
+	c := qt.New(t)
+
+	req := TextCompletionReq{}
+	key := "test_key"
+	org := "org"
+
+	testcases := []struct {
+		name          string
+		gotStatus     int
+		gotBody       string
+		wantLogFields []string
+	}{
+		{
+			name:          "nok - 401 (unexpected response body)",
+			gotStatus:     http.StatusUnauthorized,
+			wantLogFields: []string{"url", "body", "status"},
+		},
+		{
+			name:          "nok - 401",
+			gotStatus:     http.StatusUnauthorized,
+			gotBody:       `{ "error": { "message": "Incorrect API key provided." } }`,
+			wantLogFields: []string{"url", "body", "status"},
+		},
+		{
+			name:          "nok - JSON error",
+			gotStatus:     http.StatusOK,
+			gotBody:       "{",
+			wantLogFields: []string{"url", "body"},
+		},
+	}
+
+	for _, tc := range testcases {
+		c.Run(tc.name, func(c *qt.C) {
+			httpClient := &mock.HTTPClient{
+				Output: func() (*http.Response, error) {
+					return &http.Response{
+						StatusCode: tc.gotStatus,
+						Body:       io.NopCloser(strings.NewReader(tc.gotBody)),
+					}, nil
+				},
+			}
+
+			zCore, zLogs := observer.New(zap.InfoLevel)
+			logger := zap.New(zCore)
+
+			openAIClient := &Client{
+				APIKey:     key,
+				Org:        org,
+				HTTPClient: httpClient,
+				Logger:     logger,
+			}
+			_, err := openAIClient.GenerateTextCompletion(req)
+			c.Check(err, qt.IsNotNil)
+
+			// Check relevant information is logged.
+			logs := zLogs.All()
+			c.Assert(logs, qt.HasLen, 1)
+
+			entry := logs[0].ContextMap()
+			for _, k := range tc.wantLogFields {
+				_, ok := entry[k]
+				c.Check(ok, qt.IsTrue)
+			}
+		})
+	}
+
+	c.Run("nok - client error", func(c *qt.C) {
+		httpErr := fmt.Errorf("boom")
+		httpClient := &mock.HTTPClient{
+			Output: func() (*http.Response, error) {
+				return nil, httpErr
+			},
+		}
+
+		zCore, zLogs := observer.New(zap.InfoLevel)
+		logger := zap.New(zCore)
+
+		openAIClient := &Client{
+			APIKey:     key,
+			Org:        org,
+			HTTPClient: httpClient,
+			Logger:     logger,
+		}
+
+		_, err := openAIClient.GenerateTextCompletion(req)
+		c.Check(err, qt.ErrorMatches, ".*failed to call OpenAI.*boom.*")
+
+		// Check relevant information is logged.
+		logs := zLogs.All()
+		c.Assert(logs, qt.HasLen, 1)
+
+		entry := logs[0].ContextMap()
+		c.Check(entry["error"], qt.Equals, httpErr.Error())
+		_, ok := entry["url"]
+		c.Check(ok, qt.IsTrue)
+	})
+}

--- a/pkg/pinecone/main.go
+++ b/pkg/pinecone/main.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/pkg/base"
+	"github.com/instill-ai/connector/pkg/util"
 
 	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
@@ -45,11 +46,7 @@ type Execution struct {
 
 type Client struct {
 	APIKey     string
-	HTTPClient HTTPClient
-}
-
-type HTTPClient interface {
-	Do(req *http.Request) (*http.Response, error)
+	HTTPClient util.HTTPClient
 }
 
 func Init(logger *zap.Logger) base.IConnector {

--- a/pkg/restapi/client.go
+++ b/pkg/restapi/client.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/instill-ai/connector/pkg/util"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -30,12 +31,7 @@ type TaskOutput struct {
 type Client struct {
 	BaseURL        string         `json:"base_url"`
 	Authentication Authentication `json:"authentication"`
-	HTTPClient     HTTPClient
-}
-
-// HTTPClient interface
-type HTTPClient interface {
-	Do(req *http.Request) (*http.Response, error)
+	HTTPClient     util.HTTPClient
 }
 
 func NewClient(config *structpb.Struct) (Client, error) {

--- a/pkg/stabilityai/main.go
+++ b/pkg/stabilityai/main.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/instill-ai/component/pkg/base"
+	"github.com/instill-ai/connector/pkg/util"
 
 	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
@@ -49,12 +50,7 @@ type Execution struct {
 // Client represents a Stability AI client
 type Client struct {
 	APIKey     string
-	HTTPClient HTTPClient
-}
-
-// HTTPClient interface
-type HTTPClient interface {
-	Do(req *http.Request) (*http.Response, error)
+	HTTPClient util.HTTPClient
 }
 
 func Init(logger *zap.Logger) base.IConnector {

--- a/pkg/util/helper.go
+++ b/pkg/util/helper.go
@@ -62,3 +62,8 @@ func ScrapeWebpageHTMLToMarkdown(html string) (string, error) {
 
 	return markdown, nil
 }
+
+// HTTPClient implements the Do method for HTTP requests.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}

--- a/pkg/util/mock/http_client.go
+++ b/pkg/util/mock/http_client.go
@@ -1,0 +1,21 @@
+package mock
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// HTTPClient is a mocked implementation of HTTPClient. By setting the Output
+// field, clients have control over the Do method response.
+type HTTPClient struct {
+	Output func() (*http.Response, error)
+}
+
+// Do implements the HTTPClient interface.
+func (c *HTTPClient) Do(_ *http.Request) (*http.Response, error) {
+	if c.Output == nil {
+		return nil, fmt.Errorf("http client not initialized")
+	}
+
+	return c.Output()
+}


### PR DESCRIPTION
Console errorrs are unclear and expose implementation details to no-code / low-code users.

This PR proposes a way to bubble up errors from components in a way that the end-user error is separated from the internal error information (stack, low-level details). The `sendReq` method in `pkg/openai` is modified to return human-friendly errors. https://github.com/instill-ai/pipeline-backend/pull/311 is needed to test these changes.

~The [fault](https://github.com/Southclaws/fault) package is chosen to carry out this task.~ While `fault` was chosen originally, some of the features we were using were no longer needed after refactoring the code to adapt to the use of `temporal` workflows to execute sync pipelines.

- A logger is injected in the `openai.Client` struct, so we no longer need to pass the request variables as part of the error context.
- The client doesn't know the component ID and can't attach it to the end-user message. However, because communication between temporal processes prevents error unwrapping, we can only use temporal errors to pass the end-user message.

Therefore, it was simpler to use [our own implementation](https://github.com/instill-ai/x/pull/13) of error messages, at least while the required functionality doesn't get too sofisticated.

### 🗒️ Notes

- Some coverage was added due to the rapid development in the `main` branches, which made manual testing a bit unreliable. Let me know if this is a potential change preventer and if we should focus on coverage later.
  - Additionally, the `frankban/quicktest` package was added in the tests. I'm a fan of the package but I can rework the tests with `require` in order to align with the current tests.
- Many integration tests were removed as they were outdated. They aren't being run now, if there's a reason to keep them I can revert that change.

![CleanShot 2023-12-15 at 14 45 30](https://github.com/instill-ai/pipeline-backend/assets/3977183/da89cd77-b4b8-401e-aae8-506c55ef0290)


![CleanShot 2023-12-15 at 14 44 32](https://github.com/instill-ai/pipeline-backend/assets/3977183/5512bf25-6bd6-4f64-abdd-d61ee3f35e33)