### PR TITLE
feat(instill): unify the chat_history format across different LLM tasks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,11 +16,10 @@ require (
 	github.com/gocolly/colly/v2 v2.1.0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/h2non/filetype v1.1.3
-	github.com/instill-ai/component v0.8.0-beta
+	github.com/instill-ai/component v0.8.0-beta.0.20240109061804-abed794dc3a1
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240105094938-3a71d8f7a812
 	github.com/instill-ai/x v0.3.0-alpha.0.20231219052200-6230a89e386c
 	github.com/redis/go-redis/v9 v9.3.0
-	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.26.0
 	google.golang.org/api v0.150.0
 	google.golang.org/grpc v1.59.0
@@ -79,10 +78,10 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
 	github.com/temoto/robotstxt v1.1.1 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
@@ -101,6 +100,5 @@ require (
 	google.golang.org/genproto v0.0.0-20231016165738-49dd2c1f3d0b // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20231016165738-49dd2c1f3d0b // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231030173426-d783a09b4405 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.5.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
-github.com/instill-ai/component v0.8.0-beta h1:xXePzuaKhh9RjSnmo6mZE4QD8OkaAuWVxxero6b4Kyo=
-github.com/instill-ai/component v0.8.0-beta/go.mod h1:fWyVPJVJ4WyFSQMgWCc7KvcS7m9QpdS3VXCL2CZE8OY=
+github.com/instill-ai/component v0.8.0-beta.0.20240109061804-abed794dc3a1 h1:6XOE8keNtcyqx7hTlKntbfkW3iuaSdQLrsm9fpWpe5o=
+github.com/instill-ai/component v0.8.0-beta.0.20240109061804-abed794dc3a1/go.mod h1:fWyVPJVJ4WyFSQMgWCc7KvcS7m9QpdS3VXCL2CZE8OY=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240105094938-3a71d8f7a812 h1:n1EQFT0NeXkmiCD/YtoLG+b/OPo2tNg7MVK0dHNFlvk=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240105094938-3a71d8f7a812/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
 github.com/instill-ai/x v0.3.0-alpha.0.20231219052200-6230a89e386c h1:a2RVkpIV2QcrGnSHAou+t/L+vBsaIfFvk5inVg5Uh4s=
@@ -396,8 +396,6 @@ google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/pkg/airbyte/config/definitions.json
+++ b/pkg/airbyte/config/definitions.json
@@ -18,11 +18,11 @@
             "additionalProperties": false,
             "properties": {
               "access_key": {
-                "instillCredentialField": true,
                 "description": "The Access Key ID of the AWS IAM Role to use for sending  messages",
                 "examples": [
                   "xxxxxHRNxxx3TBxxxxxx"
                 ],
+                "instillCredentialField": true,
                 "order": 3,
                 "title": "AWS IAM Access Key ID",
                 "type": "string"
@@ -101,11 +101,11 @@
                 "type": "string"
               },
               "secret_key": {
-                "instillCredentialField": true,
                 "description": "The Secret Key of the AWS IAM Role to use for sending messages",
                 "examples": [
                   "hu+qE5exxxxT6o/ZrKsxxxxxxBhxxXLexxxxxVKz"
                 ],
+                "instillCredentialField": true,
                 "order": 4,
                 "title": "AWS IAM Secret Key",
                 "type": "string"
@@ -161,8 +161,8 @@
                         "type": "string"
                       },
                       "role_arn": {
-                        "instillCredentialField": false,
                         "description": "Will assume this role to write data to s3",
+                        "instillCredentialField": false,
                         "title": "Target Role Arn",
                         "type": "string"
                       }
@@ -177,14 +177,14 @@
                   {
                     "properties": {
                       "aws_access_key_id": {
-                        "instillCredentialField": true,
                         "description": "AWS User Access Key Id",
+                        "instillCredentialField": true,
                         "title": "Access Key Id",
                         "type": "string"
                       },
                       "aws_secret_access_key": {
-                        "instillCredentialField": true,
                         "description": "Secret Access Key",
+                        "instillCredentialField": true,
                         "title": "Secret Access Key",
                         "type": "string"
                       },
@@ -384,11 +384,11 @@
             "additionalProperties": false,
             "properties": {
               "azure_blob_storage_account_key": {
-                "instillCredentialField": true,
                 "description": "The Azure blob storage account key.",
                 "examples": [
                   "Z8ZkZpteggFx394vm+PJHnGTvdRncaYS+JhLKdj789YNmD+iyGTnG+PV+POiuYNhBg/ACS+LKjd%4FG3FHGN12Nd=="
                 ],
+                "instillCredentialField": true,
                 "title": "Azure Blob Storage account key",
                 "type": "string"
               },
@@ -521,10 +521,10 @@
                 "type": "integer"
               },
               "credentials_json": {
-                "instillCredentialField": true,
                 "always_show": true,
                 "description": "The contents of the JSON service account key. Check out the <a href=\"https://docs.airbyte.com/integrations/destinations/bigquery#service-account-key\">docs</a> if you need help generating this key. Default credentials will be used if this field is left empty.",
                 "group": "connection",
+                "instillCredentialField": true,
                 "order": 4,
                 "title": "Service Account Key JSON (Required for cloud, optional for open-source)",
                 "type": "string"
@@ -620,21 +620,21 @@
                                 "type": "string"
                               },
                               "hmac_key_access_id": {
-                                "instillCredentialField": true,
                                 "description": "HMAC key access ID. When linked to a service account, this ID is 61 characters long; when linked to a user account, it is 24 characters long.",
                                 "examples": [
                                   "1234567890abcdefghij1234"
                                 ],
+                                "instillCredentialField": true,
                                 "order": 1,
                                 "title": "HMAC Key Access ID",
                                 "type": "string"
                               },
                               "hmac_key_secret": {
-                                "instillCredentialField": true,
                                 "description": "The corresponding secret for the access ID. It is a 40-character base-64 encoded string.",
                                 "examples": [
                                   "1234567890abcdefghij1234567890ABCDEFGHIJ"
                                 ],
+                                "instillCredentialField": true,
                                 "order": 2,
                                 "title": "HMAC Key Secret",
                                 "type": "string"
@@ -780,8 +780,8 @@
                 "type": "string"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "Password associated with Cassandra.",
+                "instillCredentialField": true,
                 "order": 2,
                 "title": "Password",
                 "type": "string"
@@ -878,8 +878,8 @@
                         "type": "string"
                       },
                       "openai_key": {
-                        "instillCredentialField": true,
                         "description": "The API key for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource",
+                        "instillCredentialField": true,
                         "title": "Azure OpenAI API key",
                         "type": "string"
                       }
@@ -1005,8 +1005,8 @@
                     "description": "Use a service that's compatible with the OpenAI API to embed text.",
                     "properties": {
                       "api_key": {
-                        "instillCredentialField": true,
                         "default": "",
+                        "instillCredentialField": true,
                         "title": "API key",
                         "type": "string"
                       },
@@ -1124,9 +1124,9 @@
                             "type": "string"
                           },
                           "password": {
-                            "instillCredentialField": true,
                             "default": "",
                             "description": "Password used in server/client mode only",
+                            "instillCredentialField": true,
                             "order": 4,
                             "title": "Password",
                             "type": "string"
@@ -1417,8 +1417,8 @@
                 "type": "string"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "Password associated with the username.",
+                "instillCredentialField": true,
                 "order": 4,
                 "title": "Password",
                 "type": "string"
@@ -1462,8 +1462,8 @@
                   {
                     "properties": {
                       "ssh_key": {
-                        "instillCredentialField": true,
                         "description": "OS-level user account ssh key credentials in RSA PEM format ( created with ssh-keygen -t rsa -m PEM -f myuser_rsa )",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 4,
                         "title": "SSH Private Key",
@@ -1542,8 +1542,8 @@
                         "type": "string"
                       },
                       "tunnel_user_password": {
-                        "instillCredentialField": true,
                         "description": "OS-level password for logging into the jump server host",
+                        "instillCredentialField": true,
                         "order": 4,
                         "title": "Password",
                         "type": "string"
@@ -1584,8 +1584,8 @@
             "additionalProperties": false,
             "properties": {
               "access_key": {
-                "instillCredentialField": "true",
                 "description": "API access key used to send data to a Convex deployment.",
+                "instillCredentialField": "true",
                 "type": "string"
               },
               "deployment_url": {
@@ -1711,15 +1711,15 @@
                 "type": "string"
               },
               "api_key": {
-                "instillCredentialField": true,
                 "description": "An API key generated in Cumul.io's platform (can be generated here: https://app.cumul.io/start/profile/integration).",
+                "instillCredentialField": true,
                 "order": 1,
                 "title": "Cumul.io API Key",
                 "type": "string"
               },
               "api_token": {
-                "instillCredentialField": true,
                 "description": "The corresponding API token generated in Cumul.io's platform (can be generated here: https://app.cumul.io/start/profile/integration).",
+                "instillCredentialField": true,
                 "order": 2,
                 "title": "Cumul.io API Token",
                 "type": "string"
@@ -1759,8 +1759,8 @@
                 "type": "string"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "Password associated with the username.",
+                "instillCredentialField": true,
                 "order": 6,
                 "title": "Password",
                 "type": "string"
@@ -1851,11 +1851,11 @@
                         "type": "string"
                       },
                       "s3_access_key_id": {
-                        "instillCredentialField": true,
                         "description": "The Access Key Id granting allow one to access the above S3 staging bucket. Airbyte requires Read and Write permissions to the given bucket.",
                         "examples": [
                           "A012345678910EXAMPLE"
                         ],
+                        "instillCredentialField": true,
                         "order": 5,
                         "title": "S3 Access Key ID",
                         "type": "string"
@@ -1914,11 +1914,11 @@
                         "type": "string"
                       },
                       "s3_secret_access_key": {
-                        "instillCredentialField": true,
                         "description": "The corresponding secret to the above access key id.",
                         "examples": [
                           "a012345678910ABCDEFGH/AbCdEfGhEXAMPLEKEY"
                         ],
+                        "instillCredentialField": true,
                         "order": 6,
                         "title": "S3 Secret Access Key",
                         "type": "string"
@@ -1965,11 +1965,11 @@
                         "type": "string"
                       },
                       "azure_blob_storage_sas_token": {
-                        "instillCredentialField": true,
                         "description": "Shared access signature (SAS) token to grant limited access to objects in your storage account.",
                         "examples": [
                           "?sv=2016-05-31&ss=b&srt=sco&sp=rwdl&se=2018-06-27T10:05:50Z&st=2017-06-27T02:05:50Z&spr=https,http&sig=bgqQwoXwxzuD2GJfagRg7VOS8hzNr3QLT7rhS8OFRLQ%3D"
                         ],
+                        "instillCredentialField": true,
                         "order": 4,
                         "title": "SAS Token",
                         "type": "string"
@@ -2009,11 +2009,11 @@
                 "type": "string"
               },
               "databricks_personal_access_token": {
-                "instillCredentialField": true,
                 "description": "Databricks Personal Access Token for making authenticated requests.",
                 "examples": [
                   "dapi0123456789abcdefghij0123456789AB"
                 ],
+                "instillCredentialField": true,
                 "order": 5,
                 "title": "Access Token",
                 "type": "string"
@@ -2109,8 +2109,8 @@
                 "type": "integer"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "Password associated with the username.",
+                "instillCredentialField": true,
                 "order": 5,
                 "title": "Password",
                 "type": "string"
@@ -2164,8 +2164,8 @@
                 "type": "string"
               },
               "motherduck_api_key": {
-                "instillCredentialField": true,
                 "description": "API key to use for authentication to a MotherDuck database.",
+                "instillCredentialField": true,
                 "title": "MotherDuck API Key",
                 "type": "string"
               },
@@ -2188,11 +2188,11 @@
             "additionalProperties": false,
             "properties": {
               "access_key_id": {
-                "instillCredentialField": true,
                 "description": "The access key id to access the DynamoDB. Airbyte requires Read and Write permissions to the DynamoDB.",
                 "examples": [
                   "A012345678910EXAMPLE"
                 ],
+                "instillCredentialField": true,
                 "title": "DynamoDB Key Id",
                 "type": "string"
               },
@@ -2252,11 +2252,11 @@
                 "type": "string"
               },
               "secret_access_key": {
-                "instillCredentialField": true,
                 "description": "The corresponding secret to the access key id.",
                 "examples": [
                   "a012345678910ABCDEFGH/AbCdEfGhEXAMPLEKEY"
                 ],
+                "instillCredentialField": true,
                 "title": "DynamoDB Access Key",
                 "type": "string"
               }
@@ -2512,8 +2512,8 @@
                         "type": "string"
                       },
                       "apiKeySecret": {
-                        "instillCredentialField": true,
                         "description": "The secret associated with the API Key ID.",
+                        "instillCredentialField": true,
                         "title": "API Key Secret",
                         "type": "string"
                       },
@@ -2538,8 +2538,8 @@
                         "type": "string"
                       },
                       "password": {
-                        "instillCredentialField": true,
                         "description": "Basic auth password to access a secure Elasticsearch server",
+                        "instillCredentialField": true,
                         "title": "Password",
                         "type": "string"
                       },
@@ -2561,8 +2561,8 @@
                 "type": "object"
               },
               "ca_certificate": {
-                "instillCredentialField": true,
                 "description": "CA certificate",
+                "instillCredentialField": true,
                 "multiline": true,
                 "title": "CA certificate",
                 "type": "string"
@@ -2596,8 +2596,8 @@
                   {
                     "properties": {
                       "ssh_key": {
-                        "instillCredentialField": true,
                         "description": "OS-level user account ssh key credentials in RSA PEM format ( created with ssh-keygen -t rsa -m PEM -f myuser_rsa )",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 4,
                         "title": "SSH Private Key",
@@ -2676,8 +2676,8 @@
                         "type": "string"
                       },
                       "tunnel_user_password": {
-                        "instillCredentialField": true,
                         "description": "OS-level password for logging into the jump server host",
+                        "instillCredentialField": true,
                         "order": 4,
                         "title": "Password",
                         "type": "string"
@@ -2740,8 +2740,8 @@
                 "type": "string"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "Password associated with the username.",
+                "instillCredentialField": true,
                 "order": 4,
                 "title": "Password",
                 "type": "string"
@@ -2832,14 +2832,14 @@
                     "additionalProperties": false,
                     "properties": {
                       "aws_key_id": {
-                        "instillCredentialField": true,
                         "description": "AWS access key granting read and write access to S3.",
+                        "instillCredentialField": true,
                         "title": "AWS Key ID",
                         "type": "string"
                       },
                       "aws_key_secret": {
-                        "instillCredentialField": true,
                         "description": "Corresponding secret part of the AWS Key",
+                        "instillCredentialField": true,
                         "title": "AWS Key Secret",
                         "type": "string"
                       },
@@ -2875,8 +2875,8 @@
                 "type": "object"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "Firebolt password.",
+                "instillCredentialField": true,
                 "order": 1,
                 "title": "Password",
                 "type": "string"
@@ -2905,8 +2905,8 @@
             "additionalProperties": false,
             "properties": {
               "credentials_json": {
-                "instillCredentialField": true,
                 "description": "The contents of the JSON service account key. Check out the <a href=\"https://docs.airbyte.io/integrations/destinations/firestore\">docs</a> if you need help generating this key. Default credentials will be used if this field is left empty.",
+                "instillCredentialField": true,
                 "title": "Credentials JSON",
                 "type": "string"
               },
@@ -2943,21 +2943,21 @@
                         "type": "string"
                       },
                       "hmac_key_access_id": {
-                        "instillCredentialField": true,
                         "description": "When linked to a service account, this ID is 61 characters long; when linked to a user account, it is 24 characters long. Read more <a href=\"https://cloud.google.com/storage/docs/authentication/hmackeys#overview\">here</a>.",
                         "examples": [
                           "1234567890abcdefghij1234"
                         ],
+                        "instillCredentialField": true,
                         "order": 0,
                         "title": "Access ID",
                         "type": "string"
                       },
                       "hmac_key_secret": {
-                        "instillCredentialField": true,
                         "description": "The corresponding secret for the access ID. It is a 40-character base-64 encoded string.  Read more <a href=\"https://cloud.google.com/storage/docs/authentication/hmackeys#secrets\">here</a>.",
                         "examples": [
                           "1234567890abcdefghij1234567890ABCDEFGHIJ"
                         ],
+                        "instillCredentialField": true,
                         "order": 1,
                         "title": "Secret",
                         "type": "string"
@@ -3393,20 +3393,20 @@
                 "description": "Google API Credentials for connecting to Google Sheets and Google Drive APIs",
                 "properties": {
                   "client_id": {
-                    "instillCredentialField": true,
                     "description": "The Client ID of your Google Sheets developer application.",
+                    "instillCredentialField": true,
                     "title": "Client ID",
                     "type": "string"
                   },
                   "client_secret": {
-                    "instillCredentialField": true,
                     "description": "The Client Secret of your Google Sheets developer application.",
+                    "instillCredentialField": true,
                     "title": "Client Secret",
                     "type": "string"
                   },
                   "refresh_token": {
-                    "instillCredentialField": true,
                     "description": "The token for obtaining new access token.",
+                    "instillCredentialField": true,
                     "title": "Refresh Token",
                     "type": "string"
                   }
@@ -3552,8 +3552,8 @@
                         "type": "string"
                       },
                       "password": {
-                        "instillCredentialField": true,
                         "description": "Password associated with the username.",
+                        "instillCredentialField": true,
                         "order": 4,
                         "title": "Password",
                         "type": "string"
@@ -3590,19 +3590,19 @@
                         "type": "string"
                       },
                       "rest_credential": {
-                        "instillCredentialField": true,
                         "examples": [
                           "username:password"
                         ],
+                        "instillCredentialField": true,
                         "order": 2,
                         "title": "A credential to exchange for a token in the OAuth2 client credentials flow.",
                         "type": "string"
                       },
                       "rest_token": {
-                        "instillCredentialField": true,
                         "examples": [
                           "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
                         ],
+                        "instillCredentialField": true,
                         "order": 3,
                         "title": "A Bearer token which will be used for interaction with the server.",
                         "type": "string"
@@ -3681,11 +3681,11 @@
                     "description": "S3 object storage",
                     "properties": {
                       "access_key_id": {
-                        "instillCredentialField": true,
                         "description": "The access key ID to access the S3 bucket. Airbyte requires Read and Write permissions to the given bucket. Read more <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">here</a>.",
                         "examples": [
                           "A012345678910EXAMPLE"
                         ],
+                        "instillCredentialField": true,
                         "order": 0,
                         "title": "S3 Key ID",
                         "type": "string"
@@ -3757,11 +3757,11 @@
                         "type": "string"
                       },
                       "secret_access_key": {
-                        "instillCredentialField": true,
                         "description": "The corresponding secret to the access key ID. Read more <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">here</a>",
                         "examples": [
                           "a012345678910ABCDEFGH/AbCdEfGhEXAMPLEKEY"
                         ],
+                        "instillCredentialField": true,
                         "order": 1,
                         "title": "S3 Access Key",
                         "type": "string"
@@ -3967,9 +3967,9 @@
                   {
                     "properties": {
                       "sasl_jaas_config": {
-                        "instillCredentialField": true,
                         "default": "",
                         "description": "JAAS login context parameters for SASL connections in the format used by JAAS configuration files.",
+                        "instillCredentialField": true,
                         "title": "SASL JAAS Config",
                         "type": "string"
                       },
@@ -4000,9 +4000,9 @@
                   {
                     "properties": {
                       "sasl_jaas_config": {
-                        "instillCredentialField": true,
                         "default": "",
                         "description": "JAAS login context parameters for SASL connections in the format used by JAAS configuration files.",
+                        "instillCredentialField": true,
                         "title": "SASL JAAS Config",
                         "type": "string"
                       },
@@ -4141,11 +4141,11 @@
             "additionalProperties": false,
             "properties": {
               "api_key": {
-                "instillCredentialField": true,
                 "description": "To get Keen Master API Key, navigate to the Access tab from the left-hand, side panel and check the Project Details section.",
                 "examples": [
                   "ABCDEFGHIJKLMNOPRSTUWXYZ"
                 ],
+                "instillCredentialField": true,
                 "title": "API Key",
                 "type": "string"
               },
@@ -4181,8 +4181,8 @@
             "additionalProperties": true,
             "properties": {
               "accessKey": {
-                "instillCredentialField": true,
                 "description": "Generate the AWS Access Key for current user.",
+                "instillCredentialField": true,
                 "order": 3,
                 "title": "Access Key",
                 "type": "string"
@@ -4210,8 +4210,8 @@
                 "type": "string"
               },
               "privateKey": {
-                "instillCredentialField": true,
                 "description": "The AWS Private Key - a string of numbers and letters that are unique for each account, also known as a \"recovery phrase\".",
+                "instillCredentialField": true,
                 "order": 4,
                 "title": "Private Key",
                 "type": "string"
@@ -4515,8 +4515,8 @@
                 "type": "string"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "The Password associated with the username.",
+                "instillCredentialField": true,
                 "order": 4,
                 "title": "Password",
                 "type": "string"
@@ -4553,8 +4553,8 @@
                   {
                     "properties": {
                       "ssh_key": {
-                        "instillCredentialField": true,
                         "description": "OS-level user account ssh key credentials in RSA PEM format ( created with ssh-keygen -t rsa -m PEM -f myuser_rsa )",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 4,
                         "title": "SSH Private Key",
@@ -4633,8 +4633,8 @@
                         "type": "string"
                       },
                       "tunnel_user_password": {
-                        "instillCredentialField": true,
                         "description": "OS-level password for logging into the jump server host",
+                        "instillCredentialField": true,
                         "order": 4,
                         "title": "Password",
                         "type": "string"
@@ -4675,8 +4675,8 @@
             "additionalProperties": false,
             "properties": {
               "api_key": {
-                "instillCredentialField": true,
                 "description": "MeiliSearch API Key. See the <a href=\"https://docs.airbyte.com/integrations/destinations/meilisearch\">docs</a> for more information on how to obtain this key.",
+                "instillCredentialField": true,
                 "order": 1,
                 "title": "API Key",
                 "type": "string"
@@ -4826,8 +4826,8 @@
                         "type": "string"
                       },
                       "openai_key": {
-                        "instillCredentialField": true,
                         "description": "The API key for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource",
+                        "instillCredentialField": true,
                         "title": "Azure OpenAI API key",
                         "type": "string"
                       }
@@ -4845,8 +4845,8 @@
                     "description": "Use a service that's compatible with the OpenAI API to embed text.",
                     "properties": {
                       "api_key": {
-                        "instillCredentialField": true,
                         "default": "",
+                        "instillCredentialField": true,
                         "title": "API key",
                         "type": "string"
                       },
@@ -4918,8 +4918,8 @@
                             "type": "string"
                           },
                           "token": {
-                            "instillCredentialField": true,
                             "description": "API Token for the Milvus instance",
+                            "instillCredentialField": true,
                             "title": "API Token",
                             "type": "string"
                           }
@@ -4944,8 +4944,8 @@
                             "type": "string"
                           },
                           "password": {
-                            "instillCredentialField": true,
                             "description": "Password for the Milvus instance",
+                            "instillCredentialField": true,
                             "order": 2,
                             "title": "Password",
                             "type": "string"
@@ -5273,8 +5273,8 @@
                         "type": "string"
                       },
                       "password": {
-                        "instillCredentialField": true,
                         "description": "Password associated with the username.",
+                        "instillCredentialField": true,
                         "order": 2,
                         "title": "Password",
                         "type": "string"
@@ -5431,8 +5431,8 @@
                   {
                     "properties": {
                       "ssh_key": {
-                        "instillCredentialField": true,
                         "description": "OS-level user account ssh key credentials in RSA PEM format ( created with ssh-keygen -t rsa -m PEM -f myuser_rsa )",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 4,
                         "title": "SSH Private Key",
@@ -5511,8 +5511,8 @@
                         "type": "string"
                       },
                       "tunnel_user_password": {
-                        "instillCredentialField": true,
                         "description": "OS-level password for logging into the jump server host",
+                        "instillCredentialField": true,
                         "order": 4,
                         "title": "Password",
                         "type": "string"
@@ -5601,8 +5601,8 @@
                 "type": "boolean"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "Password to use for the connection.",
+                "instillCredentialField": true,
                 "title": "Password",
                 "type": "string"
               },
@@ -5683,8 +5683,8 @@
                 "type": "string"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "The password associated with this username.",
+                "instillCredentialField": true,
                 "order": 5,
                 "title": "Password",
                 "type": "string"
@@ -5801,8 +5801,8 @@
                   {
                     "properties": {
                       "ssh_key": {
-                        "instillCredentialField": true,
                         "description": "OS-level user account ssh key credentials in RSA PEM format ( created with ssh-keygen -t rsa -m PEM -f myuser_rsa )",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 4,
                         "title": "SSH Private Key",
@@ -5881,8 +5881,8 @@
                         "type": "string"
                       },
                       "tunnel_user_password": {
-                        "instillCredentialField": true,
                         "description": "OS-level password for logging into the jump server host",
+                        "instillCredentialField": true,
                         "order": 4,
                         "title": "Password",
                         "type": "string"
@@ -5946,8 +5946,8 @@
                 "type": "string"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "Password associated with the username.",
+                "instillCredentialField": true,
                 "order": 4,
                 "title": "Password",
                 "type": "string"
@@ -5991,8 +5991,8 @@
                   {
                     "properties": {
                       "ssh_key": {
-                        "instillCredentialField": true,
                         "description": "OS-level user account ssh key credentials in RSA PEM format ( created with ssh-keygen -t rsa -m PEM -f myuser_rsa )",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 4,
                         "title": "SSH Private Key",
@@ -6071,8 +6071,8 @@
                         "type": "string"
                       },
                       "tunnel_user_password": {
-                        "instillCredentialField": true,
                         "description": "OS-level password for logging into the jump server host",
+                        "instillCredentialField": true,
                         "order": 4,
                         "title": "Password",
                         "type": "string"
@@ -6176,8 +6176,8 @@
                         "type": "string"
                       },
                       "ssl_certificate": {
-                        "instillCredentialField": true,
                         "description": "Privacy Enhanced Mail (PEM) files are concatenated certificate containers frequently used in certificate installations.",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "title": "SSL PEM file",
                         "type": "string"
@@ -6207,8 +6207,8 @@
                 "type": "string"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "The password associated with the username.",
+                "instillCredentialField": true,
                 "order": 4,
                 "title": "Password",
                 "type": "string"
@@ -6261,8 +6261,8 @@
                   {
                     "properties": {
                       "ssh_key": {
-                        "instillCredentialField": true,
                         "description": "OS-level user account ssh key credentials in RSA PEM format ( created with ssh-keygen -t rsa -m PEM -f myuser_rsa )",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 4,
                         "title": "SSH Private Key",
@@ -6341,8 +6341,8 @@
                         "type": "string"
                       },
                       "tunnel_user_password": {
-                        "instillCredentialField": true,
                         "description": "OS-level password for logging into the jump server host",
+                        "instillCredentialField": true,
                         "order": 4,
                         "title": "Password",
                         "type": "string"
@@ -6505,8 +6505,8 @@
                         "type": "string"
                       },
                       "openai_key": {
-                        "instillCredentialField": true,
                         "description": "The API key for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource",
+                        "instillCredentialField": true,
                         "title": "Azure OpenAI API key",
                         "type": "string"
                       }
@@ -6524,8 +6524,8 @@
                     "description": "Use a service that's compatible with the OpenAI API to embed text.",
                     "properties": {
                       "api_key": {
-                        "instillCredentialField": true,
                         "default": "",
+                        "instillCredentialField": true,
                         "title": "API key",
                         "type": "string"
                       },
@@ -6596,8 +6596,8 @@
                     "type": "string"
                   },
                   "pinecone_key": {
-                    "instillCredentialField": true,
                     "description": "The Pinecone API key to use matching the environment (copy from Pinecone console)",
+                    "instillCredentialField": true,
                     "title": "Pinecone API key",
                     "type": "string"
                   }
@@ -6849,8 +6849,8 @@
                 "type": "string"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "Password associated with the username.",
+                "instillCredentialField": true,
                 "order": 5,
                 "title": "Password",
                 "type": "string"
@@ -6968,16 +6968,16 @@
                     "description": "Verify-ca SSL mode.",
                     "properties": {
                       "ca_certificate": {
-                        "instillCredentialField": true,
                         "description": "CA certificate",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 1,
                         "title": "CA certificate",
                         "type": "string"
                       },
                       "client_key_password": {
-                        "instillCredentialField": true,
                         "description": "Password for keystorage. This field is optional. If you do not add it - the password will be generated automatically.",
+                        "instillCredentialField": true,
                         "order": 4,
                         "title": "Client key password",
                         "type": "string"
@@ -7003,32 +7003,32 @@
                     "description": "Verify-full SSL mode.",
                     "properties": {
                       "ca_certificate": {
-                        "instillCredentialField": true,
                         "description": "CA certificate",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 1,
                         "title": "CA certificate",
                         "type": "string"
                       },
                       "client_certificate": {
-                        "instillCredentialField": true,
                         "description": "Client certificate",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 2,
                         "title": "Client certificate",
                         "type": "string"
                       },
                       "client_key": {
-                        "instillCredentialField": true,
                         "description": "Client key",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 3,
                         "title": "Client key",
                         "type": "string"
                       },
                       "client_key_password": {
-                        "instillCredentialField": true,
                         "description": "Password for keystorage. This field is optional. If you do not add it - the password will be generated automatically.",
+                        "instillCredentialField": true,
                         "order": 4,
                         "title": "Client key password",
                         "type": "string"
@@ -7076,8 +7076,8 @@
                   {
                     "properties": {
                       "ssh_key": {
-                        "instillCredentialField": true,
                         "description": "OS-level user account ssh key credentials in RSA PEM format ( created with ssh-keygen -t rsa -m PEM -f myuser_rsa )",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 4,
                         "title": "SSH Private Key",
@@ -7156,8 +7156,8 @@
                         "type": "string"
                       },
                       "tunnel_user_password": {
-                        "instillCredentialField": true,
                         "description": "OS-level password for logging into the jump server host",
+                        "instillCredentialField": true,
                         "order": 4,
                         "title": "Password",
                         "type": "string"
@@ -7226,8 +7226,8 @@
                 "type": "integer"
               },
               "credentials_json": {
-                "instillCredentialField": true,
                 "description": "The contents of the JSON service account key. Check out the <a href=\"https://docs.airbyte.com/integrations/destinations/pubsub\">docs</a> if you need help generating this key.",
+                "instillCredentialField": true,
                 "title": "Credentials JSON",
                 "type": "string"
               },
@@ -7547,8 +7547,8 @@
                         "type": "string"
                       },
                       "openai_key": {
-                        "instillCredentialField": true,
                         "description": "The API key for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource",
+                        "instillCredentialField": true,
                         "title": "Azure OpenAI API key",
                         "type": "string"
                       }
@@ -7566,8 +7566,8 @@
                     "description": "Use a service that's compatible with the OpenAI API to embed text.",
                     "properties": {
                       "api_key": {
-                        "instillCredentialField": true,
                         "default": "",
+                        "instillCredentialField": true,
                         "title": "API key",
                         "type": "string"
                       },
@@ -7630,8 +7630,8 @@
                       {
                         "properties": {
                           "api_key": {
-                            "instillCredentialField": true,
                             "description": "API Key for the Qdrant instance",
+                            "instillCredentialField": true,
                             "title": "API Key",
                             "type": "string"
                           },
@@ -7930,11 +7930,11 @@
             "$schema": "http://json-schema.org/draft-07/schema#",
             "properties": {
               "access_key_id": {
-                "instillCredentialField": true,
                 "description": "The access key ID to access the R2 bucket. Airbyte requires Read and Write permissions to the given bucket. Read more <a href=\"https://developers.cloudflare.com/r2/platform/s3-compatibility/tokens/\">here</a>.",
                 "examples": [
                   "A012345678910EXAMPLE"
                 ],
+                "instillCredentialField": true,
                 "order": 1,
                 "title": "R2 Key ID *",
                 "type": "string"
@@ -8263,11 +8263,11 @@
                 "type": "string"
               },
               "secret_access_key": {
-                "instillCredentialField": true,
                 "description": "The corresponding secret to the access key ID. Read more <a href=\"https://developers.cloudflare.com/r2/platform/s3-compatibility/tokens/\">here</a>",
                 "examples": [
                   "a012345678910ABCDEFGHAbCdEfGhEXAMPLEKEY"
                 ],
+                "instillCredentialField": true,
                 "order": 2,
                 "title": "R2 Access Key *",
                 "type": "string"
@@ -8302,8 +8302,8 @@
                 "type": "string"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "The password to connect.",
+                "instillCredentialField": true,
                 "title": "Password",
                 "type": "string"
               },
@@ -8365,8 +8365,8 @@
                 "type": "string"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "Password associated with Redis.",
+                "instillCredentialField": true,
                 "order": 4,
                 "title": "Password",
                 "type": "string"
@@ -8414,32 +8414,32 @@
                     "description": "Verify-full SSL mode.",
                     "properties": {
                       "ca_certificate": {
-                        "instillCredentialField": true,
                         "description": "CA certificate",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 1,
                         "title": "CA Certificate",
                         "type": "string"
                       },
                       "client_certificate": {
-                        "instillCredentialField": true,
                         "description": "Client certificate",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 2,
                         "title": "Client Certificate",
                         "type": "string"
                       },
                       "client_key": {
-                        "instillCredentialField": true,
                         "description": "Client key",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 3,
                         "title": "Client Key",
                         "type": "string"
                       },
                       "client_key_password": {
-                        "instillCredentialField": true,
                         "description": "Password for keystorage. If you do not add it - the password will be generated automatically.",
+                        "instillCredentialField": true,
                         "order": 4,
                         "title": "Client key password",
                         "type": "string"
@@ -8487,8 +8487,8 @@
                   {
                     "properties": {
                       "ssh_key": {
-                        "instillCredentialField": true,
                         "description": "OS-level user account ssh key credentials in RSA PEM format ( created with ssh-keygen -t rsa -m PEM -f myuser_rsa )",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 4,
                         "title": "SSH Private Key",
@@ -8567,8 +8567,8 @@
                         "type": "string"
                       },
                       "tunnel_user_password": {
-                        "instillCredentialField": true,
                         "description": "OS-level password for logging into the jump server host",
+                        "instillCredentialField": true,
                         "order": 4,
                         "title": "Password",
                         "type": "string"
@@ -8734,9 +8734,9 @@
                 "type": "string"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "Password associated with the username.",
                 "group": "connection",
+                "instillCredentialField": true,
                 "order": 4,
                 "title": "Password",
                 "type": "string"
@@ -8791,8 +8791,8 @@
                   {
                     "properties": {
                       "ssh_key": {
-                        "instillCredentialField": true,
                         "description": "OS-level user account ssh key credentials in RSA PEM format ( created with ssh-keygen -t rsa -m PEM -f myuser_rsa )",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 4,
                         "title": "SSH Private Key",
@@ -8871,8 +8871,8 @@
                         "type": "string"
                       },
                       "tunnel_user_password": {
-                        "instillCredentialField": true,
                         "description": "OS-level password for logging into the jump server host",
+                        "instillCredentialField": true,
                         "order": 4,
                         "title": "Password",
                         "type": "string"
@@ -8900,8 +8900,8 @@
                     "description": "<i>(recommended)</i> Uploads data to S3 and then uses a COPY to insert the data into Redshift. COPY is recommended for production workloads for better speed and scalability. See <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-bucket.html\">AWS docs</a> for more details.",
                     "properties": {
                       "access_key_id": {
-                        "instillCredentialField": true,
                         "description": "This ID grants access to the above S3 staging bucket. Airbyte requires Read and Write permissions to the given bucket. See <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">AWS docs</a> on how to generate an access key ID and secret access key.",
+                        "instillCredentialField": true,
                         "order": 3,
                         "title": "S3 Access Key Id",
                         "type": "string"
@@ -8942,8 +8942,8 @@
                                 "type": "string"
                               },
                               "key_encrypting_key": {
-                                "instillCredentialField": true,
                                 "description": "The key, base64-encoded. Must be either 128, 192, or 256 bits. Leave blank to have Airbyte generate an ephemeral key for each sync.",
+                                "instillCredentialField": true,
                                 "title": "Key",
                                 "type": "string"
                               }
@@ -9046,8 +9046,8 @@
                         "type": "string"
                       },
                       "secret_access_key": {
-                        "instillCredentialField": true,
                         "description": "The corresponding secret to the above access key id. See <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">AWS docs</a> on how to generate an access key ID and secret access key.",
+                        "instillCredentialField": true,
                         "order": 4,
                         "title": "S3 Secret Access Key",
                         "type": "string"
@@ -9111,16 +9111,16 @@
             "additionalProperties": false,
             "properties": {
               "api_key": {
-                "instillCredentialField": true,
                 "description": "Rockset api key",
+                "instillCredentialField": true,
                 "order": 0,
                 "title": "Api Key",
                 "type": "string"
               },
               "api_server": {
-                "instillCredentialField": false,
                 "default": "https://api.rs2.usw2.rockset.com",
                 "description": "Rockset api URL",
+                "instillCredentialField": false,
                 "order": 2,
                 "pattern": "^https:\\/\\/.*.rockset.com$",
                 "title": "Api Server",
@@ -9131,13 +9131,13 @@
                 "type": "string"
               },
               "workspace": {
-                "instillCredentialField": false,
                 "default": "commons",
                 "description": "The Rockset workspace in which collections will be created + written to.",
                 "examples": [
                   "commons",
                   "my_workspace"
                 ],
+                "instillCredentialField": false,
                 "order": 1,
                 "title": "Workspace",
                 "type": "string"
@@ -9155,11 +9155,11 @@
             "$schema": "http://json-schema.org/draft-07/schema#",
             "properties": {
               "access_key_id": {
-                "instillCredentialField": true,
                 "description": "The access key ID to access the S3 bucket. Airbyte requires Read and Write permissions to the given bucket. Read more <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">here</a>.",
                 "examples": [
                   "A012345678910EXAMPLE"
                 ],
+                "instillCredentialField": true,
                 "order": 0,
                 "title": "S3 Key ID",
                 "type": "string"
@@ -9341,11 +9341,11 @@
                 "type": "string"
               },
               "secret_access_key": {
-                "instillCredentialField": true,
                 "description": "The corresponding secret to the access key ID. Read more <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">here</a>",
                 "examples": [
                   "a012345678910ABCDEFGH/AbCdEfGhEXAMPLEKEY"
                 ],
+                "instillCredentialField": true,
                 "order": 1,
                 "title": "S3 Access Key",
                 "type": "string"
@@ -9367,11 +9367,11 @@
             "$schema": "http://json-schema.org/draft-07/schema#",
             "properties": {
               "access_key_id": {
-                "instillCredentialField": true,
                 "description": "The access key ID to access the S3 bucket. Airbyte requires Read and Write permissions to the given bucket. Read more <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">here</a>.",
                 "examples": [
                   "A012345678910EXAMPLE"
                 ],
+                "instillCredentialField": true,
                 "order": 0,
                 "title": "S3 Key ID",
                 "type": "string"
@@ -9819,11 +9819,11 @@
                 "type": "string"
               },
               "secret_access_key": {
-                "instillCredentialField": true,
                 "description": "The corresponding secret to the access key ID. Read more <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">here</a>",
                 "examples": [
                   "a012345678910ABCDEFGH/AbCdEfGhEXAMPLEKEY"
                 ],
+                "instillCredentialField": true,
                 "order": 1,
                 "title": "S3 Access Key",
                 "type": "string"
@@ -9860,8 +9860,8 @@
                 "type": "string"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "Password associated with Scylla.",
+                "instillCredentialField": true,
                 "order": 2,
                 "title": "Password",
                 "type": "string"
@@ -9932,8 +9932,8 @@
                 "type": "string"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "Password associated with the username.",
+                "instillCredentialField": true,
                 "order": 4,
                 "title": "Password",
                 "type": "string"
@@ -9981,8 +9981,8 @@
                 "type": "string"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "Password associated with the username.",
+                "instillCredentialField": true,
                 "order": 3,
                 "title": "Password",
                 "type": "string"
@@ -10027,8 +10027,8 @@
                     "order": 0,
                     "properties": {
                       "access_token": {
-                        "instillCredentialField": true,
                         "description": "Enter you application's Access Token",
+                        "instillCredentialField": true,
                         "title": "Access Token",
                         "type": "string"
                       },
@@ -10042,20 +10042,20 @@
                         "type": "string"
                       },
                       "client_id": {
-                        "instillCredentialField": true,
                         "description": "Enter your application's Client ID",
+                        "instillCredentialField": true,
                         "title": "Client ID",
                         "type": "string"
                       },
                       "client_secret": {
-                        "instillCredentialField": true,
                         "description": "Enter your application's Client secret",
+                        "instillCredentialField": true,
                         "title": "Client Secret",
                         "type": "string"
                       },
                       "refresh_token": {
-                        "instillCredentialField": true,
                         "description": "Enter your application's Refresh Token",
+                        "instillCredentialField": true,
                         "title": "Refresh Token",
                         "type": "string"
                       }
@@ -10080,15 +10080,15 @@
                         "type": "string"
                       },
                       "private_key": {
-                        "instillCredentialField": true,
                         "description": "RSA Private key to use for Snowflake connection. See the <a href=\"https://docs.airbyte.com/integrations/destinations/snowflake\">docs</a> for more information on how to obtain this key.",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "title": "Private Key",
                         "type": "string"
                       },
                       "private_key_password": {
-                        "instillCredentialField": true,
                         "description": "Passphrase for private key",
+                        "instillCredentialField": true,
                         "title": "Passphrase",
                         "type": "string"
                       }
@@ -10112,8 +10112,8 @@
                         "type": "string"
                       },
                       "password": {
-                        "instillCredentialField": true,
                         "description": "Enter the password associated with the username.",
+                        "instillCredentialField": true,
                         "order": 1,
                         "title": "Password",
                         "type": "string"
@@ -10278,11 +10278,11 @@
                 "type": "string"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "Starburst Galaxy password for the specified user.",
                 "examples": [
                   "password"
                 ],
+                "instillCredentialField": true,
                 "order": 5,
                 "title": "Password",
                 "type": "string"
@@ -10327,11 +10327,11 @@
                         "type": "string"
                       },
                       "s3_access_key_id": {
-                        "instillCredentialField": true,
                         "description": "Access key with access to the bucket. Airbyte requires read and write permissions to a given bucket.",
                         "examples": [
                           "A012345678910EXAMPLE"
                         ],
+                        "instillCredentialField": true,
                         "order": 4,
                         "title": "Access key",
                         "type": "string"
@@ -10376,11 +10376,11 @@
                         "type": "string"
                       },
                       "s3_secret_access_key": {
-                        "instillCredentialField": true,
                         "description": "Secret key used with the specified access key.",
                         "examples": [
                           "a012345678910ABCDEFGH/AbCdEfGhEXAMPLEKEY"
                         ],
+                        "instillCredentialField": true,
                         "order": 5,
                         "title": "Secret key",
                         "type": "string"
@@ -10444,8 +10444,8 @@
                 "type": "string"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "Password associated with the username.",
+                "instillCredentialField": true,
                 "order": 2,
                 "title": "Password",
                 "type": "string"
@@ -10560,8 +10560,8 @@
                         "type": "string"
                       },
                       "ssl_ca_certificate": {
-                        "instillCredentialField": true,
                         "description": "Specifies the file name of a PEM file that contains Certificate Authority (CA) certificates for use with SSLMODE=verify-ca.\n See more information - <a href=\"https://teradata-docs.s3.amazonaws.com/doc/connectivity/jdbc/reference/current/jdbcug_chapter_2.html#URL_SSLCA\"> in the docs</a>.",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 1,
                         "title": "CA certificate",
@@ -10588,8 +10588,8 @@
                         "type": "string"
                       },
                       "ssl_ca_certificate": {
-                        "instillCredentialField": true,
                         "description": "Specifies the file name of a PEM file that contains Certificate Authority (CA) certificates for use with SSLMODE=verify-full.\n See more information - <a href=\"https://teradata-docs.s3.amazonaws.com/doc/connectivity/jdbc/reference/current/jdbcug_chapter_2.html#URL_SSLCA\"> in the docs</a>.",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 1,
                         "title": "CA certificate",
@@ -10649,9 +10649,9 @@
                 "type": "string"
               },
               "password": {
-                "instillCredentialField": true,
                 "default": "",
                 "description": "Password associated with the username.",
+                "instillCredentialField": true,
                 "order": 4,
                 "title": "Password",
                 "type": "string"
@@ -10695,8 +10695,8 @@
                   {
                     "properties": {
                       "ssh_key": {
-                        "instillCredentialField": true,
                         "description": "OS-level user account ssh key credentials in RSA PEM format ( created with ssh-keygen -t rsa -m PEM -f myuser_rsa )",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 4,
                         "title": "SSH Private Key",
@@ -10775,8 +10775,8 @@
                         "type": "string"
                       },
                       "tunnel_user_password": {
-                        "instillCredentialField": true,
                         "description": "OS-level password for logging into the jump server host",
+                        "instillCredentialField": true,
                         "order": 4,
                         "title": "Password",
                         "type": "string"
@@ -10817,8 +10817,8 @@
             "additionalProperties": false,
             "properties": {
               "apikey": {
-                "instillCredentialField": true,
                 "description": "Personal API key",
+                "instillCredentialField": true,
                 "order": 1,
                 "title": "API key",
                 "type": "string"
@@ -10920,8 +10920,8 @@
                 "type": "string"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "Password associated with the username.",
+                "instillCredentialField": true,
                 "order": 4,
                 "title": "Password",
                 "type": "string"
@@ -10964,8 +10964,8 @@
                   {
                     "properties": {
                       "ssh_key": {
-                        "instillCredentialField": true,
                         "description": "OS-level user account ssh key credentials in RSA PEM format ( created with ssh-keygen -t rsa -m PEM -f myuser_rsa )",
+                        "instillCredentialField": true,
                         "multiline": true,
                         "order": 4,
                         "title": "SSH Private Key",
@@ -11044,8 +11044,8 @@
                         "type": "string"
                       },
                       "tunnel_user_password": {
-                        "instillCredentialField": true,
                         "description": "OS-level password for logging into the jump server host",
+                        "instillCredentialField": true,
                         "order": 4,
                         "title": "Password",
                         "type": "string"
@@ -11159,8 +11159,8 @@
                         "type": "string"
                       },
                       "openai_key": {
-                        "instillCredentialField": true,
                         "description": "The API key for your Azure OpenAI resource.  You can find this in the Azure portal under your Azure OpenAI resource",
+                        "instillCredentialField": true,
                         "title": "Azure OpenAI API key",
                         "type": "string"
                       }
@@ -11286,8 +11286,8 @@
                     "description": "Use a service that's compatible with the OpenAI API to embed text.",
                     "properties": {
                       "api_key": {
-                        "instillCredentialField": true,
                         "default": "",
+                        "instillCredentialField": true,
                         "title": "API key",
                         "type": "string"
                       },
@@ -11390,8 +11390,8 @@
                             "type": "string"
                           },
                           "token": {
-                            "instillCredentialField": true,
                             "description": "API Token for the Weaviate instance",
+                            "instillCredentialField": true,
                             "title": "API Token",
                             "type": "string"
                           }
@@ -11416,8 +11416,8 @@
                             "type": "string"
                           },
                           "password": {
-                            "instillCredentialField": true,
                             "description": "Password for the Weaviate cluster",
+                            "instillCredentialField": true,
                             "order": 2,
                             "title": "Password",
                             "type": "string"
@@ -11723,8 +11723,8 @@
             "additionalProperties": true,
             "properties": {
               "api_key": {
-                "instillCredentialField": true,
                 "description": "API Key to connect.",
+                "instillCredentialField": true,
                 "order": 0,
                 "title": "API Key",
                 "type": "string"
@@ -11776,8 +11776,8 @@
                 "type": "string"
               },
               "password": {
-                "instillCredentialField": true,
                 "description": "The Password associated with the username.",
+                "instillCredentialField": true,
                 "order": 5,
                 "title": "Password",
                 "type": "string"
@@ -11831,8 +11831,8 @@
                 "type": "string"
               },
               "privateKey": {
-                "instillCredentialField": true,
                 "description": "You private key on Streamr",
+                "instillCredentialField": true,
                 "type": "string"
               },
               "streamId": {

--- a/pkg/huggingface/connector_test.go
+++ b/pkg/huggingface/connector_test.go
@@ -315,7 +315,7 @@ func testTask(c *qt.C, p taskParams) {
 			srv := httptest.NewServer(h)
 			c.Cleanup(srv.Close)
 
-			config, err := structpb.NewStruct(map[string]any{
+			config, _ := structpb.NewStruct(map[string]any{
 				"api_key":            apiKey,
 				"base_url":           srv.URL,
 				"is_custom_endpoint": tc.customEndpoint,

--- a/pkg/instill/config/tasks.json
+++ b/pkg/instill/config/tasks.json
@@ -1,5 +1,28 @@
 {
   "$defs": {
+    "chat_message": {
+      "properties": {
+        "content": {
+          "$ref": "https://raw.githubusercontent.com/instill-ai/component/747ec5eaa8fe611c3be91354923afd544eb54b13/schema.json#/$defs/instill_types/multi_modal_content",
+          "description": "The message content",
+          "instillUIOrder": 1,
+          "title": "Content"
+        },
+        "role": {
+          "description": "The message role, i.e. 'system', 'user' or 'assistant'",
+          "instillFormat": "string",
+          "instillUIOrder": 0,
+          "title": "Role",
+          "type": "string"
+        }
+      },
+      "required": [
+        "role",
+        "content"
+      ],
+      "title": "Chat Message",
+      "type": "object"
+    },
     "common": {
       "description": "Input",
       "instillEditOnNodeFields": [
@@ -59,40 +82,17 @@
       "type": "object"
     },
     "extra_params": {
+      "description": "Extra Parameters",
       "instillAcceptFormats": [
-        "array:object"
+        "semi-structured/object"
       ],
-      "instillShortDescription": "Extra Params",
-      "instillUIOrder": 10,
+      "instillUIOrder": 3,
       "instillUpstreamTypes": [
-        "value",
         "reference"
       ],
-      "items": {
-        "properties": {
-          "param_name": {
-            "instillFormat": "string",
-            "instillUIMultiline": true,
-            "instillUIOrder": 0,
-            "title": "Param Name",
-            "type": "string"
-          },
-          "param_value": {
-            "instillFormat": "string",
-            "instillUIOrder": 1,
-            "title": "Param Value",
-            "type": "string"
-          }
-        },
-        "required": [
-          "param_name",
-          "param_value"
-        ],
-        "title": "Param",
-        "type": "object"
-      },
-      "title": "Extra Params",
-      "type": "array"
+      "required":[],
+      "title": "Extra Parameters",
+      "type": "object"
     }
   },
   "TASK_CLASSIFICATION": {
@@ -341,6 +341,39 @@
       ],
       "instillUIOrder": 0,
       "properties": {
+        "chat_history": {
+          "description": "Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: : {\"role\": \"The message role, i.e. 'system', 'user' or 'assistant'\", \"content\": \"message content\"}.",
+          "instillAcceptFormats": [
+            "structured/chat_messages"
+          ],
+          "instillShortDescription": "Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: : {\"role\": \"The message role, i.e. 'system', 'user' or 'assistant'\", \"content\": \"message content\"}.",
+          "instillUIOrder": 4,
+          "instillUpstreamTypes": [
+            "reference"
+          ],
+          "items": {
+            "$ref": "#/$defs/chat_message"
+          },
+          "title": "Chat history",
+          "type": "array"
+        },
+        "system_message": {
+          "default": "You are a helpful assistant.",
+          "description": "The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model\u2019s behavior is using a generic message as \"You are a helpful assistant.\"",
+          "instillAcceptFormats": [
+            "string"
+          ],
+          "instillShortDescription": "The system message helps set the behavior of the assistant",
+          "instillUIMultiline": true,
+          "instillUIOrder": 2,
+          "instillUpstreamTypes": [
+            "value",
+            "reference",
+            "template"
+          ],
+          "title": "System message",
+          "type": "string"
+        },
         "extra_params": {
           "$ref": "#/$defs/extra_params"
         },
@@ -400,6 +433,21 @@
           ],
           "title": "Prompt",
           "type": "string"
+        },
+        "prompt_images": {
+          "description": "The prompt images",
+          "instillAcceptFormats": [
+            "array:image/*"
+          ],
+          "instillUIOrder": 3,
+          "instillUpstreamTypes": [
+            "reference"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "title": "Prompt Images",
+          "type": "array"
         },
         "seed": {
           "description": "The seed",
@@ -475,171 +523,7 @@
     }
   },
   "TASK_TEXT_GENERATION_CHAT": {
-    "input": {
-      "description": "Input",
-      "instillEditOnNodeFields": [
-        "conversation",
-        "model_namespace",
-        "model_id"
-      ],
-      "instillUIOrder": 0,
-      "properties": {
-        "conversation": {
-          "description": "Conversion, each message should adhere to the format: : {\"role\": \"The message role, i.e. 'system', 'user' or 'assistant'\", \"content\": \"message content\"}.",
-          "instillAcceptFormats": [
-            "array:*/*"
-          ],
-          "instillShortDescription": "Conversion, each message should adhere to the format: : {\"role\": \"The message role, i.e. 'system', 'user' or 'assistant'\", \"content\": \"message content\"}.",
-          "instillUIOrder": 2,
-          "instillUpstreamTypes": [
-            "value",
-            "reference"
-          ],
-          "items": {
-            "properties": {
-              "content": {
-                "description": "The message content",
-                "instillFormat": "string",
-                "instillUIMultiline": true,
-                "instillUIOrder": 1,
-                "title": "Content",
-                "type": "string"
-              },
-              "role": {
-                "description": "The message role, i.e. 'system', 'user' or 'assistant'",
-                "instillFormat": "string",
-                "instillUIOrder": 0,
-                "title": "Role",
-                "type": "string"
-              }
-            },
-            "required": [
-              "role",
-              "content"
-            ],
-            "title": "Conversation",
-            "type": "object"
-          },
-          "title": "Conversation",
-          "type": "array"
-        },
-        "extra_params": {
-          "$ref": "#/$defs/extra_params"
-        },
-        "max_new_tokens": {
-          "default": 50,
-          "description": "The maximum number of tokens for model to generate",
-          "instillAcceptFormats": [
-            "integer"
-          ],
-          "instillUIOrder": 6,
-          "instillUpstreamTypes": [
-            "value",
-            "reference"
-          ],
-          "title": "Max new tokens",
-          "type": "integer"
-        },
-        "model_id": {
-          "description": "ID of the Instill Model model to be used.",
-          "instillAcceptFormats": [
-            "string"
-          ],
-          "instillUIOrder": 1,
-          "instillUpstreamTypes": [
-            "value",
-            "reference",
-            "template"
-          ],
-          "title": "Model ID",
-          "type": "string"
-        },
-        "model_namespace": {
-          "description": "Namespace of the Instill Model model to be used.",
-          "instillAcceptFormats": [
-            "string"
-          ],
-          "instillUIOrder": 0,
-          "instillUpstreamTypes": [
-            "value",
-            "reference",
-            "template"
-          ],
-          "title": "Model Namespace",
-          "type": "string"
-        },
-        "seed": {
-          "description": "The seed",
-          "instillAcceptFormats": [
-            "integer"
-          ],
-          "instillUIOrder": 4,
-          "instillUpstreamTypes": [
-            "value",
-            "reference"
-          ],
-          "title": "Seed",
-          "type": "integer"
-        },
-        "temperature": {
-          "default": 0.7,
-          "description": "The temperature for sampling",
-          "instillAcceptFormats": [
-            "number"
-          ],
-          "instillUIOrder": 5,
-          "instillUpstreamTypes": [
-            "value",
-            "reference"
-          ],
-          "title": "Temperature",
-          "type": "number"
-        },
-        "top_k": {
-          "default": 10,
-          "description": "Top k for sampling",
-          "instillAcceptFormats": [
-            "integer"
-          ],
-          "instillUIOrder": 5,
-          "instillUpstreamTypes": [
-            "value",
-            "reference"
-          ],
-          "title": "Top K",
-          "type": "integer"
-        }
-      },
-      "required": [
-        "conversation",
-        "model_namespace",
-        "model_id"
-      ],
-      "title": "Input",
-      "type": "object"
-    },
-    "output": {
-      "description": "Output",
-      "instillEditOnNodeFields": [
-        "text"
-      ],
-      "instillUIOrder": 0,
-      "properties": {
-        "text": {
-          "description": "Text",
-          "instillFormat": "string",
-          "instillUIMultiline": true,
-          "instillUIOrder": 0,
-          "title": "Text",
-          "type": "string"
-        }
-      },
-      "required": [
-        "text"
-      ],
-      "title": "Output",
-      "type": "object"
-    }
+    "$ref": "#/TASK_TEXT_GENERATION"
   },
   "TASK_TEXT_TO_IMAGE": {
     "input": {
@@ -785,160 +669,6 @@
     }
   },
   "TASK_VISUAL_QUESTION_ANSWERING": {
-    "input": {
-      "description": "Input",
-      "instillEditOnNodeFields": [
-        "prompt",
-        "image_base64",
-        "model_namespace",
-        "model_id"
-      ],
-      "instillUIOrder": 0,
-      "properties": {
-        "extra_params": {
-          "$ref": "#/$defs/extra_params"
-        },
-        "image_base64": {
-          "description": "The prompt image",
-          "instillAcceptFormats": [
-            "image/*"
-          ],
-          "instillUIOrder": 3,
-          "instillUpstreamTypes": [
-            "reference"
-          ],
-          "title": "Prompt Image",
-          "type": "string"
-        },
-        "max_new_tokens": {
-          "default": 50,
-          "description": "The maximum number of tokens for model to generate",
-          "instillAcceptFormats": [
-            "integer"
-          ],
-          "instillUIOrder": 6,
-          "instillUpstreamTypes": [
-            "value",
-            "reference"
-          ],
-          "title": "Max new tokens",
-          "type": "integer"
-        },
-        "model_id": {
-          "description": "ID of the Instill Model model to be used.",
-          "instillAcceptFormats": [
-            "string"
-          ],
-          "instillUIOrder": 1,
-          "instillUpstreamTypes": [
-            "value",
-            "reference",
-            "template"
-          ],
-          "title": "Model ID",
-          "type": "string"
-        },
-        "model_namespace": {
-          "description": "Namespace of the Instill Model model to be used.",
-          "instillAcceptFormats": [
-            "string"
-          ],
-          "instillUIOrder": 0,
-          "instillUpstreamTypes": [
-            "value",
-            "reference",
-            "template"
-          ],
-          "title": "Model Namespace",
-          "type": "string"
-        },
-        "prompt": {
-          "description": "The prompt text",
-          "instillAcceptFormats": [
-            "string"
-          ],
-          "instillUIMultiline": true,
-          "instillUIOrder": 2,
-          "instillUpstreamTypes": [
-            "value",
-            "reference",
-            "template"
-          ],
-          "title": "Prompt",
-          "type": "string"
-        },
-        "seed": {
-          "description": "The seed",
-          "instillAcceptFormats": [
-            "integer"
-          ],
-          "instillUIOrder": 4,
-          "instillUpstreamTypes": [
-            "value",
-            "reference"
-          ],
-          "title": "Seed",
-          "type": "integer"
-        },
-        "temperature": {
-          "default": 0.7,
-          "description": "The temperature for sampling",
-          "instillAcceptFormats": [
-            "number"
-          ],
-          "instillUIOrder": 5,
-          "instillUpstreamTypes": [
-            "value",
-            "reference"
-          ],
-          "title": "Temperature",
-          "type": "number"
-        },
-        "top_k": {
-          "default": 10,
-          "description": "Top k for sampling",
-          "instillAcceptFormats": [
-            "integer"
-          ],
-          "instillUIOrder": 5,
-          "instillUpstreamTypes": [
-            "value",
-            "reference"
-          ],
-          "title": "Top K",
-          "type": "integer"
-        }
-      },
-      "required": [
-        "prompt",
-        "image_base64",
-        "model_namespace",
-        "model_id"
-      ],
-      "title": "Input",
-      "type": "object"
-    },
-    "output": {
-      "description": "Output",
-      "instillEditOnNodeFields": [
-        "text"
-      ],
-      "instillUIOrder": 0,
-      "properties": {
-        "text": {
-          "description": "Text",
-          "instillFormat": "string",
-          "instillUIMultiline": true,
-          "instillUIOrder": 0,
-          "title": "Text",
-          "type": "string"
-        }
-      },
-      "required": [
-        "text"
-      ],
-      "title": "Output",
-      "type": "object"
-    }
+    "$ref": "#/TASK_TEXT_GENERATION"
   }
 }

--- a/pkg/instill/text_generation_chat.go
+++ b/pkg/instill/text_generation_chat.go
@@ -1,8 +1,11 @@
 package instill
 
 import (
+	"context"
 	"fmt"
 
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
@@ -21,7 +24,7 @@ func (c *Execution) executeTextGenerationChat(grpcClient modelPB.ModelPublicServ
 	outputs := []*structpb.Struct{}
 
 	for _, input := range inputs {
-		llmInput := ConvertLLMInput(input)
+		llmInput := c.convertLLMInput(input)
 		taskInput := &modelPB.TaskInput_TextGenerationChat{
 			TextGenerationChat: &modelPB.TextGenerationChatInput{
 				Prompt:        llmInput.Prompt,
@@ -37,10 +40,34 @@ func (c *Execution) executeTextGenerationChat(grpcClient modelPB.ModelPublicServ
 		}
 
 		// only support batch 1
-		output, err := c.SendLLMRequest(grpcClient, &modelPB.TriggerUserModelRequest{
+		req := modelPB.TriggerUserModelRequest{
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
-		}, modelName)
+		}
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
+		ctx := metadata.NewOutgoingContext(context.Background(), md)
+		res, err := grpcClient.TriggerUserModel(ctx, &req)
+		if err != nil || res == nil {
+			return nil, err
+		}
+		taskOutputs := res.GetTaskOutputs()
+		if len(taskOutputs) <= 0 {
+			return nil, fmt.Errorf("invalid output: %v for model: %s", taskOutputs, modelName)
+		}
+
+		textGenChatOutput := taskOutputs[0].GetTextGenerationChat()
+		if textGenChatOutput == nil {
+			return nil, fmt.Errorf("invalid output: %v for model: %s", textGenChatOutput, modelName)
+		}
+		outputJson, err := protojson.MarshalOptions{
+			UseProtoNames:   true,
+			EmitUnpopulated: true,
+		}.Marshal(textGenChatOutput)
+		if err != nil {
+			return nil, err
+		}
+		output := &structpb.Struct{}
+		err = protojson.Unmarshal(outputJson, output)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/openai/client.go
+++ b/pkg/openai/client.go
@@ -6,10 +6,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-type oaClient struct {
-	*httpclient.Client
-}
-
 func newClient(config *structpb.Struct, logger *zap.Logger) *httpclient.Client {
 	c := httpclient.New("OpenAI", getBasePath(config),
 		httpclient.WithLogger(logger),

--- a/pkg/openai/config/tasks.json
+++ b/pkg/openai/config/tasks.json
@@ -3,12 +3,10 @@
     "chat_message": {
       "properties": {
         "content": {
+          "$ref": "https://raw.githubusercontent.com/instill-ai/component/5e43199713238124565c596433927ef7cb92c565/schema.json#/$defs/instill_types/multi_modal_content",
           "description": "The message content",
-          "instillFormat": "string",
-          "instillUIMultiline": true,
           "instillUIOrder": 1,
-          "title": "Content",
-          "type": "string"
+          "title": "Content"
         },
         "role": {
           "description": "The message role, i.e. 'system', 'user' or 'assistant'",
@@ -186,7 +184,7 @@
         "chat_history": {
           "description": "Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: : {\"role\": \"The message role, i.e. 'system', 'user' or 'assistant'\", \"content\": \"message content\"}.",
           "instillAcceptFormats": [
-            "array:*/*"
+            "structured/chat_messages"
           ],
           "instillShortDescription": "Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: : {\"role\": \"The message role, i.e. 'system', 'user' or 'assistant'\", \"content\": \"message content\"}.",
           "instillUIOrder": 4,

--- a/pkg/openai/text_generation.go
+++ b/pkg/openai/text_generation.go
@@ -5,8 +5,8 @@ const (
 )
 
 type TextMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role    string    `json:"role"`
+	Content []Content `json:"content"`
 }
 type TextCompletionInput struct {
 	Prompt           string                `json:"prompt"`
@@ -34,7 +34,7 @@ type TextCompletionOutput struct {
 
 type TextCompletionReq struct {
 	Model            string                `json:"model"`
-	Messages         []Message             `json:"messages"`
+	Messages         []interface{}         `json:"messages"`
 	Temperature      *float32              `json:"temperature,omitempty"`
 	TopP             *float32              `json:"top_p,omitempty"`
 	N                *int                  `json:"n,omitempty"`
@@ -45,9 +45,14 @@ type TextCompletionReq struct {
 	ResponseFormat   *ResponseFormatStruct `json:"response_format,omitempty"`
 }
 
-type Message struct {
+type MultiModalMessage struct {
 	Role    string    `json:"role"`
 	Content []Content `json:"content"`
+}
+
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
 }
 
 type ImageUrl struct {

--- a/pkg/pinecone/config/tasks.json
+++ b/pkg/pinecone/config/tasks.json
@@ -3,12 +3,27 @@
     "input": {
       "instillUIOrder": 0,
       "properties": {
+        "filter": {
+          "description": "The filter to apply. You can use vector metadata to limit your search. See https://www.pinecone.io/docs/metadata-filtering/.",
+          "instillAcceptFormats": [
+            "semi-structured/object"
+          ],
+          "instillShortDescription": "The filter to apply on vector metadata",
+          "instillUIOrder": 3,
+          "instillUpstreamTypes": [
+            "reference"
+          ],
+          "order": 1,
+          "required": [],
+          "title": "Filter",
+          "type": "object"
+        },
         "id": {
           "description": "The unique ID of the vector to be used as a query vector. If present, the vector parameter will be ignored.",
-          "instillShortDescription": "Query by vector ID instead of by vector",
           "instillAcceptFormats": [
             "string"
           ],
+          "instillShortDescription": "Query by vector ID instead of by vector",
           "instillUIOrder": 0,
           "instillUpstreamTypes": [
             "reference",
@@ -16,6 +31,34 @@
           ],
           "title": "ID",
           "type": "string"
+        },
+        "include_metadata": {
+          "default": false,
+          "description": "Indicates whether metadata is included in the response as well as the IDs",
+          "instillAcceptFormats": [
+            "boolean"
+          ],
+          "instillUIOrder": 5,
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "title": "Include Metadata",
+          "type": "boolean"
+        },
+        "include_values": {
+          "default": false,
+          "description": "Indicates whether vector values are included in the response",
+          "instillAcceptFormats": [
+            "boolean"
+          ],
+          "instillUIOrder": 4,
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "title": "Include Values",
+          "type": "boolean"
         },
         "namespace": {
           "description": "The namespace to query",
@@ -30,6 +73,19 @@
           ],
           "title": "Namespace",
           "type": "string"
+        },
+        "top_k": {
+          "description": "The number of results to return for each query",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUIOrder": 6,
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "title": "Top K",
+          "type": "integer"
         },
         "vector": {
           "description": "An array of dimensions for the query vector.",
@@ -49,62 +105,6 @@
           "minItems": 1,
           "title": "Vector",
           "type": "array"
-        },
-        "filter": {
-          "description": "The filter to apply. You can use vector metadata to limit your search. See https://www.pinecone.io/docs/metadata-filtering/.",
-          "instillAcceptFormats": [
-            "semi-structured/object"
-          ],
-          "instillShortDescription": "The filter to apply on vector metadata",
-          "instillUIOrder": 3,
-          "instillUpstreamTypes": [
-            "reference"
-          ],
-          "order": 1,
-          "required": [],
-          "title": "Filter",
-          "type": "object"
-        },
-        "include_values": {
-          "default": false,
-          "description": "Indicates whether vector values are included in the response",
-          "instillAcceptFormats": [
-            "boolean"
-          ],
-          "instillUIOrder": 4,
-          "instillUpstreamTypes": [
-            "value",
-            "reference"
-          ],
-          "title": "Include Values",
-          "type": "boolean"
-        },
-        "include_metadata": {
-          "default": false,
-          "description": "Indicates whether metadata is included in the response as well as the IDs",
-          "instillAcceptFormats": [
-            "boolean"
-          ],
-          "instillUIOrder": 5,
-          "instillUpstreamTypes": [
-            "value",
-            "reference"
-          ],
-          "title": "Include Metadata",
-          "type": "boolean"
-        },
-        "top_k": {
-          "description": "The number of results to return for each query",
-          "instillAcceptFormats": [
-            "integer"
-          ],
-          "instillUIOrder": 6,
-          "instillUpstreamTypes": [
-            "value",
-            "reference"
-          ],
-          "title": "Top K",
-          "type": "integer"
         }
       },
       "required": [
@@ -131,8 +131,8 @@
               },
               "metadata": {
                 "description": "Metadata",
-                "instillUIOrder": 3,
                 "instillFormat": "semi-structured/object",
+                "instillUIOrder": 3,
                 "required": [],
                 "title": "Metadata",
                 "type": "object"
@@ -199,6 +199,21 @@
           "title": "ID",
           "type": "string"
         },
+        "metadata": {
+          "description": "The vector metadata",
+          "instillAcceptFormats": [
+            "semi-structured/object"
+          ],
+          "instillShortDescription": "The vector metadata",
+          "instillUIOrder": 2,
+          "instillUpstreamTypes": [
+            "reference"
+          ],
+          "order": 1,
+          "required": [],
+          "title": "Metadata",
+          "type": "object"
+        },
         "values": {
           "description": "An array of dimensions for the vector to be saved",
           "instillAcceptFormats": [
@@ -217,21 +232,6 @@
           "minItems": 1,
           "title": "Values",
           "type": "array"
-        },
-        "metadata": {
-          "description": "The vector metadata",
-          "instillAcceptFormats": [
-            "semi-structured/object"
-          ],
-          "instillShortDescription": "The vector metadata",
-          "instillUIOrder": 2,
-          "instillUpstreamTypes": [
-            "reference"
-          ],
-          "order": 1,
-          "required": [],
-          "title": "Metadata",
-          "type": "object"
         }
       },
       "required": [

--- a/pkg/pinecone/connector_test.go
+++ b/pkg/pinecone/connector_test.go
@@ -174,7 +174,7 @@ func TestConnector_Execute(t *testing.T) {
 			pineconeServer := httptest.NewServer(h)
 			c.Cleanup(pineconeServer.Close)
 
-			config, err := structpb.NewStruct(map[string]any{
+			config, _ := structpb.NewStruct(map[string]any{
 				"api_key": pineconeKey,
 				"url":     pineconeServer.URL,
 			})
@@ -205,7 +205,7 @@ func TestConnector_Execute(t *testing.T) {
 		pineconeServer := httptest.NewServer(h)
 		c.Cleanup(pineconeServer.Close)
 
-		config, err := structpb.NewStruct(map[string]any{
+		config, _ := structpb.NewStruct(map[string]any{
 			"url": pineconeServer.URL,
 		})
 
@@ -221,7 +221,7 @@ func TestConnector_Execute(t *testing.T) {
 	})
 
 	c.Run("nok - URL misconfiguration", func(c *qt.C) {
-		config, err := structpb.NewStruct(map[string]any{
+		config, _ := structpb.NewStruct(map[string]any{
 			"url": "http://no-such.host",
 		})
 

--- a/pkg/redis/chat_history.go
+++ b/pkg/redis/chat_history.go
@@ -20,14 +20,38 @@ type Message struct {
 	Metadata *map[string]interface{} `json:"metadata,omitempty"`
 }
 
+type MultiModalMessage struct {
+	Role     string                  `json:"role"`
+	Content  []MultiModalContent     `json:"content"`
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+}
+
+type MultiModalContent struct {
+	Type     string  `json:"type"`
+	Text     *string `json:"text,omitempty"`
+	ImageUrl *struct {
+		Url string `json:"url"`
+	} `json:"image_url,omitempty"`
+}
+
 type MessageWithTime struct {
 	Message
+	Timestamp int64 `json:"timestamp"`
+}
+
+type MultiModalMessageWithTime struct {
+	MultiModalMessage
 	Timestamp int64 `json:"timestamp"`
 }
 
 type ChatMessageWriteInput struct {
 	SessionID string `json:"session_id"`
 	Message
+}
+
+type ChatMultiModalMessageWriteInput struct {
+	SessionID string `json:"session_id"`
+	MultiModalMessage
 }
 
 type ChatMessageWriteOutput struct {
@@ -42,22 +66,22 @@ type ChatHistoryRetrieveInput struct {
 
 // ChatHistoryReadOutput is a wrapper struct for the messages associated with a session ID
 type ChatHistoryRetrieveOutput struct {
-	Messages []*Message `json:"messages"`
-	Status   bool       `json:"status"`
+	Messages []*MultiModalMessage `json:"messages"`
+	Status   bool                 `json:"status"`
 }
 
 // WriteSystemMessage writes system message for a given session ID
-func WriteSystemMessage(client *goredis.Client, sessionID string, message MessageWithTime) error {
+func WriteSystemMessage(client *goredis.Client, sessionID string, message MultiModalMessageWithTime) error {
 	messageJSON, err := json.Marshal(message)
 	if err != nil {
 		return err
 	}
 
 	// Store in a hash with a unique SessionID
-	return client.HSet(context.Background(), "system_messages", sessionID, messageJSON).Err()
+	return client.HSet(context.Background(), "chat_history:system_messages", sessionID, messageJSON).Err()
 }
 
-func WriteNonSystemMessage(client *goredis.Client, sessionID string, message MessageWithTime) error {
+func WriteNonSystemMessage(client *goredis.Client, sessionID string, message MultiModalMessageWithTime) error {
 	// Marshal the MessageWithTime struct to JSON
 	messageJSON, err := json.Marshal(message)
 	if err != nil {
@@ -65,15 +89,15 @@ func WriteNonSystemMessage(client *goredis.Client, sessionID string, message Mes
 	}
 
 	// Index by Timestamp: Add to the Sorted Set
-	return client.ZAdd(context.Background(), sessionID+":timestamps", goredis.Z{
+	return client.ZAdd(context.Background(), "chat_history:"+sessionID+":timestamps", goredis.Z{
 		Score:  float64(message.Timestamp),
 		Member: string(messageJSON),
 	}).Err()
 }
 
 // RetrieveSystemMessage gets system message based on a given session ID
-func RetrieveSystemMessage(client *goredis.Client, sessionID string) (bool, *MessageWithTime, error) {
-	serializedMessage, err := client.HGet(context.Background(), "system_messages", sessionID).Result()
+func RetrieveSystemMessage(client *goredis.Client, sessionID string) (bool, *MultiModalMessageWithTime, error) {
+	serializedMessage, err := client.HGet(context.Background(), "chat_history:system_messages", sessionID).Result()
 
 	// Check if the messageID does not exist
 	if err == goredis.Nil {
@@ -84,7 +108,7 @@ func RetrieveSystemMessage(client *goredis.Client, sessionID string) (bool, *Mes
 		return false, nil, err
 	}
 
-	var message MessageWithTime
+	var message MultiModalMessageWithTime
 	if err := json.Unmarshal([]byte(serializedMessage), &message); err != nil {
 		return false, nil, err
 	}
@@ -97,8 +121,45 @@ func WriteMessage(client *goredis.Client, input ChatMessageWriteInput) ChatMessa
 	currTime := time.Now().Unix()
 
 	// Create a MessageWithTime struct with the provided input and timestamp
-	messageWithTime := MessageWithTime{
-		Message: Message{
+	messageWithTime := MultiModalMessageWithTime{
+		MultiModalMessage: MultiModalMessage{
+			Role: input.Role,
+			Content: []MultiModalContent{
+				{
+					Type: "text",
+					Text: &input.Content,
+				},
+			},
+			Metadata: input.Metadata,
+		},
+		Timestamp: currTime,
+	}
+
+	// Treat system message differently
+	if input.Role == "system" {
+		err := WriteSystemMessage(client, input.SessionID, messageWithTime)
+		if err != nil {
+			return ChatMessageWriteOutput{Status: false}
+		} else {
+			return ChatMessageWriteOutput{Status: true}
+		}
+	}
+
+	err := WriteNonSystemMessage(client, input.SessionID, messageWithTime)
+	if err != nil {
+		return ChatMessageWriteOutput{Status: false}
+	} else {
+		return ChatMessageWriteOutput{Status: true}
+	}
+}
+
+func WriteMultiModelMessage(client *goredis.Client, input ChatMultiModalMessageWriteInput) ChatMessageWriteOutput {
+	// Current time
+	currTime := time.Now().Unix()
+
+	// Create a MessageWithTime struct with the provided input and timestamp
+	messageWithTime := MultiModalMessageWithTime{
+		MultiModalMessage: MultiModalMessage{
 			Role:     input.Role,
 			Content:  input.Content,
 			Metadata: input.Metadata,
@@ -131,13 +192,13 @@ func RetrieveSessionMessages(client *goredis.Client, input ChatHistoryRetrieveIn
 	}
 	key := input.SessionID
 
-	messagesWithTime := []MessageWithTime{}
-	messages := []*Message{}
+	messagesWithTime := []MultiModalMessageWithTime{}
+	messages := []*MultiModalMessage{}
 	ctx := context.Background()
 
 	// Retrieve the latest K conversation turns associated with the session ID by descending timestamp order
 	messagesNum := *input.LatestK * 2
-	timestampMessages, err := client.ZRevRange(ctx, key+":timestamps", 0, int64(messagesNum-1)).Result()
+	timestampMessages, err := client.ZRevRange(ctx, "chat_history:"+key+":timestamps", 0, int64(messagesNum-1)).Result()
 	if err != nil {
 		return ChatHistoryRetrieveOutput{
 			Messages: messages,
@@ -147,7 +208,7 @@ func RetrieveSessionMessages(client *goredis.Client, input ChatHistoryRetrieveIn
 
 	// Iterate through the members and deserialize them into MessageWithTime
 	for _, member := range timestampMessages {
-		var messageWithTime MessageWithTime
+		var messageWithTime MultiModalMessageWithTime
 		if err := json.Unmarshal([]byte(member), &messageWithTime); err != nil {
 			return ChatHistoryRetrieveOutput{
 				Messages: messages,
@@ -172,7 +233,7 @@ func RetrieveSessionMessages(client *goredis.Client, input ChatHistoryRetrieveIn
 			}
 		}
 		if exist {
-			messages = append(messages, &Message{
+			messages = append(messages, &MultiModalMessage{
 				Role:     sysMessage.Role,
 				Content:  sysMessage.Content,
 				Metadata: sysMessage.Metadata,
@@ -182,7 +243,7 @@ func RetrieveSessionMessages(client *goredis.Client, input ChatHistoryRetrieveIn
 
 	// Convert the MessageWithTime structs to Message structs
 	for _, m := range messagesWithTime {
-		messages = append(messages, &Message{
+		messages = append(messages, &MultiModalMessage{
 			Role:     m.Role,
 			Content:  m.Content,
 			Metadata: m.Metadata,

--- a/pkg/redis/config/definitions.json
+++ b/pkg/redis/config/definitions.json
@@ -2,7 +2,8 @@
   {
     "available_tasks": [
       "TASK_CHAT_HISTORY_RETRIEVE",
-      "TASK_CHAT_MESSAGE_WRITE"
+      "TASK_CHAT_MESSAGE_WRITE",
+      "TASK_CHAT_MESSAGE_WRITE_MULTI_MODAL"
     ],
     "custom": false,
     "documentation_url": "https://www.instill.tech/docs/latest/vdp/data-connectors/redis",

--- a/pkg/redis/config/tasks.json
+++ b/pkg/redis/config/tasks.json
@@ -1,39 +1,4 @@
 {
-  "$defs": {
-    "message": {
-      "properties": {
-        "content": {
-          "description": "The message content",
-          "instillFormat": "string",
-          "instillUIMultiline": true,
-          "instillUIOrder": 1,
-          "title": "Content",
-          "type": "string"
-        },
-        "metadata": {
-          "additionalProperties": true,
-          "description": "The message metadata",
-          "instillUIOrder": 2,
-          "required": [],
-          "title": "Metadata",
-          "type": "object"
-        },
-        "role": {
-          "description": "The message role, i.e. 'system', 'user' or 'assistant'",
-          "instillFormat": "string",
-          "instillUIOrder": 0,
-          "title": "Role",
-          "type": "string"
-        }
-      },
-      "required": [
-        "role",
-        "content"
-      ],
-      "title": "Message",
-      "type": "object"
-    }
-  },
   "TASK_CHAT_HISTORY_RETRIEVE": {
     "input": {
       "instillUIOrder": 0,
@@ -92,13 +57,7 @@
       "instillUIOrder": 0,
       "properties": {
         "messages": {
-          "description": "The retrieved chat messages",
-          "instillUIOrder": 0,
-          "items": {
-            "$ref": "#/$defs/message"
-          },
-          "title": "Messages",
-          "type": "array"
+          "$ref": "https://raw.githubusercontent.com/instill-ai/component/747ec5eaa8fe611c3be91354923afd544eb54b13/schema.json#/$defs/instill_types/chat_messages"
         }
       },
       "required": [
@@ -123,6 +82,86 @@
             "value",
             "reference",
             "template"
+          ],
+          "title": "Content",
+          "type": "string"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "description": "The message metadata",
+          "instillUIOrder": 3,
+          "required": [],
+          "title": "Metadata",
+          "type": "object"
+        },
+        "role": {
+          "description": "The message role, i.e. 'system', 'user' or 'assistant'",
+          "instillAcceptFormats": [
+            "string"
+          ],
+          "instillUIOrder": 1,
+          "instillUpstreamTypes": [
+            "value",
+            "reference",
+            "template"
+          ],
+          "title": "Role",
+          "type": "string"
+        },
+        "session_id": {
+          "description": "A unique identifier for the chat session",
+          "instillAcceptFormats": [
+            "string"
+          ],
+          "instillUIOrder": 0,
+          "instillUpstreamTypes": [
+            "value",
+            "reference",
+            "template"
+          ],
+          "title": "Session ID",
+          "type": "string"
+        }
+      },
+      "required": [
+        "session_id",
+        "role",
+        "content"
+      ],
+      "title": "Input",
+      "type": "object"
+    },
+    "output": {
+      "instillUIOrder": 0,
+      "properties": {
+        "status": {
+          "description": "The status of the write operation",
+          "instillFormat": "boolean",
+          "instillUIOrder": 0,
+          "title": "Status",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "status"
+      ],
+      "title": "Output",
+      "type": "object"
+    }
+  },
+  "TASK_CHAT_MESSAGE_WRITE_MULTI_MODAL": {
+    "input": {
+      "instillUIOrder": 0,
+      "properties": {
+        "content": {
+          "$ref": "https://raw.githubusercontent.com/instill-ai/component/747ec5eaa8fe611c3be91354923afd544eb54b13/schema.json#/$defs/instill_types/multi_modal_content",
+          "description": "The multi-modal message content",
+          "instillAcceptFormats": [
+            "structured/multi_modal_content"
+          ],
+          "instillUIOrder": 2,
+          "instillUpstreamTypes": [
+            "reference"
           ],
           "title": "Content",
           "type": "string"

--- a/pkg/redis/main.go
+++ b/pkg/redis/main.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	taskChatMessageWrite    = "TASK_CHAT_MESSAGE_WRITE"
-	taskChatHistoryRetrieve = "TASK_CHAT_HISTORY_RETRIEVE"
+	taskChatMessageWrite           = "TASK_CHAT_MESSAGE_WRITE"
+	taskChatMessageWriteMultiModal = "TASK_CHAT_MESSAGE_WRITE_MULTI_MODAL"
+	taskChatHistoryRetrieve        = "TASK_CHAT_HISTORY_RETRIEVE"
 )
 
 var (
@@ -78,6 +79,17 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 				return nil, err
 			}
 			outputStruct := WriteMessage(client, inputStruct)
+			output, err = base.ConvertToStructpb(outputStruct)
+			if err != nil {
+				return nil, err
+			}
+		case taskChatMessageWriteMultiModal:
+			inputStruct := ChatMultiModalMessageWriteInput{}
+			err := base.ConvertFromStructpb(input, &inputStruct)
+			if err != nil {
+				return nil, err
+			}
+			outputStruct := WriteMultiModelMessage(client, inputStruct)
 			output, err = base.ConvertToStructpb(outputStruct)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Because

- Previously, we didn't have a standardized chat history format, which caused an issue where our chat history data in Redis could not be shared among different LLM tasks providers. We have decided to use the [OpenAI message format](https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages) as a reference and unify all the chat history formats in VDP.

This commit

- Unifies the chat history format across different LLM tasks.