### PR TITLE
feat(restapi): remove base_url in restapi connector

### DIFF
--- a/pkg/restapi/client.go
+++ b/pkg/restapi/client.go
@@ -17,8 +17,8 @@ type TaskOutput struct {
 	Header     map[string][]string    `json:"header"`
 }
 
-func newClient(baseUrl string, config *structpb.Struct, logger *zap.Logger) (*httpclient.Client, error) {
-	c := httpclient.New("REST API", baseUrl,
+func newClient(config *structpb.Struct, logger *zap.Logger) (*httpclient.Client, error) {
+	c := httpclient.New("REST API", "",
 		httpclient.WithLogger(logger),
 	)
 

--- a/pkg/restapi/client.go
+++ b/pkg/restapi/client.go
@@ -7,8 +7,8 @@ import (
 )
 
 type TaskInput struct {
-	EndpointPath *string                `json:"endpoint_path,omitempty"`
-	Body         map[string]interface{} `json:"body,omitempty"`
+	EndpointUrl string                 `json:"endpoint_url"`
+	Body        map[string]interface{} `json:"body,omitempty"`
 }
 
 type TaskOutput struct {
@@ -17,8 +17,8 @@ type TaskOutput struct {
 	Header     map[string][]string    `json:"header"`
 }
 
-func newClient(config *structpb.Struct, logger *zap.Logger) (*httpclient.Client, error) {
-	c := httpclient.New("REST API", getBaseURL(config),
+func newClient(baseUrl string, config *structpb.Struct, logger *zap.Logger) (*httpclient.Client, error) {
+	c := httpclient.New("REST API", baseUrl,
 		httpclient.WithLogger(logger),
 	)
 

--- a/pkg/restapi/config/definitions.json
+++ b/pkg/restapi/config/definitions.json
@@ -145,13 +145,6 @@
             "order": 1,
             "title": "Authentication",
             "type": "object"
-          },
-          "base_url": {
-            "description": "Base URL of the REST API",
-            "instillUIOrder": 0,
-            "order": 0,
-            "title": "Base URL",
-            "type": "string"
           }
         },
         "required": [

--- a/pkg/restapi/config/tasks.json
+++ b/pkg/restapi/config/tasks.json
@@ -3,7 +3,7 @@
     "inputWithBody": {
       "instillEditOnNodeFields": [
         "body",
-        "endpoint_path"
+        "endpoint_url"
       ],
       "instillUIOrder": 0,
       "properties": {
@@ -22,8 +22,8 @@
           "title": "Body",
           "type": "object"
         },
-        "endpoint_path": {
-          "description": "The API endpoint path relative to the base URL",
+        "endpoint_url": {
+          "description": "The API endpoint url",
           "instillAcceptFormats": [
             "string"
           ],
@@ -33,7 +33,7 @@
             "reference",
             "template"
           ],
-          "title": "Endpoint Path",
+          "title": "Endpoint Url",
           "type": "string"
         },
         "output_body_schema": {
@@ -56,7 +56,7 @@
         }
       },
       "required": [
-        "endpoint_path"
+        "endpoint_url"
       ],
       "title": "Input",
       "type": "object"
@@ -64,8 +64,8 @@
     "inputWithoutBody": {
       "instillUIOrder": 0,
       "properties": {
-        "endpoint_path": {
-          "description": "The API endpoint path relative to the base URL",
+        "endpoint_url": {
+          "description": "The API endpoint url",
           "instillAcceptFormats": [
             "string"
           ],
@@ -75,7 +75,7 @@
             "reference",
             "template"
           ],
-          "title": "Endpoint Path",
+          "title": "Endpoint Url",
           "type": "string"
         },
         "output_body_schema": {
@@ -98,7 +98,7 @@
         }
       },
       "required": [
-        "endpoint_path"
+        "endpoint_url"
       ],
       "title": "Input",
       "type": "object"

--- a/pkg/restapi/connector_test.go
+++ b/pkg/restapi/connector_test.go
@@ -162,12 +162,6 @@ func TestConnector_Test(t *testing.T) {
 	connector := Init(logger)
 	defID := uuid.Must(uuid.NewV4())
 
-	c.Run("nok", func(c *qt.C) {
-		got, err := connector.Test(defID, cfg(noAuthType), logger)
-		c.Check(err, qt.IsNil)
-		c.Check(got, qt.Equals, pipelinePB.Connector_STATE_CONNECTED)
-	})
-
 	c.Run("ok - connected (even with non-2xx status", func(c *qt.C) {
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			c.Check(r.Method, qt.Equals, http.MethodGet)

--- a/pkg/restapi/main.go
+++ b/pkg/restapi/main.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"sync"
 
 	"github.com/gofrs/uuid"
@@ -135,15 +134,9 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 		if err := base.ConvertFromStructpb(input, &taskIn); err != nil {
 			return nil, err
 		}
-		url, err := url.Parse(taskIn.EndpointUrl)
-		if err != nil {
-			return nil, err
-		}
-		baseUrl := fmt.Sprintf("%s://%s", url.Scheme, url.Host)
-		path := url.Path
 
 		// We may have different url in batch.
-		client, err := newClient(baseUrl, e.Config, e.Logger)
+		client, err := newClient(e.Config, e.Logger)
 		if err != nil {
 			return nil, err
 		}
@@ -154,7 +147,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 			req.SetBody(taskIn.Body)
 		}
 
-		resp, err := req.Execute(method, path)
+		resp, err := req.Execute(method, taskIn.EndpointUrl)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Because

- We should put the full URL in component setting, so that the user can have a better understanding of the meaning of the Restapi component.

This commit

- Move the URL field to the component configuration section, and only keep Authentication in the connector configuration.
