### PR TITLE
fix(instill): fix wrong required field in json-schema

### DIFF
--- a/pkg/instill/config/definitions.json
+++ b/pkg/instill/config/definitions.json
@@ -50,12 +50,12 @@
                 "title": "Server URL",
                 "type": "string"
               }
-            }
+            },
+            "required": [
+              "api_token",
+              "server_url"
+            ]
           }
-        ],
-        "required": [
-          "api_token",
-          "server_url"
         ],
         "title": "Instill Model Connector",
         "type": "object"

--- a/pkg/instill/config/tasks.json
+++ b/pkg/instill/config/tasks.json
@@ -90,7 +90,7 @@
       "instillUpstreamTypes": [
         "reference"
       ],
-      "required":[],
+      "required": [],
       "title": "Extra Parameters",
       "type": "object"
     }
@@ -357,23 +357,6 @@
           "title": "Chat history",
           "type": "array"
         },
-        "system_message": {
-          "default": "You are a helpful assistant.",
-          "description": "The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model\u2019s behavior is using a generic message as \"You are a helpful assistant.\"",
-          "instillAcceptFormats": [
-            "string"
-          ],
-          "instillShortDescription": "The system message helps set the behavior of the assistant",
-          "instillUIMultiline": true,
-          "instillUIOrder": 2,
-          "instillUpstreamTypes": [
-            "value",
-            "reference",
-            "template"
-          ],
-          "title": "System message",
-          "type": "string"
-        },
         "extra_params": {
           "$ref": "#/$defs/extra_params"
         },
@@ -461,6 +444,23 @@
           ],
           "title": "Seed",
           "type": "integer"
+        },
+        "system_message": {
+          "default": "You are a helpful assistant.",
+          "description": "The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model\u2019s behavior is using a generic message as \"You are a helpful assistant.\"",
+          "instillAcceptFormats": [
+            "string"
+          ],
+          "instillShortDescription": "The system message helps set the behavior of the assistant",
+          "instillUIMultiline": true,
+          "instillUIOrder": 2,
+          "instillUpstreamTypes": [
+            "value",
+            "reference",
+            "template"
+          ],
+          "title": "System message",
+          "type": "string"
         },
         "temperature": {
           "default": 0.7,


### PR DESCRIPTION
Because

- `required` field in json-schema of Instill Model connector is wrong

This commit

- fix wrong `required` field in json-schema
