### PR TITLE
feat(website): add `https` protocol to the url automatically

### DIFF
--- a/pkg/website/scrape_website.go
+++ b/pkg/website/scrape_website.go
@@ -176,6 +176,9 @@ func Scrape(input ScrapeWebsiteInput) (ScrapeWebsiteOutput, error) {
 	})
 
 	// Start scraping
+	if !strings.HasPrefix(input.TargetURL, "http://") && !strings.HasPrefix(input.TargetURL, "https://") {
+		input.TargetURL = "https://" + input.TargetURL
+	}
 	_ = c.Visit(input.TargetURL)
 
 	return output, nil


### PR DESCRIPTION
Because

- Sometimes, users will only use the URL without a protocol, e.g., `instill.tech` rather than `https://instill.tech`. We should add the default `https` protocol when it is not provided.

This commit

- Automatically adds the `https` protocol to the URL when there is no protocol specified.