### PR TITLE
feat: support metadata in Pinecone connector

### DIFF
--- a/pkg/pinecone/config/tasks.json
+++ b/pkg/pinecone/config/tasks.json
@@ -16,34 +16,6 @@
           "title": "ID",
           "type": "string"
         },
-        "include_metadata": {
-          "default": false,
-          "description": "Indicates whether metadata is included in the response as well as the IDs",
-          "instillAcceptFormats": [
-            "boolean"
-          ],
-          "instillUIOrder": 4,
-          "instillUpstreamTypes": [
-            "value",
-            "reference"
-          ],
-          "title": "Include Metadata",
-          "type": "boolean"
-        },
-        "include_values": {
-          "default": false,
-          "description": "Indicates whether vector values are included in the response",
-          "instillAcceptFormats": [
-            "boolean"
-          ],
-          "instillUIOrder": 3,
-          "instillUpstreamTypes": [
-            "value",
-            "reference"
-          ],
-          "title": "Include Values",
-          "type": "boolean"
-        },
         "namespace": {
           "description": "The namespace to query",
           "instillAcceptFormats": [
@@ -57,19 +29,6 @@
           ],
           "title": "Namespace",
           "type": "string"
-        },
-        "top_k": {
-          "description": "The number of results to return for each query",
-          "instillAcceptFormats": [
-            "integer"
-          ],
-          "instillUIOrder": 5,
-          "instillUpstreamTypes": [
-            "value",
-            "reference"
-          ],
-          "title": "Top K",
-          "type": "integer"
         },
         "vector": {
           "description": "An array of dimensions for the query vector.",
@@ -89,6 +48,62 @@
           "minItems": 1,
           "title": "Vector",
           "type": "array"
+        },
+        "filter": {
+          "description": "The filter to apply. You can use vector metadata to limit your search. See https://www.pinecone.io/docs/metadata-filtering/.",
+          "instillAcceptFormats": [
+            "semi-structured/object"
+          ],
+          "instillShortDescription": "The filter to apply on vector metadata",
+          "instillUIOrder": 3,
+          "instillUpstreamTypes": [
+            "reference"
+          ],
+          "order": 1,
+          "required": [],
+          "title": "Filter",
+          "type": "object"
+        },
+        "include_values": {
+          "default": false,
+          "description": "Indicates whether vector values are included in the response",
+          "instillAcceptFormats": [
+            "boolean"
+          ],
+          "instillUIOrder": 4,
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "title": "Include Values",
+          "type": "boolean"
+        },
+        "include_metadata": {
+          "default": false,
+          "description": "Indicates whether metadata is included in the response as well as the IDs",
+          "instillAcceptFormats": [
+            "boolean"
+          ],
+          "instillUIOrder": 5,
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "title": "Include Metadata",
+          "type": "boolean"
+        },
+        "top_k": {
+          "description": "The number of results to return for each query",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUIOrder": 6,
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "title": "Top K",
+          "type": "integer"
         }
       },
       "required": [

--- a/pkg/pinecone/config/tasks.json
+++ b/pkg/pinecone/config/tasks.json
@@ -4,7 +4,8 @@
       "instillUIOrder": 0,
       "properties": {
         "id": {
-          "description": "The unique ID of the vector to be used as a query vector",
+          "description": "The unique ID of the vector to be used as a query vector. If present, the vector parameter will be ignored.",
+          "instillShortDescription": "Query by vector ID instead of by vector",
           "instillAcceptFormats": [
             "string"
           ],

--- a/pkg/pinecone/config/tasks.json
+++ b/pkg/pinecone/config/tasks.json
@@ -207,7 +207,7 @@
             "semi-structured/object"
           ],
           "instillShortDescription": "The vector metadata",
-          "instillUIOrder": 1,
+          "instillUIOrder": 2,
           "instillUpstreamTypes": [
             "reference"
           ],

--- a/pkg/pinecone/config/tasks.json
+++ b/pkg/pinecone/config/tasks.json
@@ -18,7 +18,7 @@
         },
         "include_metadata": {
           "default": false,
-          "description": "Indicates whether metadata is included in the response as well as the ids",
+          "description": "Indicates whether metadata is included in the response as well as the IDs",
           "instillAcceptFormats": [
             "boolean"
           ],
@@ -107,7 +107,7 @@
           "items": {
             "properties": {
               "id": {
-                "description": "The id of the matched vector",
+                "description": "The ID of the matched vector",
                 "instillFormat": "string",
                 "instillUIOrder": 0,
                 "title": "ID",
@@ -116,12 +116,13 @@
               "metadata": {
                 "description": "Metadata",
                 "instillUIOrder": 3,
+                "instillFormat": "semi-structured/object",
                 "required": [],
                 "title": "Metadata",
                 "type": "object"
               },
               "score": {
-                "description": "A measure of similarity between this vector and the query vector. The higher the score, the more they are similar.",
+                "description": "A measure of similarity between this vector and the query vector. The higher the score, the more similar they are.",
                 "instillFormat": "number",
                 "instillUIOrder": 1,
                 "title": "Score",

--- a/pkg/pinecone/config/tasks.json
+++ b/pkg/pinecone/config/tasks.json
@@ -200,6 +200,21 @@
           "minItems": 1,
           "title": "Values",
           "type": "array"
+        },
+        "metadata": {
+          "description": "The vector metadata",
+          "instillAcceptFormats": [
+            "semi-structured/object"
+          ],
+          "instillShortDescription": "The vector metadata",
+          "instillUIOrder": 1,
+          "instillUpstreamTypes": [
+            "reference"
+          ],
+          "order": 1,
+          "required": [],
+          "title": "Metadata",
+          "type": "object"
         }
       },
       "required": [

--- a/pkg/pinecone/connector_test.go
+++ b/pkg/pinecone/connector_test.go
@@ -21,6 +21,20 @@ const (
 
 	upsertPath = "/vectors/upsert"
 	upsertResp = `{"upsertedCount": 1}`
+
+	queryPath = "/query"
+	queryResp = `
+{
+	"namespace": "color-schemes",
+	"matches": [
+		{
+			"id": "A",
+			"values": [ 2.23 ],
+			"metadata": { "color": "pumpkin" },
+			"score": 0.99
+		}
+	]
+}`
 )
 
 var (
@@ -29,56 +43,109 @@ var (
 		Values:   []float64{2.23},
 		Metadata: map[string]any{"color": "pumpkin"},
 	}
+	queryByVector = QueryInput{
+		Namespace:       "color-schemes",
+		TopK:            1,
+		Vector:          vectorA.Values,
+		IncludeValues:   true,
+		IncludeMetadata: true,
+	}
 )
 
 func TestConnector_Execute(t *testing.T) {
 	c := qt.New(t)
 
+	testcases := []struct {
+		name string
+
+		task     string
+		execIn   any
+		wantExec any
+
+		wantClientPath string
+		wantClientReq  any
+		clientResp     string
+	}{
+		{
+			name: "ok - upsert",
+
+			task:     taskUpsert,
+			execIn:   vectorA,
+			wantExec: UpsertOutput{RecordsUpserted: 1},
+
+			wantClientPath: upsertPath,
+			wantClientReq:  UpsertReq{Vectors: []Vector{vectorA}},
+			clientResp:     upsertResp,
+		},
+		{
+			name: "ok - query",
+
+			task:   taskQuery,
+			execIn: queryByVector,
+			wantExec: QueryResp{
+				Namespace: "color-schemes",
+				Matches: []Match{
+					{
+						Vector: vectorA,
+						Score:  0.99,
+					},
+				},
+			},
+
+			wantClientPath: queryPath,
+			wantClientReq:  QueryReq(queryByVector),
+			clientResp:     queryResp,
+		},
+	}
+
 	logger := zap.NewNop()
 	connector := Init(logger)
 
-	pineconeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		c.Check(r.URL.Path, qt.Equals, upsertPath)
-		c.Check(r.Method, qt.Equals, "POST")
+	for _, tc := range testcases {
+		c.Run(tc.name, func(c *qt.C) {
+			pineconeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// For now only POST methods are considered. When this changes,
+				// this will need to be asserted per-path.
+				c.Check(r.Method, qt.Equals, "POST")
+				c.Check(r.URL.Path, qt.Equals, tc.wantClientPath)
 
-		c.Check(r.Header.Get("Content-Type"), qt.Equals, jsonMimeType)
-		c.Check(r.Header.Get("Accept"), qt.Equals, jsonMimeType)
-		c.Check(r.Header.Get("Api-Key"), qt.Equals, pineconeKey)
+				c.Check(r.Header.Get("Content-Type"), qt.Equals, jsonMimeType)
+				c.Check(r.Header.Get("Accept"), qt.Equals, jsonMimeType)
+				c.Check(r.Header.Get("Api-Key"), qt.Equals, pineconeKey)
 
-		c.Assert(r.Body, qt.IsNotNil)
-		defer r.Body.Close()
+				c.Assert(r.Body, qt.IsNotNil)
+				defer r.Body.Close()
 
-		body, err := io.ReadAll(r.Body)
-		c.Assert(err, qt.IsNil)
-		c.Check(body, qt.JSONEquals, UpsertReq{Vectors: []Vector{vectorA}})
+				body, err := io.ReadAll(r.Body)
+				c.Assert(err, qt.IsNil)
+				c.Check(body, qt.JSONEquals, tc.wantClientReq)
 
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintln(w, upsertResp)
-	}))
-	c.Cleanup(pineconeServer.Close)
+				fmt.Fprintln(w, tc.clientResp)
+			}))
+			c.Cleanup(pineconeServer.Close)
 
-	config, err := structpb.NewStruct(map[string]any{
-		"api_key": pineconeKey,
-		"url":     pineconeServer.URL,
-	})
+			config, err := structpb.NewStruct(map[string]any{
+				"api_key": pineconeKey,
+				"url":     pineconeServer.URL,
+			})
 
-	defID := uuid.Must(uuid.NewV4())
-	exec, err := connector.CreateExecution(defID, taskUpsert, config, logger)
-	c.Assert(err, qt.IsNil)
+			defID := uuid.Must(uuid.NewV4())
+			exec, err := connector.CreateExecution(defID, tc.task, config, logger)
+			c.Assert(err, qt.IsNil)
 
-	in := vectorA
-	pbIn, err := base.ConvertToStructpb(in)
-	c.Assert(err, qt.IsNil)
+			pbIn, err := base.ConvertToStructpb(tc.execIn)
+			c.Assert(err, qt.IsNil)
 
-	out, err := exec.Execute([]*structpb.Struct{pbIn})
-	c.Check(err, qt.IsNil)
+			got, err := exec.Execute([]*structpb.Struct{pbIn})
+			c.Check(err, qt.IsNil)
 
-	c.Assert(out, qt.HasLen, 1)
-	want, err := json.Marshal(UpsertOutput{
-		RecordsUpserted: 1,
-	})
-	c.Assert(err, qt.IsNil)
-	c.Check(want, qt.JSONEquals, out[0].AsMap())
+			c.Assert(got, qt.HasLen, 1)
+			wantJSON, err := json.Marshal(tc.wantExec)
+			c.Assert(err, qt.IsNil)
+			c.Check(wantJSON, qt.JSONEquals, got[0].AsMap())
+		})
+	}
 }

