### PR TITLE
fix(stabilityai): add the missing datauri prefix in image-to-image task

### DIFF
--- a/pkg/stabilityai/connector_test.go
+++ b/pkg/stabilityai/connector_test.go
@@ -158,7 +158,7 @@ func TestConnector_ExecuteImageFromImage(t *testing.T) {
 			gotStatus: http.StatusOK,
 			gotResp:   okResp,
 			wantResp: ImageToImageOutput{
-				Images: []string{"a"},
+				Images: []string{"data:image/png;base64,a"},
 				Seeds:  []uint32{1234},
 			},
 		},

--- a/pkg/stabilityai/image_to_image.go
+++ b/pkg/stabilityai/image_to_image.go
@@ -175,7 +175,7 @@ func imageToImageOutput(from ImageTaskRes) (*structpb.Struct, error) {
 			continue
 		}
 
-		output.Images = append(output.Images, image.Base64)
+		output.Images = append(output.Images, fmt.Sprintf("data:image/png;base64,%s", image.Base64))
 		output.Seeds = append(output.Seeds, image.Seed)
 
 	}


### PR DESCRIPTION
Because

- The data-uri prefix in image-to-image task output is missing

This commit

- Add the missing data-uri prefix in image-to-image task
