### PR TITLE
feat(instill): generate enumeration for `model_name` automatically

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/gocolly/colly/v2 v2.1.0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/h2non/filetype v1.1.3
-	github.com/instill-ai/component v0.8.0-beta.0.20240109061804-abed794dc3a1
+	github.com/instill-ai/component v0.8.0-beta.0.20240112032605-792559e0b538
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240105094938-3a71d8f7a812
 	github.com/instill-ai/x v0.3.0-alpha.0.20231219052200-6230a89e386c
 	github.com/redis/go-redis/v9 v9.3.0

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
-github.com/instill-ai/component v0.8.0-beta.0.20240109061804-abed794dc3a1 h1:6XOE8keNtcyqx7hTlKntbfkW3iuaSdQLrsm9fpWpe5o=
-github.com/instill-ai/component v0.8.0-beta.0.20240109061804-abed794dc3a1/go.mod h1:fWyVPJVJ4WyFSQMgWCc7KvcS7m9QpdS3VXCL2CZE8OY=
+github.com/instill-ai/component v0.8.0-beta.0.20240112032605-792559e0b538 h1:wHkWugd03PwOrupcwrd8/FBaeQhKyvK0xmEK6vwmZVM=
+github.com/instill-ai/component v0.8.0-beta.0.20240112032605-792559e0b538/go.mod h1:fWyVPJVJ4WyFSQMgWCc7KvcS7m9QpdS3VXCL2CZE8OY=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240105094938-3a71d8f7a812 h1:n1EQFT0NeXkmiCD/YtoLG+b/OPo2tNg7MVK0dHNFlvk=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240105094938-3a71d8f7a812/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
 github.com/instill-ai/x v0.3.0-alpha.0.20231219052200-6230a89e386c h1:a2RVkpIV2QcrGnSHAou+t/L+vBsaIfFvk5inVg5Uh4s=

--- a/pkg/airbyte/main.go
+++ b/pkg/airbyte/main.go
@@ -89,13 +89,13 @@ func Init(logger *zap.Logger, options ConnectorOptions) base.IConnector {
 		}
 
 		if options.ExcludeLocalConnector {
-			def, _ := connector.GetConnectorDefinitionByID("airbyte-destination-local-json")
+			def, _ := connector.GetConnectorDefinitionByID("airbyte-destination-local-json", nil, nil)
 			(*def).Tombstone = true
-			def, _ = connector.GetConnectorDefinitionByID("airbyte-destination-csv")
+			def, _ = connector.GetConnectorDefinitionByID("airbyte-destination-csv", nil, nil)
 			(*def).Tombstone = true
-			def, _ = connector.GetConnectorDefinitionByID("airbyte-destination-sqlite")
+			def, _ = connector.GetConnectorDefinitionByID("airbyte-destination-sqlite", nil, nil)
 			(*def).Tombstone = true
-			def, _ = connector.GetConnectorDefinitionByID("airbyte-destination-duckdb")
+			def, _ = connector.GetConnectorDefinitionByID("airbyte-destination-duckdb", nil, nil)
 			(*def).Tombstone = true
 		}
 
@@ -159,7 +159,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	// Remove the last "\n"
 	byteAbMsgs = byteAbMsgs[:len(byteAbMsgs)-1]
 
