### PR TITLE
refactor(instill): make server_url and api_token be optional

### DIFF
--- a/pkg/instill/config/definitions.json
+++ b/pkg/instill/config/definitions.json
@@ -20,27 +20,38 @@
       "resource_specification": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": true,
-        "properties": {
-          "api_token": {
-            "description": "To access models on Instill Core/Cloud, enter your Instill Core/Cloud API Token. You can find your tokens by visiting your Console's Settings > API Tokens page.",
-            "instillCredentialField": true,
-            "instillUIOrder": 0,
-            "title": "API Token",
-            "type": "string"
+        "oneOf": [
+          {
+            "properties": {
+              "mode": {
+                "const": "Internal Mode"
+              }
+            }
           },
-          "server_url": {
-            "default": "https://api.instill.tech",
-            "description": "Base URL for the Instill Cloud API. To access models on Instill Cloud, use the base URL `https://api.instill.tech`. To access models on your local Instill Core, use the base URL `http://api-gateway:8080`.",
-            "instillUIOrder": 1,
-            "title": "Server URL",
-            "type": "string"
+          {
+            "properties": {
+              "api_token": {
+                "description": "To access models on Instill Core/Cloud, enter your Instill Core/Cloud API Token. You can find your tokens by visiting your Console's Settings > API Tokens page.",
+                "instillCredentialField": true,
+                "instillUIOrder": 0,
+                "title": "API Token",
+                "type": "string"
+              },
+              "server_url": {
+                "default": "https://api.instill.tech",
+                "description": "Base URL for the Instill Cloud API. To access models on Instill Cloud, use the base URL `https://api.instill.tech`. To access models on your local Instill Core, use the base URL `http://api-gateway:8080`.",
+                "instillUIOrder": 1,
+                "title": "Server URL",
+                "type": "string"
+              },
+              "mode": {
+                "const": "External Mode"
+              }
+            }
           }
-        },
-        "required": [
-          "api_token",
-          "server_url"
         ],
-        "title": "Instill Model Connector Resource",
+        "required": ["api_token", "server_url"],
+        "title": "Instill Model Connector",
         "type": "object"
       }
     },

--- a/pkg/instill/image_classification.go
+++ b/pkg/instill/image_classification.go
@@ -46,7 +46,7 @@ func (c *Execution) executeImageClassification(grpcClient modelPB.ModelPublicSer
 	if c.client == nil || grpcClient == nil {
 		return nil, fmt.Errorf("client not setup: %v", c.client)
 	}
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Jwt-Sub", getJwtSub(c.Config))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {

--- a/pkg/instill/instance_segmentation.go
+++ b/pkg/instill/instance_segmentation.go
@@ -44,7 +44,7 @@ func (c *Execution) executeInstanceSegmentation(grpcClient modelPB.ModelPublicSe
 	if c.client == nil || grpcClient == nil {
 		return nil, fmt.Errorf("client not setup: %v", c.client)
 	}
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Jwt-Sub", getJwtSub(c.Config))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {

--- a/pkg/instill/keypoint_detection.go
+++ b/pkg/instill/keypoint_detection.go
@@ -44,7 +44,7 @@ func (c *Execution) executeKeyPointDetection(grpcClient modelPB.ModelPublicServi
 	if c.client == nil || grpcClient == nil {
 		return nil, fmt.Errorf("client not setup: %v", c.client)
 	}
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Jwt-Sub", getJwtSub(c.Config))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {

--- a/pkg/instill/object_detection.go
+++ b/pkg/instill/object_detection.go
@@ -47,7 +47,7 @@ func (c *Execution) executeObjectDetection(grpcClient modelPB.ModelPublicService
 		return nil, fmt.Errorf("client not setup: %v", c.client)
 	}
 
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Jwt-Sub", getJwtSub(c.Config))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {

--- a/pkg/instill/ocr.go
+++ b/pkg/instill/ocr.go
@@ -40,7 +40,7 @@ func (c *Execution) executeOCR(grpcClient modelPB.ModelPublicServiceClient, mode
 		if c.client == nil || grpcClient == nil {
 			return nil, fmt.Errorf("client not setup: %v", c.client)
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Jwt-Sub", getJwtSub(c.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {

--- a/pkg/instill/semantic_segmentation.go
+++ b/pkg/instill/semantic_segmentation.go
@@ -45,7 +45,7 @@ func (c *Execution) executeSemanticSegmentation(grpcClient modelPB.ModelPublicSe
 	if c.client == nil || grpcClient == nil {
 		return nil, fmt.Errorf("client not setup: %v", c.client)
 	}
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Jwt-Sub", getJwtSub(c.Config))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {

--- a/pkg/instill/text_generation.go
+++ b/pkg/instill/text_generation.go
@@ -52,7 +52,7 @@ func (c *Execution) executeTextGeneration(grpcClient modelPB.ModelPublicServiceC
 		if c.client == nil || grpcClient == nil {
 			return nil, fmt.Errorf("client not setup: %v", c.client)
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Jwt-Sub", getJwtSub(c.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {

--- a/pkg/instill/text_to_image.go
+++ b/pkg/instill/text_to_image.go
@@ -55,7 +55,7 @@ func (c *Execution) executeTextToImage(grpcClient modelPB.ModelPublicServiceClie
 		if c.client == nil || grpcClient == nil {
 			return nil, fmt.Errorf("client not setup: %v", c.client)
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Jwt-Sub", getJwtSub(c.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {

--- a/pkg/stabilityai/config/tasks.json
+++ b/pkg/stabilityai/config/tasks.json
@@ -4,7 +4,8 @@
       "additionalProperties": false,
       "description": "Input",
       "instillEditOnNodeFields": [
-        "prompts"
+        "prompts",
+        "engine"
       ],
       "instillUIOrder": 0,
       "properties": {
@@ -223,7 +224,8 @@
         }
       },
       "required": [
-        "prompts"
+        "prompts",
+        "engine"
       ],
       "title": "Input",
       "type": "object"
@@ -237,7 +239,8 @@
       "additionalProperties": false,
       "description": "Input",
       "instillEditOnNodeFields": [
-        "prompts"
+        "prompts",
+        "engine"
       ],
       "instillUIOrder": 0,
       "properties": {
@@ -415,7 +418,8 @@
         }
       },
       "required": [
-        "prompts"
+        "prompts",
+        "engine"
       ],
       "title": "Input",
       "type": "object"


### PR DESCRIPTION
Because

- we'd want to make `server_url` and `api_token` be optional to simplify the user experience

This commit

- InstillModel: make `server_url` and `api_token` be optional
- StabilityAI: mark `engine` field as required
