### PR TITLE
chore(deps): upgrade protobufs version to beta

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/gocolly/colly/v2 v2.1.0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/h2non/filetype v1.1.3
-	github.com/instill-ai/component v0.7.0-alpha.0.20231123142642-cdd8e3280413
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231204163044-92ce7cc80023
+	github.com/instill-ai/component v0.7.1-alpha.0.20231206035822-12eee341c80e
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231205045546-99b6fc00f67e
 	github.com/redis/go-redis/v9 v9.3.0
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -139,10 +139,10 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
-github.com/instill-ai/component v0.7.0-alpha.0.20231123142642-cdd8e3280413 h1:3Acm2vzGNhzRaMRW02SMQIvgIkN+ra5yg4XFshluNX4=
-github.com/instill-ai/component v0.7.0-alpha.0.20231123142642-cdd8e3280413/go.mod h1:GgpdzmunwTzpZh4Fxrb8MPpBRm1Yl7kdCED2ph2O3tA=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231204163044-92ce7cc80023 h1:QxE9Y/Yyw91gdyJAdvndpakGAFdGtNXyjKfvcTw0Sx8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231204163044-92ce7cc80023/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
+github.com/instill-ai/component v0.7.1-alpha.0.20231206035822-12eee341c80e h1:nhjzSXK71aB5WQEoSW3sR9OLCkKU1YlGal9lhdQJ9ao=
+github.com/instill-ai/component v0.7.1-alpha.0.20231206035822-12eee341c80e/go.mod h1:fWyVPJVJ4WyFSQMgWCc7KvcS7m9QpdS3VXCL2CZE8OY=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231205045546-99b6fc00f67e h1:n9hR63xsrYQ104bj397LwYr3hpu51nAJRYQLdy/S/I0=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20231205045546-99b6fc00f67e/go.mod h1:q/YL5TZXD9nvmJ7Rih4gY3/B2HT2+GiFdxeZp9D+yE4=
 github.com/jawher/mow.cli v1.1.0/go.mod h1:aNaQlc7ozF3vw6IJ2dHjp2ZFiA4ozMIYY6PyuRJwlUg=
 github.com/kennygrant/sanitize v1.2.4 h1:gN25/otpP5vAsO2djbMhF/LQX6R7+O1TB4yv8NzpJ3o=
 github.com/kennygrant/sanitize v1.2.4/go.mod h1:LGsjYYtgxbetdg5owWB2mpgUL6e2nfw2eObZ0u0qvak=

--- a/pkg/airbyte/main.go
+++ b/pkg/airbyte/main.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 //go:embed config/definitions.json

--- a/pkg/bigquery/main.go
+++ b/pkg/bigquery/main.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (

--- a/pkg/googlecloudstorage/main.go
+++ b/pkg/googlecloudstorage/main.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (

--- a/pkg/googlesearch/main.go
+++ b/pkg/googlesearch/main.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (

--- a/pkg/huggingface/common.go
+++ b/pkg/huggingface/common.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (

--- a/pkg/huggingface/main.go
+++ b/pkg/huggingface/main.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (

--- a/pkg/instill/main.go
+++ b/pkg/instill/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/instill-ai/component/pkg/base"
 
 	commonPB "github.com/instill-ai/protogen-go/common/task/v1alpha"
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -22,7 +22,7 @@ import (
 	"github.com/instill-ai/connector/pkg/stabilityai"
 	"github.com/instill-ai/connector/pkg/website"
 
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 var once sync.Once

--- a/pkg/numbers/main.go
+++ b/pkg/numbers/main.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const ApiUrlPin = "https://eoqctv92ahgrcif.m.pipedream.net"

--- a/pkg/openai/main.go
+++ b/pkg/openai/main.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (

--- a/pkg/pinecone/main.go
+++ b/pkg/pinecone/main.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (

--- a/pkg/redis/main.go
+++ b/pkg/redis/main.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (

--- a/pkg/restapi/main.go
+++ b/pkg/restapi/main.go
@@ -12,7 +12,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
 
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (

--- a/pkg/stabilityai/main.go
+++ b/pkg/stabilityai/main.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (

--- a/pkg/website/main.go
+++ b/pkg/website/main.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/instill-ai/component/pkg/base"
 
-	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1alpha"
+	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
 const (


### PR DESCRIPTION
Because

- we are going to release beta version of Core and VDP

This commit

- upgrade protobufs version to beta
