### PR TITLE
chore(instill): update header in instill connector

### DIFF
--- a/pkg/instill/image_classification.go
+++ b/pkg/instill/image_classification.go
@@ -46,7 +46,7 @@ func (c *Execution) executeImageClassification(grpcClient modelPB.ModelPublicSer
 	if c.client == nil || grpcClient == nil {
 		return nil, fmt.Errorf("client not setup: %v", c.client)
 	}
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Jwt-Sub", getJwtSub(c.Config))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {

--- a/pkg/instill/image_to_image.go
+++ b/pkg/instill/image_to_image.go
@@ -70,7 +70,7 @@ func (c *Execution) executeImageToImage(grpcClient modelPB.ModelPublicServiceCli
 		if c.client == nil || grpcClient == nil {
 			return nil, fmt.Errorf("client not setup: %v", c.client)
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Jwt-Sub", getJwtSub(c.Config))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {

--- a/pkg/instill/instance_segmentation.go
+++ b/pkg/instill/instance_segmentation.go
@@ -44,7 +44,7 @@ func (c *Execution) executeInstanceSegmentation(grpcClient modelPB.ModelPublicSe
 	if c.client == nil || grpcClient == nil {
 		return nil, fmt.Errorf("client not setup: %v", c.client)
 	}
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Jwt-Sub", getJwtSub(c.Config))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {

--- a/pkg/instill/keypoint_detection.go
+++ b/pkg/instill/keypoint_detection.go
@@ -44,7 +44,7 @@ func (c *Execution) executeKeyPointDetection(grpcClient modelPB.ModelPublicServi
 	if c.client == nil || grpcClient == nil {
 		return nil, fmt.Errorf("client not setup: %v", c.client)
 	}
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Jwt-Sub", getJwtSub(c.Config))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {

--- a/pkg/instill/main.go
+++ b/pkg/instill/main.go
@@ -48,9 +48,9 @@ type Execution struct {
 
 // Client represents an Instill Model client
 type Client struct {
-	APIKey     string
-	JwtSub     string
-	HTTPClient util.HTTPClient
+	APIKey         string
+	InstillUserUid string
+	HTTPClient     util.HTTPClient
 }
 
 func Init(logger *zap.Logger) base.IConnector {
@@ -80,7 +80,7 @@ func NewClient(config *structpb.Struct) (*Client, error) {
 		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
 		DisableKeepAlives: true,
 	}
-	return &Client{APIKey: getAPIKey(config), JwtSub: getJwtSub(config), HTTPClient: &http.Client{Timeout: reqTimeout, Transport: tr}}, nil
+	return &Client{APIKey: getAPIKey(config), InstillUserUid: getInstillUserUid(config), HTTPClient: &http.Client{Timeout: reqTimeout, Transport: tr}}, nil
 }
 
 func getMode(config *structpb.Struct) string {
@@ -90,8 +90,8 @@ func getMode(config *structpb.Struct) string {
 func getAPIKey(config *structpb.Struct) string {
 	return config.GetFields()["api_token"].GetStringValue()
 }
-func getJwtSub(config *structpb.Struct) string {
-	return config.GetFields()["instill_jwt_sub"].GetStringValue()
+func getInstillUserUid(config *structpb.Struct) string {
+	return config.GetFields()["instill_user_uid"].GetStringValue()
 }
 
 func getServerURL(config *structpb.Struct) string {
@@ -128,8 +128,8 @@ func (c *Client) sendReq(reqURL, method string, params interface{}) (err error) 
 	if c.APIKey != "" {
 		req.Header.Add("Authorization", "Bearer "+c.APIKey)
 	}
-	if c.JwtSub != "" {
-		req.Header.Add("Jwt-Sub", c.JwtSub)
+	if c.InstillUserUid != "" {
+		req.Header.Add("Instill-User-Uid", c.InstillUserUid)
 	}
 
 	http.DefaultClient.Timeout = reqTimeout

--- a/pkg/instill/object_detection.go
+++ b/pkg/instill/object_detection.go
@@ -47,7 +47,7 @@ func (c *Execution) executeObjectDetection(grpcClient modelPB.ModelPublicService
 		return nil, fmt.Errorf("client not setup: %v", c.client)
 	}
 
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Jwt-Sub", getJwtSub(c.Config))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {

--- a/pkg/instill/ocr.go
+++ b/pkg/instill/ocr.go
@@ -40,7 +40,7 @@ func (c *Execution) executeOCR(grpcClient modelPB.ModelPublicServiceClient, mode
 		if c.client == nil || grpcClient == nil {
 			return nil, fmt.Errorf("client not setup: %v", c.client)
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Jwt-Sub", getJwtSub(c.Config))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {

--- a/pkg/instill/semantic_segmentation.go
+++ b/pkg/instill/semantic_segmentation.go
@@ -45,7 +45,7 @@ func (c *Execution) executeSemanticSegmentation(grpcClient modelPB.ModelPublicSe
 	if c.client == nil || grpcClient == nil {
 		return nil, fmt.Errorf("client not setup: %v", c.client)
 	}
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Jwt-Sub", getJwtSub(c.Config))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {

--- a/pkg/instill/text_generation.go
+++ b/pkg/instill/text_generation.go
@@ -62,7 +62,7 @@ func (c *Execution) executeTextGeneration(grpcClient modelPB.ModelPublicServiceC
 		if c.client == nil || grpcClient == nil {
 			return nil, fmt.Errorf("client not setup: %v", c.client)
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Jwt-Sub", getJwtSub(c.Config))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {

--- a/pkg/instill/text_generation_chat.go
+++ b/pkg/instill/text_generation_chat.go
@@ -71,7 +71,7 @@ func (c *Execution) executeTextGenerationChat(grpcClient modelPB.ModelPublicServ
 		if c.client == nil || grpcClient == nil {
 			return nil, fmt.Errorf("client not setup: %v", c.client)
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Jwt-Sub", getJwtSub(c.Config))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {

--- a/pkg/instill/text_to_image.go
+++ b/pkg/instill/text_to_image.go
@@ -55,7 +55,7 @@ func (c *Execution) executeTextToImage(grpcClient modelPB.ModelPublicServiceClie
 		if c.client == nil || grpcClient == nil {
 			return nil, fmt.Errorf("client not setup: %v", c.client)
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Jwt-Sub", getJwtSub(c.Config))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {

--- a/pkg/instill/visual_question_answering.go
+++ b/pkg/instill/visual_question_answering.go
@@ -68,7 +68,7 @@ func (c *Execution) executeVisualQuestionAnswering(grpcClient modelPB.ModelPubli
 		if c.client == nil || grpcClient == nil {
 			return nil, fmt.Errorf("client not setup: %v", c.client)
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Jwt-Sub", getJwtSub(c.Config))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {


### PR DESCRIPTION
Because

- we have changed the header for Instill connector from `jwt-sub` to `instill-user-uid`

This commit

- update header in instill connector
