### PR TITLE
fix(googlesearch,website): fix potential memory leak by disabling http keep-alive

### DIFF
--- a/pkg/googlesearch/search.go
+++ b/pkg/googlesearch/search.go
@@ -72,7 +72,10 @@ func scrapeSearchResults(searchResults *customsearch.Search, includeLinkText, in
 		linkText, linkHtml := "", ""
 		if includeLinkText || includeLinkHtml {
 			// Make an HTTP GET request to the web page
-			response, err := http.Get(item.Link)
+			client := &http.Client{Transport: &http.Transport{
+				DisableKeepAlives: true,
+			}}
+			response, err := client.Get(item.Link)
 			if err != nil {
 				log.Printf("Error making HTTP GET request to %s: %v", item.Link, err)
 				continue

--- a/pkg/website/scrape_website.go
+++ b/pkg/website/scrape_website.go
@@ -74,7 +74,10 @@ func existsInSlice(slice []string, item string) bool {
 // getHTMLPageDoc returns the *goquery.Document of a webpage
 func getHTMLPageDoc(url string) (*goquery.Document, error) {
 	// Request the HTML page.
-	res, err := http.Get(url)
+	client := &http.Client{Transport: &http.Transport{
+		DisableKeepAlives: true,
+	}}
+	res, err := client.Get(url)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Because

- The default HTTP client enables HTTP keep-alive. In our architecture, it is challenging to reuse the same connection, which might cause some dangling connections.

This commit

- Fixes potential memory leaks by disabling HTTP keep-alive.