--- a/pkg/pinecone/connector_test.go
+++ b/pkg/pinecone/connector_test.go
@@ -1,0 +1,84 @@
+package pinecone
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/gofrs/uuid"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/instill-ai/component/pkg/base"
+)
+
+const (
+	pineconeKey = "secret-key"
+
+	upsertPath = "/vectors/upsert"
+	upsertResp = `{"upsertedCount": 1}`
+)
+
+var (
+	vectorA = Vector{
+		ID:       "A",
+		Values:   []float64{2.23},
+		Metadata: map[string]any{"color": "pumpkin"},
+	}
+)
+
+func TestConnector_Execute(t *testing.T) {
+	c := qt.New(t)
+
+	logger := zap.NewNop()
+	connector := Init(logger)
+
+	pineconeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.URL.Path, qt.Equals, upsertPath)
+		c.Check(r.Method, qt.Equals, "POST")
+
+		c.Check(r.Header.Get("Content-Type"), qt.Equals, jsonMimeType)
+		c.Check(r.Header.Get("Accept"), qt.Equals, jsonMimeType)
+		c.Check(r.Header.Get("Api-Key"), qt.Equals, pineconeKey)
+
+		c.Assert(r.Body, qt.IsNotNil)
+		defer r.Body.Close()
+
+		body, err := io.ReadAll(r.Body)
+		c.Assert(err, qt.IsNil)
+		c.Check(body, qt.JSONEquals, UpsertReq{Vectors: []Vector{vectorA}})
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintln(w, upsertResp)
+	}))
+	c.Cleanup(pineconeServer.Close)
+
+	config, err := structpb.NewStruct(map[string]any{
+		"api_key": pineconeKey,
+		"url":     pineconeServer.URL,
+	})
+
+	defID := uuid.Must(uuid.NewV4())
+	exec, err := connector.CreateExecution(defID, taskUpsert, config, logger)
+	c.Assert(err, qt.IsNil)
+
+	in := vectorA
+	pbIn, err := base.ConvertToStructpb(in)
+	c.Assert(err, qt.IsNil)
+
+	out, err := exec.Execute([]*structpb.Struct{pbIn})
+	c.Check(err, qt.IsNil)
+
+	c.Assert(out, qt.HasLen, 1)
+	want, err := json.Marshal(UpsertOutput{
+		RecordsUpserted: 1,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Check(want, qt.JSONEquals, out[0].AsMap())
+}

--- a/pkg/pinecone/connector_test.go
+++ b/pkg/pinecone/connector_test.go
@@ -55,6 +55,14 @@ var (
 			},
 		},
 	}
