### PR TITLE
chore: update icon paths

### DIFF
--- a/pkg/airbyte/config/definitions.json
+++ b/pkg/airbyte/config/definitions.json
@@ -5,7 +5,7 @@
     ],
     "custom": false,
     "documentation_url": "https://docs.airbyte.com/integrations/destinations",
-    "icon": "airbyte.svg",
+    "icon": "Airbyte/airbyte.svg",
     "icon_url": "",
     "id": "airbyte-destination",
     "public": true,

--- a/pkg/airbyte/config/seed/generate_definitions.py
+++ b/pkg/airbyte/config/seed/generate_definitions.py
@@ -42,7 +42,7 @@ new_def = [{
     ],
     "custom": False,
     "documentation_url": "https://docs.airbyte.com/integrations/destinations",
-    "icon": "airbyte.svg",
+    "icon": "Airbyte/airbyte.svg",
     "icon_url": "",
     "id": "airbyte-destination",
     "public": True,

--- a/pkg/bigquery/config/definitions.json
+++ b/pkg/bigquery/config/definitions.json
@@ -5,7 +5,7 @@
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/data-connectors/bigquery",
-    "icon": "bigquery.svg",
+    "icon": "Google/bigquery.svg",
     "icon_url": "",
     "id": "bigquery",
     "public": true,

--- a/pkg/googlecloudstorage/config/definitions.json
+++ b/pkg/googlecloudstorage/config/definitions.json
@@ -5,7 +5,7 @@
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/data-connectors/gcs",
-    "icon": "gcs.svg",
+    "icon": "Google/gcs.svg",
     "icon_url": "",
     "id": "gcs",
     "public": true,

--- a/pkg/googlesearch/config/definitions.json
+++ b/pkg/googlesearch/config/definitions.json
@@ -5,7 +5,7 @@
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/data-connectors/google-search",
-    "icon": "google-search.svg",
+    "icon": "Google/google-search.svg",
     "icon_url": "",
     "id": "google-search",
     "public": true,

--- a/pkg/huggingface/config/definitions.json
+++ b/pkg/huggingface/config/definitions.json
@@ -21,7 +21,7 @@
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/ai-connectors/hugging-face",
-    "icon": "huggingface.svg",
+    "icon": "Hugging Face/huggingface.svg",
     "icon_url": "",
     "id": "hugging-face",
     "public": true,

--- a/pkg/instill/config/definitions.json
+++ b/pkg/instill/config/definitions.json
@@ -15,7 +15,7 @@
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/ai-connectors/instill-model",
-    "icon": "instillmodel.svg",
+    "icon": "Instill AI/instillmodel.svg",
     "icon_url": "",
     "id": "instill-model",
     "public": true,

--- a/pkg/numbers/config/definitions.json
+++ b/pkg/numbers/config/definitions.json
@@ -5,7 +5,7 @@
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/app-connectors/numbers-protocol",
-    "icon": "numbers.svg",
+    "icon": "Numbers Protocol/numbers.svg",
     "icon_url": "",
     "id": "numbers",
     "public": true,

--- a/pkg/openai/config/definitions.json
+++ b/pkg/openai/config/definitions.json
@@ -9,7 +9,7 @@
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/ai-connectors/openai",
-    "icon": "openai.svg",
+    "icon": "OpenAI/openai.svg",
     "icon_url": "",
     "id": "openai",
     "public": true,

--- a/pkg/pinecone/config/definitions.json
+++ b/pkg/pinecone/config/definitions.json
@@ -6,7 +6,7 @@
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/data-connectors/pinecone",
-    "icon": "pinecone.svg",
+    "icon": "Pinecone/pinecone.svg",
     "icon_url": "https://www.pinecone.io/favicon.ico",
     "id": "pinecone",
     "public": true,

--- a/pkg/redis/config/definitions.json
+++ b/pkg/redis/config/definitions.json
@@ -6,7 +6,7 @@
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/data-connectors/redis",
-    "icon": "redis.svg",
+    "icon": "Instill AI/redis.svg",
     "icon_url": "",
     "id": "redis",
     "public": true,

--- a/pkg/restapi/config/definitions.json
+++ b/pkg/restapi/config/definitions.json
@@ -11,7 +11,7 @@
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/data-connectors/restapi",
-    "icon": "restapi.svg",
+    "icon": "Instill AI/restapi.svg",
     "icon_url": "",
     "id": "restapi",
     "public": true,

--- a/pkg/stabilityai/config/definitions.json
+++ b/pkg/stabilityai/config/definitions.json
@@ -6,7 +6,7 @@
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/ai-connectors/stability-ai",
-    "icon": "stabilityai.svg",
+    "icon": "Stability AI/stabilityai.svg",
     "icon_url": "",
     "id": "stability-ai",
     "public": true,

--- a/pkg/website/config/definitions.json
+++ b/pkg/website/config/definitions.json
@@ -5,7 +5,7 @@
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/data-connectors/website",
-    "icon": "website.svg",
+    "icon": "Instill AI/website.svg",
     "icon_url": "",
     "id": "website",
     "public": true,


### PR DESCRIPTION
Because

- Currently, the console uses `vendor` and `id` to locate the icon image. However, there is actually an `icon` field in the definition response, and we should utilize it.

This commit

- update icon paths