-	connDef, err := e.connector.GetConnectorDefinitionByUID(e.UID)
+	connDef, err := e.connector.GetConnectorDefinitionByUID(e.UID, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +330,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 
 func (con *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 
-	def, err := con.GetConnectorDefinitionByUID(defUid)
+	def, err := con.GetConnectorDefinitionByUID(defUid, nil, nil)
 	if err != nil {
 		return pipelinePB.Connector_STATE_ERROR, err
 	}

--- a/pkg/instill/client.go
+++ b/pkg/instill/client.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
+	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
@@ -28,6 +29,24 @@ func initModelPublicServiceClient(serverURL string) (modelPB.ModelPublicServiceC
 	}
 
 	return modelPB.NewModelPublicServiceClient(clientConn), clientConn
+}
+
+func initMgmtPublicServiceClient(serverURL string) (mgmtPB.MgmtPublicServiceClient, *grpc.ClientConn) {
+	var clientDialOpts grpc.DialOption
+
+	if strings.HasPrefix(serverURL, "https://") {
+		clientDialOpts = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true}))
+	} else {
+		clientDialOpts = grpc.WithTransportCredentials(insecure.NewCredentials())
+	}
+
+	serverURL = stripProtocolFromURL(serverURL)
+	clientConn, err := grpc.Dial(serverURL, clientDialOpts)
+	if err != nil {
+		return nil, nil
+	}
+
+	return mgmtPB.NewMgmtPublicServiceClient(clientConn), clientConn
 }
 
 func stripProtocolFromURL(url string) string {

--- a/pkg/instill/config/tasks.json
+++ b/pkg/instill/config/tasks.json
@@ -27,8 +27,7 @@
       "description": "Input",
       "instillEditOnNodeFields": [
         "image_base64",
-        "model_namespace",
-        "model_id"
+        "model_name"
       ],
       "instillUIOrder": 0,
       "properties": {
@@ -44,22 +43,8 @@
           "title": "Image",
           "type": "string"
         },
-        "model_id": {
-          "description": "ID of the Instill Model model to be used.",
-          "instillAcceptFormats": [
-            "string"
-          ],
-          "instillUIOrder": 1,
-          "instillUpstreamTypes": [
-            "value",
-            "reference",
-            "template"
-          ],
-          "title": "Model ID",
-          "type": "string"
-        },
-        "model_namespace": {
-          "description": "Namespace of the Instill Model model to be used.",
+        "model_name": {
+          "description": "The Instill Model model to be used.",
           "instillAcceptFormats": [
             "string"
           ],
@@ -69,14 +54,13 @@
             "reference",
             "template"
           ],
-          "title": "Model Namespace",
+          "title": "Model Name",
           "type": "string"
         }
       },
       "required": [
         "image_base64",
-        "model_namespace",
-        "model_id"
+        "model_name"
       ],
       "title": "Input",
       "type": "object"
@@ -127,8 +111,7 @@
       "instillEditOnNodeFields": [
         "prompt",
         "image_base64",
-        "model_namespace",
-        "model_id"
+        "model_name"
       ],
       "instillUIOrder": 0,
       "properties": {
@@ -161,22 +144,8 @@
           "title": "Prompt Image",
           "type": "string"
         },
