### PR TITLE
feat(restapi): inject the `output_body_schema` into component OpenAPI schema

### DIFF
--- a/pkg/restapi/config/definitions.json
+++ b/pkg/restapi/config/definitions.json
@@ -148,9 +148,6 @@
           },
           "base_url": {
             "description": "Base URL of the REST API",
-            "examples": [
-              "https://api.example.com/v1"
-            ],
             "instillUIOrder": 0,
             "order": 0,
             "title": "Base URL",
@@ -158,7 +155,6 @@
           }
         },
         "required": [
-          "base_url",
           "authentication"
         ],
         "title": "REST API Connector Spec",

--- a/pkg/restapi/config/tasks.json
+++ b/pkg/restapi/config/tasks.json
@@ -35,6 +35,24 @@
           ],
           "title": "Endpoint Path",
           "type": "string"
+        },
+        "output_body_schema": {
+          "description": "The request body",
+          "instillAcceptFormats": [
+            "string"
+          ],
+          "instillUIMultiline": true,
+          "instillMultiline": true,
+          "instillShortDescription": "The request body",
+          "instillUIOrder": 1,
+          "instillUpstreamTypes": [
+            "reference",
+            "value"
+          ],
+          "order": 2,
+          "required": [],
+          "title": "Body",
+          "type": "string"
         }
       },
       "required": [
@@ -58,6 +76,24 @@
             "template"
           ],
           "title": "Endpoint Path",
+          "type": "string"
+        },
+        "output_body_schema": {
+          "description": "The request body",
+          "instillAcceptFormats": [
+            "string"
+          ],
+          "instillShortDescription": "The request body",
+          "instillUIOrder": 1,
+          "instillUpstreamTypes": [
+            "reference",
+            "value"
+          ],
+          "instillUIMultiline": true,
+          "instillMultiline": true,
+          "order": 1,
+          "required": [],
+          "title": "Body",
           "type": "string"
         }
       },


### PR DESCRIPTION
Because

- In the RestAPI connector, we don't know the JSON schema of the response body, making it difficult to display on the console.
- Users may want to leave `base_url` empty and set up the full URL path directly in the component.

This commit

- Injects the `output_body_schema` into the component OpenAPI schema.
- Makes `base_url` optional.