### PR TITLE
feat: Extend Pinecone tasks with namespace and threshold

### DIFF
--- a/pkg/pinecone/config/tasks.json
+++ b/pkg/pinecone/config/tasks.json
@@ -205,7 +205,7 @@
             "semi-structured/object"
           ],
           "instillShortDescription": "The vector metadata",
-          "instillUIOrder": 2,
+          "instillUIOrder": 3,
           "instillUpstreamTypes": [
             "reference"
           ],
@@ -232,6 +232,20 @@
           "minItems": 1,
           "title": "Values",
           "type": "array"
+        },
+        "namespace": {
+          "description": "The namespace to query",
+          "instillAcceptFormats": [
+            "string"
+          ],
+          "instillUIOrder": 2,
+          "instillUpstreamTypes": [
+            "value",
+            "reference",
+            "template"
+          ],
+          "title": "Namespace",
+          "type": "string"
         }
       },
       "required": [

--- a/pkg/pinecone/config/tasks.json
+++ b/pkg/pinecone/config/tasks.json
@@ -3,21 +3,6 @@
     "input": {
       "instillUIOrder": 0,
       "properties": {
-        "filter": {
-          "description": "The filter to apply. You can use vector metadata to limit your search. See https://www.pinecone.io/docs/metadata-filtering/.",
-          "instillAcceptFormats": [
-            "semi-structured/object"
-          ],
-          "instillShortDescription": "The filter to apply on vector metadata",
-          "instillUIOrder": 3,
-          "instillUpstreamTypes": [
-            "reference"
-          ],
-          "order": 1,
-          "required": [],
-          "title": "Filter",
-          "type": "object"
-        },
         "id": {
           "description": "The unique ID of the vector to be used as a query vector. If present, the vector parameter will be ignored.",
           "instillAcceptFormats": [
@@ -32,13 +17,88 @@
           "title": "ID",
           "type": "string"
         },
+        "vector": {
+          "description": "An array of dimensions for the query vector.",
+          "instillAcceptFormats": [
+            "array:number",
+            "array:integer"
+          ],
+          "instillUIOrder": 1,
+          "instillUpstreamTypes": [
+            "reference"
+          ],
+          "items": {
+            "description": "A dimension of the vector",
+            "example": 0.8167237,
+            "type": "number"
+          },
+          "minItems": 1,
+          "title": "Vector",
+          "type": "array"
+        },
+        "top_k": {
+          "description": "The number of results to return for each query",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUIOrder": 2,
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "title": "Top K",
+          "type": "integer"
+        },
+        "namespace": {
+          "description": "The namespace to query",
+          "instillAcceptFormats": [
+            "string"
+          ],
+          "instillUIOrder": 3,
+          "instillUpstreamTypes": [
+            "value",
+            "reference",
+            "template"
+          ],
+          "title": "Namespace",
+          "type": "string"
+        },
+        "filter": {
+          "description": "The filter to apply. You can use vector metadata to limit your search. See https://www.pinecone.io/docs/metadata-filtering/.",
+          "instillAcceptFormats": [
+            "semi-structured/object"
+          ],
+          "instillShortDescription": "The filter to apply on vector metadata",
+          "instillUIOrder": 4,
+          "instillUpstreamTypes": [
+            "reference"
+          ],
+          "order": 1,
+          "required": [],
+          "title": "Filter",
+          "type": "object"
+        },
+        "min_score": {
+          "description": "Exclude results whose score is below this value",
+          "instillAcceptFormats": [
+            "number",
+            "integer"
+          ],
+          "instillUIOrder": 5,
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "title": "Minimum Score",
+          "type": "number"
+        },
         "include_metadata": {
           "default": false,
           "description": "Indicates whether metadata is included in the response as well as the IDs",
           "instillAcceptFormats": [
             "boolean"
           ],
-          "instillUIOrder": 5,
+          "instillUIOrder": 6,
           "instillUpstreamTypes": [
             "value",
             "reference"
@@ -52,59 +112,13 @@
           "instillAcceptFormats": [
             "boolean"
           ],
-          "instillUIOrder": 4,
+          "instillUIOrder": 7,
           "instillUpstreamTypes": [
             "value",
             "reference"
           ],
           "title": "Include Values",
           "type": "boolean"
-        },
-        "namespace": {
-          "description": "The namespace to query",
-          "instillAcceptFormats": [
-            "string"
-          ],
-          "instillUIOrder": 1,
-          "instillUpstreamTypes": [
-            "value",
-            "reference",
-            "template"
-          ],
-          "title": "Namespace",
-          "type": "string"
-        },
-        "top_k": {
-          "description": "The number of results to return for each query",
-          "instillAcceptFormats": [
-            "integer"
-          ],
-          "instillUIOrder": 6,
-          "instillUpstreamTypes": [
-            "value",
-            "reference"
-          ],
-          "title": "Top K",
-          "type": "integer"
-        },
-        "vector": {
-          "description": "An array of dimensions for the query vector.",
-          "instillAcceptFormats": [
-            "array:number",
-            "array:integer"
-          ],
-          "instillUIOrder": 2,
-          "instillUpstreamTypes": [
-            "reference"
-          ],
-          "items": {
-            "description": "A dimension of the vector",
-            "example": 0.8167237,
-            "type": "number"
-          },
-          "minItems": 1,
-          "title": "Vector",
-          "type": "array"
         }
       },
       "required": [

--- a/pkg/pinecone/connector_test.go
+++ b/pkg/pinecone/connector_test.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	pineconeKey = "secret-key"
+	namespace   = "pantone"
 
 	upsertOK = `{"upsertedCount": 1}`
 
@@ -89,12 +90,15 @@ func TestConnector_Execute(t *testing.T) {
 		{
 			name: "ok - upsert",
 
-			task:     taskUpsert,
-			execIn:   vectorA,
+			task: taskUpsert,
+			execIn: upsertInput{
+				vector:    vectorA,
+				Namespace: namespace,
+			},
 			wantExec: upsertOutput{RecordsUpserted: 1},
 
 			wantClientPath: upsertPath,
-			wantClientReq:  upsertReq{Vectors: []vector{vectorA}},
+			wantClientReq:  upsertReq{Vectors: []vector{vectorA}, Namespace: namespace},
 			clientResp:     upsertOK,
 		},
 		{

--- a/pkg/pinecone/connector_test.go
+++ b/pkg/pinecone/connector_test.go
@@ -21,9 +21,9 @@ import (
 const (
 	pineconeKey = "secret-key"
 
-	upsertResp = `{"upsertedCount": 1}`
+	upsertOK = `{"upsertedCount": 1}`
 
-	queryResp = `
+	queryOK = `
 {
 	"namespace": "color-schemes",
 	"matches": [
@@ -45,12 +45,12 @@ const (
 )
 
 var (
-	vectorA = Vector{
+	vectorA = vector{
 		ID:       "A",
 		Values:   []float64{2.23},
 		Metadata: map[string]any{"color": "pumpkin"},
 	}
-	queryByVector = QueryInput{
+	queryByVector = queryInput{
 		Namespace:       "color-schemes",
 		TopK:            1,
 		Vector:          vectorA.Values,
@@ -62,7 +62,7 @@ var (
 			},
 		},
 	}
-	queryByID = QueryInput{
+	queryByID = queryInput{
 		Namespace:       "color-schemes",
 		TopK:            1,
 		Vector:          vectorA.Values,
@@ -91,48 +91,48 @@ func TestConnector_Execute(t *testing.T) {
 
 			task:     taskUpsert,
 			execIn:   vectorA,
-			wantExec: UpsertOutput{RecordsUpserted: 1},
+			wantExec: upsertOutput{RecordsUpserted: 1},
 
 			wantClientPath: upsertPath,
-			wantClientReq:  UpsertReq{Vectors: []Vector{vectorA}},
-			clientResp:     upsertResp,
+			wantClientReq:  upsertReq{Vectors: []vector{vectorA}},
+			clientResp:     upsertOK,
 		},
 		{
 			name: "ok - query by vector",
 
 			task:   taskQuery,
 			execIn: queryByVector,
-			wantExec: QueryResp{
+			wantExec: queryResp{
 				Namespace: "color-schemes",
-				Matches: []Match{
+				Matches: []match{
 					{
-						Vector: vectorA,
+						vector: vectorA,
 						Score:  0.99,
 					},
 				},
 			},
 
 			wantClientPath: queryPath,
-			wantClientReq:  QueryReq(queryByVector),
-			clientResp:     queryResp,
+			wantClientReq:  queryReq(queryByVector),
+			clientResp:     queryOK,
 		},
 		{
 			name: "ok - query by ID",
 
 			task:   taskQuery,
 			execIn: queryByID,
-			wantExec: QueryResp{
+			wantExec: queryResp{
 				Namespace: "color-schemes",
-				Matches: []Match{
+				Matches: []match{
 					{
-						Vector: vectorA,
+						vector: vectorA,
 						Score:  0.99,
 					},
 				},
 			},
 
 			wantClientPath: queryPath,
-			wantClientReq: QueryReq{
+			wantClientReq: queryReq{
 				// Vector is wiped from the request.
 				Namespace:       "color-schemes",
 				TopK:            1,
@@ -140,7 +140,7 @@ func TestConnector_Execute(t *testing.T) {
 				IncludeValues:   true,
 				IncludeMetadata: true,
 			},
-			clientResp: queryResp,
+			clientResp: queryOK,
 		},
 	}
 

--- a/pkg/pinecone/main.go
+++ b/pkg/pinecone/main.go
@@ -87,7 +87,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 		var output *structpb.Struct
 		switch e.Task {
 		case taskQuery:
-			inputStruct := QueryInput{}
+			inputStruct := queryInput{}
 			err := base.ConvertFromStructpb(input, &inputStruct)
 			if err != nil {
 				return nil, err
@@ -100,8 +100,8 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 				inputStruct.Vector = nil
 			}
 
-			resp := QueryResp{}
-			req.SetResult(&resp).SetBody(QueryReq(inputStruct))
+			resp := queryResp{}
+			req.SetResult(&resp).SetBody(queryReq(inputStruct))
 
 			if _, err := req.Post(queryPath); err != nil {
 				return nil, httpclient.WrapURLError(err)
@@ -112,22 +112,22 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 				return nil, err
 			}
 		case taskUpsert:
-			vector := Vector{}
-			err := base.ConvertFromStructpb(input, &vector)
+			v := vector{}
+			err := base.ConvertFromStructpb(input, &v)
 			if err != nil {
 				return nil, err
 			}
 
-			resp := UpsertResp{}
-			req.SetResult(&resp).SetBody(UpsertReq{
-				Vectors: []Vector{vector},
+			resp := upsertResp{}
+			req.SetResult(&resp).SetBody(upsertReq{
+				Vectors: []vector{v},
 			})
 
 			if _, err := req.Post(upsertPath); err != nil {
 				return nil, httpclient.WrapURLError(err)
 			}
 
-			output, err = base.ConvertToStructpb(UpsertOutput(resp))
+			output, err = base.ConvertToStructpb(upsertOutput(resp))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/pinecone/main.go
+++ b/pkg/pinecone/main.go
@@ -112,7 +112,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 				return nil, err
 			}
 		case taskUpsert:
-			v := vector{}
+			v := upsertInput{}
 			err := base.ConvertFromStructpb(input, &v)
 			if err != nil {
 				return nil, err
@@ -120,7 +120,8 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 
 			resp := upsertResp{}
 			req.SetResult(&resp).SetBody(upsertReq{
-				Vectors: []vector{v},
+				Vectors:   []vector{v.vector},
+				Namespace: v.Namespace,
 			})
 
 			if _, err := req.Post(upsertPath); err != nil {

--- a/pkg/pinecone/main.go
+++ b/pkg/pinecone/main.go
@@ -101,11 +101,13 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 			}
 
 			resp := queryResp{}
-			req.SetResult(&resp).SetBody(queryReq(inputStruct))
+			req.SetResult(&resp).SetBody(inputStruct.asRequest())
 
 			if _, err := req.Post(queryPath); err != nil {
 				return nil, httpclient.WrapURLError(err)
 			}
+
+			resp = resp.filterOutBelowThreshold(inputStruct.MinScore)
 
 			output, err = base.ConvertToStructpb(resp)
 			if err != nil {

--- a/pkg/pinecone/structs.go
+++ b/pkg/pinecone/structs.go
@@ -1,6 +1,6 @@
 package pinecone
 
-type QueryInput struct {
+type queryInput struct {
 	Namespace       string      `json:"namespace"`
 	TopK            int64       `json:"top_k"`
 	Vector          []float64   `json:"vector"`
@@ -10,7 +10,7 @@ type QueryInput struct {
 	Filter          interface{} `json:"filter"`
 }
 
-type QueryReq struct {
+type queryReq struct {
 	Namespace       string      `json:"namespace"`
 	TopK            int64       `json:"topK"`
 	Vector          []float64   `json:"vector,omitempty"`
@@ -20,31 +20,31 @@ type QueryReq struct {
 	Filter          interface{} `json:"filter,omitempty"`
 }
 
-type QueryResp struct {
+type queryResp struct {
 	Namespace string  `json:"namespace"`
-	Matches   []Match `json:"matches"`
+	Matches   []match `json:"matches"`
 }
 
-type Match struct {
-	Vector
+type match struct {
+	vector
 	Score float64 `json:"score"`
 }
 
-type UpsertReq struct {
-	Vectors []Vector `json:"vectors"`
+type upsertReq struct {
+	Vectors []vector `json:"vectors"`
 }
 
-type Vector struct {
+type vector struct {
 	ID       string      `json:"id"`
 	Values   []float64   `json:"values,omitempty"`
 	Metadata interface{} `json:"metadata,omitempty"`
 }
 
-type UpsertResp struct {
+type upsertResp struct {
 	RecordsUpserted int64 `json:"upsertedCount"`
 }
 
-type UpsertOutput struct {
+type upsertOutput struct {
 	RecordsUpserted int64 `json:"upserted_count"`
 }
 

--- a/pkg/pinecone/structs.go
+++ b/pkg/pinecone/structs.go
@@ -31,7 +31,13 @@ type match struct {
 }
 
 type upsertReq struct {
-	Vectors []vector `json:"vectors"`
+	Vectors   []vector `json:"vectors"`
+	Namespace string   `json:"namespace"`
+}
+
+type upsertInput struct {
+	vector
+	Namespace string `json:"namespace"`
 }
 
 type vector struct {


### PR DESCRIPTION
Because

- Namespace insertion is supported in Pinecone API but not in the connector.
- Sometimes users want to retrieve only relevant matches.

This commit

- make Pinecone structs unexported (as they are only used locally)
- add optional namespace parameter to Pinecone upsert
- add score threshold to Pinecone queries


## QA 🔨 

### Insert namespace
![CleanShot 2024-01-12 at 18 12 34](https://github.com/instill-ai/connector/assets/3977183/325e7331-587f-41bb-8ea9-2559096d3d79)
![CleanShot 2024-01-12 at 18 12 02](https://github.com/instill-ai/connector/assets/3977183/52925d2c-4bd9-4165-882c-a8335dce7b61)


### Query with threshold


![CleanShot 2024-01-12 at 18 09 30](https://github.com/instill-ai/connector/assets/3977183/9d69e820-8044-46d4-8b43-10acfa384d43)


![CleanShot 2024-01-12 at 18 09 05](https://github.com/instill-ai/connector/assets/3977183/9e71096a-517f-4178-9847-c28913cf929a)