+	queryByID = QueryInput{
+		Namespace:       "color-schemes",
+		TopK:            1,
+		Vector:          vectorA.Values,
+		ID:              vectorA.ID,
+		IncludeValues:   true,
+		IncludeMetadata: true,
+	}
 )
 
 func TestConnector_Execute(t *testing.T) {
@@ -83,7 +91,7 @@ func TestConnector_Execute(t *testing.T) {
 			clientResp:     upsertResp,
 		},
 		{
-			name: "ok - query",
+			name: "ok - query by vector",
 
 			task:   taskQuery,
 			execIn: queryByVector,
@@ -100,6 +108,32 @@ func TestConnector_Execute(t *testing.T) {
 			wantClientPath: queryPath,
 			wantClientReq:  QueryReq(queryByVector),
 			clientResp:     queryResp,
+		},
+		{
+			name: "ok - query by ID",
+
+			task:   taskQuery,
+			execIn: queryByID,
+			wantExec: QueryResp{
+				Namespace: "color-schemes",
+				Matches: []Match{
+					{
+						Vector: vectorA,
+						Score:  0.99,
+					},
+				},
+			},
+
+			wantClientPath: queryPath,
+			wantClientReq: QueryReq{
+				// Vector is wiped from the request.
+				Namespace:       "color-schemes",
+				TopK:            1,
+				ID:              vectorA.ID,
+				IncludeValues:   true,
+				IncludeMetadata: true,
+			},
+			clientResp: queryResp,
 		},
 	}
 

--- a/pkg/pinecone/connector_test.go
+++ b/pkg/pinecone/connector_test.go
@@ -49,6 +49,11 @@ var (
 		Vector:          vectorA.Values,
 		IncludeValues:   true,
 		IncludeMetadata: true,
+		Filter: map[string]any{
+			"color": map[string]any{
+				"$in": []string{"green", "cerulean", "pumpkin"},
+			},
+		},
 	}
 )
 