-        "model_id": {
-          "description": "ID of the Instill Model model to be used.",
-          "instillAcceptFormats": [
-            "string"
-          ],
-          "instillUIOrder": 1,
-          "instillUpstreamTypes": [
-            "value",
-            "reference",
-            "template"
-          ],
-          "title": "Model ID",
-          "type": "string"
-        },
-        "model_namespace": {
-          "description": "Namespace of the Instill Model model to be used.",
+        "model_name": {
+          "description": "The Instill Model model to be used.",
           "instillAcceptFormats": [
             "string"
           ],
@@ -186,7 +155,7 @@
             "reference",
             "template"
           ],
-          "title": "Model Namespace",
+          "title": "Model Name",
           "type": "string"
         },
         "prompt": {
@@ -248,8 +217,7 @@
       "required": [
         "prompt",
         "image_base64",
-        "model_namespace",
-        "model_id"
+        "model_name"
       ],
       "title": "Input",
       "type": "object"
@@ -336,8 +304,7 @@
       "description": "Input",
       "instillEditOnNodeFields": [
         "prompt",
-        "model_namespace",
-        "model_id"
+        "model_name"
       ],
       "instillUIOrder": 0,
       "properties": {
@@ -374,22 +341,8 @@
           "title": "Max new tokens",
           "type": "integer"
         },
-        "model_id": {
-          "description": "ID of the Instill Model model to be used.",
-          "instillAcceptFormats": [
-            "string"
-          ],
-          "instillUIOrder": 1,
-          "instillUpstreamTypes": [
-            "value",
-            "reference",
-            "template"
-          ],
-          "title": "Model ID",
-          "type": "string"
-        },
-        "model_namespace": {
-          "description": "Namespace of the Instill Model model to be used.",
+        "model_name": {
+          "description": "The Instill Model model to be used.",
           "instillAcceptFormats": [
             "string"
           ],
@@ -399,7 +352,7 @@
             "reference",
             "template"
           ],
-          "title": "Model Namespace",
+          "title": "Model Name",
           "type": "string"
         },
         "prompt": {
@@ -493,8 +446,7 @@
       },
       "required": [
         "prompt",
-        "model_namespace",
-        "model_id"
+        "model_name"
       ],
       "title": "Input",
       "type": "object"
@@ -530,8 +482,7 @@
       "description": "Input",
       "instillEditOnNodeFields": [
         "prompt",
-        "model_namespace",
-        "model_id"
+        "model_name"
       ],
       "instillUIOrder": 0,
       "properties": {
@@ -552,22 +503,8 @@
         "extra_params": {
           "$ref": "#/$defs/extra_params"
         },
-        "model_id": {
-          "description": "ID of the Instill Model model to be used.",
-          "instillAcceptFormats": [
-            "string"
-          ],
-          "instillUIOrder": 1,
-          "instillUpstreamTypes": [
-            "value",
-            "reference",
-            "template"
-          ],
-          "title": "Model ID",
-          "type": "string"
-        },
-        "model_namespace": {
-          "description": "Namespace of the Instill Model model to be used.",
+        "model_name": {
+          "description": "The Instill Model model to be used.",
           "instillAcceptFormats": [
             "string"
           ],
@@ -577,7 +514,7 @@
             "reference",
             "template"
           ],
-          "title": "Model Namespace",
+          "title": "Model Name",
           "type": "string"
         },
         "prompt": {
@@ -637,8 +574,7 @@
       },
       "required": [
         "prompt",
-        "model_namespace",
-        "model_id"
+        "model_name"
       ],
       "title": "Input",
       "type": "object"

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -31,6 +31,7 @@ var connector base.IConnector
 type Connector struct {
 	base.Connector
 	connectorUIDMap map[uuid.UUID]base.IConnector
+	connectorIDMap  map[string]base.IConnector
 }
 
 type ConnectorOptions struct {
@@ -43,6 +44,7 @@ func Init(logger *zap.Logger, options ConnectorOptions) base.IConnector {
 		connector = &Connector{
 			Connector:       base.Connector{Component: base.Component{Logger: logger}},
 			connectorUIDMap: map[uuid.UUID]base.IConnector{},
+			connectorIDMap:  map[string]base.IConnector{},
 		}
 
 		connector.(*Connector).ImportDefinitions(stabilityai.Init(logger))
@@ -69,6 +71,7 @@ func (c *Connector) ImportDefinitions(con base.IConnector) {
 			panic(err)
 		}
 		c.connectorUIDMap[uuid.FromStringOrNil(v.Uid)] = con
+		c.connectorIDMap[v.Id] = con
 	}
 }
 
@@ -78,4 +81,12 @@ func (c *Connector) CreateExecution(defUID uuid.UUID, task string, config *struc
 
 func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 	return c.connectorUIDMap[defUid].Test(defUid, config, logger)
+}
+
+func (c *Connector) GetConnectorDefinitionByID(defID string, resourceConfig *structpb.Struct, componentConfig *structpb.Struct) (*pipelinePB.ConnectorDefinition, error) {
+	return c.connectorIDMap[defID].GetConnectorDefinitionByID(defID, resourceConfig, componentConfig)
+}
+
+func (c *Connector) GetConnectorDefinitionByUID(defUid uuid.UUID, resourceConfig *structpb.Struct, componentConfig *structpb.Struct) (*pipelinePB.ConnectorDefinition, error) {
+	return c.connectorUIDMap[defUid].GetConnectorDefinitionByUID(defUid, resourceConfig, componentConfig)
 }


### PR DESCRIPTION
Because

- Originally, we used `model_namespace` and `model_id` to set up the Model connector. However, users may struggle to identify the correct values for these settings. To enhance user-friendliness, we should employ enumerations (options).

This commit

- generate enumeration for `model_name` automatically