--- a/pkg/pinecone/main.go
+++ b/pkg/pinecone/main.go
@@ -132,6 +132,14 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 			if err != nil {
 				return nil, err
 			}
+
+			// Each query request can contain only one of the parameters
+			// vector, or id.
+			// Ref: https://docs.pinecone.io/reference/query
+			if inputStruct.ID != "" {
+				inputStruct.Vector = nil
+			}
+
 			url := getURL(e.Config) + "/query"
 			resp := QueryResp{}
 			err = client.sendReq(url, http.MethodPost, QueryReq(inputStruct), &resp)

--- a/pkg/pinecone/structs.go
+++ b/pkg/pinecone/structs.go
@@ -13,10 +13,10 @@ type QueryInput struct {
 type QueryReq struct {
 	Namespace       string      `json:"namespace"`
 	TopK            int64       `json:"topK"`
-	Vector          []float64   `json:"vector"`
+	Vector          []float64   `json:"vector,omitempty"`
 	IncludeValues   bool        `json:"includeValues"`
 	IncludeMetadata bool        `json:"includeMetadata"`
-	ID              string      `json:"id"`
+	ID              string      `json:"id,omitempty"`
 	Filter          interface{} `json:"filter,omitempty"`
 }
 

--- a/pkg/pinecone/structs.go
+++ b/pkg/pinecone/structs.go
@@ -24,10 +24,8 @@ type QueryResp struct {
 }
 
 type Match struct {
-	ID       string      `json:"id"`
-	Score    float64     `json:"score"`
-	Values   []float64   `json:"values"`
-	Metadata interface{} `json:"metadata,omitempty"`
+	Vector
+	Score float64 `json:"score"`
 }
 
 type UpsertReq struct {
@@ -35,8 +33,9 @@ type UpsertReq struct {
 }
 
 type Vector struct {
-	ID     string    `json:"id"`
-	Values []float64 `json:"values"`
+	ID       string      `json:"id"`
+	Values   []float64   `json:"values"`
+	Metadata interface{} `json:"metadata,omitempty"`
 }
 
 type UpsertResp struct {

--- a/pkg/pinecone/structs.go
+++ b/pkg/pinecone/structs.go
@@ -1,21 +1,23 @@
 package pinecone
 
 type QueryInput struct {
-	Namespace       string    `json:"namespace"`
-	TopK            int64     `json:"top_k"`
-	Vector          []float64 `json:"vector"`
-	IncludeValues   bool      `json:"include_values"`
-	IncludeMetadata bool      `json:"include_metadata"`
-	ID              string    `json:"id"`
+	Namespace       string      `json:"namespace"`
+	TopK            int64       `json:"top_k"`
+	Vector          []float64   `json:"vector"`
+	IncludeValues   bool        `json:"include_values"`
+	IncludeMetadata bool        `json:"include_metadata"`
+	ID              string      `json:"id"`
+	Filter          interface{} `json:"filter"`
 }
 
 type QueryReq struct {
-	Namespace       string    `json:"namespace"`
-	TopK            int64     `json:"topK"`
-	Vector          []float64 `json:"vector"`
-	IncludeValues   bool      `json:"includeValues"`
-	IncludeMetadata bool      `json:"includeMetadata"`
-	ID              string    `json:"id"`
+	Namespace       string      `json:"namespace"`
+	TopK            int64       `json:"topK"`
+	Vector          []float64   `json:"vector"`
+	IncludeValues   bool        `json:"includeValues"`
+	IncludeMetadata bool        `json:"includeMetadata"`
+	ID              string      `json:"id"`
+	Filter          interface{} `json:"filter,omitempty"`
 }
 
 type QueryResp struct {

--- a/pkg/pinecone/structs.go
+++ b/pkg/pinecone/structs.go
@@ -34,7 +34,7 @@ type UpsertReq struct {
 
 type Vector struct {
 	ID       string      `json:"id"`
-	Values   []float64   `json:"values"`
+	Values   []float64   `json:"values,omitempty"`
 	Metadata interface{} `json:"metadata,omitempty"`
 }
 


### PR DESCRIPTION
Because

- RAG pipelines lack the ability to insert / query metadata from Pinecone

This PR

- Adds a `metadata` input to the Pinecone `UPSERT` task (thx @donch1989)
- Parses the user input and sends it to Pinecone
- When the metadata flag is enabled in `QUERY` actions, the `metadata` field in a vector is shown in the output

## 🔨  QA

2 pipelines, one upserts a 3D vector with metadata and the other fetches the closest vector

![CleanShot 2023-12-27 at 15 13 57](https://github.com/instill-ai/connector/assets/3977183/b6276dfb-cb72-4bd6-a3e6-5c016310dbdc)
![CleanShot 2023-12-27 at 15 15 23](https://github.com/instill-ai/connector/assets/3977183/cfce9deb-45d5-4a28-94a8-2ffd98206c45)

```sh
> curl -X POST 'http://localhost:8080/vdp/v1beta/users/admin/pipelines/pinecone-query/trigger' \
--header 'Content-Type: application/json' \
--header "Authorization: Bearer $API_TOKEN" \
--data-raw '{"inputs":[{"coordinates":{"vector":[1.234,1,0.45]}}]}' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   236  100   182  100    54    451    133 --:--:-- --:--:-- --:--:--   585
{
  "outputs": [
    {
      "closest_match": [
        {
          "id": "b",
          "metadata": {
            "color": "magenta"
          },
          "score": 0.770666,
          "values": [
            2.234,
            9.2342,
            0.123345
          ]
        }
      ],
      "input": [
        1.234,
        1,
        0.45
      ]
    }
  ],
  "metadata": {
    "traces": {}
  }
}
```

## 🗒️ Notes

- ⏭️ Next I'll implement the query by metadata.
- I'm not the happiest with submitting this without coverage, let me know if it's a blocker for merging. At this point the functionality is more important than the coverage so I'll do ☝️first.

- I didn't manage to use directly an object input in the `start` component as metadata. However, using `{start.myObjectInput.metadata}` worked just fine. I think it has more to do with references than with the Pinecone connector, I'll check if it's an identified bug and otherwise I'll create a ticket for it.
- I could trigger the pipelines that have a JSON object as input from the canvas and the CLI but not from the pipeline view. Same CTA as the point above.

![CleanShot 2023-12-27 at 15 09 07](https://github.com/instill-ai/connector/assets/3977183/e66c8fd6-d235-4f43-bbcd-536230bdec58)