### PR TITLE
refactor: update variable name with initialisms

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,23 @@
+name: golangci-lint
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.54

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,3 +21,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.54
+          args: --timeout=10m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,7 @@
+linters:
+  enable:
+    - stylecheck
+
+linters-settings:
+  stylecheck:
+    checks: [ "all" ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,9 @@ repos:
     rev: v4.4.0
     hooks:
       - id: check-yaml
+      - id: check-json
+      - id: check-merge-conflict
       - id: end-of-file-fixer
-      - id: pretty-format-json
-        args: [--autofix]
       - id: trailing-whitespace
   - repo: https://github.com/dnephin/pre-commit-golang
     rev: v0.5.1

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/gocolly/colly/v2 v2.1.0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/h2non/filetype v1.1.3
-	github.com/instill-ai/component v0.8.0-beta.0.20240112032605-792559e0b538
+	github.com/instill-ai/component v0.8.0-beta.0.20240112193844-0946e6a23d49
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240105094938-3a71d8f7a812
 	github.com/instill-ai/x v0.3.0-alpha.0.20231219052200-6230a89e386c
 	github.com/redis/go-redis/v9 v9.3.0

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
-github.com/instill-ai/component v0.8.0-beta.0.20240112032605-792559e0b538 h1:wHkWugd03PwOrupcwrd8/FBaeQhKyvK0xmEK6vwmZVM=
-github.com/instill-ai/component v0.8.0-beta.0.20240112032605-792559e0b538/go.mod h1:fWyVPJVJ4WyFSQMgWCc7KvcS7m9QpdS3VXCL2CZE8OY=
+github.com/instill-ai/component v0.8.0-beta.0.20240112193844-0946e6a23d49 h1:Kc6U1LnA7KgsJkk3kN9RxctsX8C6UKtXRqmi9/eR3VY=
+github.com/instill-ai/component v0.8.0-beta.0.20240112193844-0946e6a23d49/go.mod h1:fWyVPJVJ4WyFSQMgWCc7KvcS7m9QpdS3VXCL2CZE8OY=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240105094938-3a71d8f7a812 h1:n1EQFT0NeXkmiCD/YtoLG+b/OPo2tNg7MVK0dHNFlvk=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240105094938-3a71d8f7a812/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
 github.com/instill-ai/x v0.3.0-alpha.0.20231219052200-6230a89e386c h1:a2RVkpIV2QcrGnSHAou+t/L+vBsaIfFvk5inVg5Uh4s=

--- a/pkg/bigquery/main.go
+++ b/pkg/bigquery/main.go
@@ -114,7 +114,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 
 	client, err := NewClient(getJSONKey(config), getProjectID(config))
 	if err != nil || client == nil {

--- a/pkg/googlecloudstorage/main.go
+++ b/pkg/googlecloudstorage/main.go
@@ -115,7 +115,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 
 	client, err := NewClient(getJSONKey(config))
 	if err != nil {

--- a/pkg/googlesearch/main.go
+++ b/pkg/googlesearch/main.go
@@ -100,12 +100,12 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 				return nil, err
 			}
 
-			outputJson, err := json.Marshal(outputStruct)
+			outputJSON, err := json.Marshal(outputStruct)
 			if err != nil {
 				return nil, err
 			}
 			output := structpb.Struct{}
-			err = json.Unmarshal(outputJson, &output)
+			err = json.Unmarshal(outputJSON, &output)
 			if err != nil {
 				return nil, err
 			}
@@ -119,7 +119,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 
 	service, err := NewService(getAPIKey(config))
 	if err != nil || service == nil {

--- a/pkg/googlesearch/search.go
+++ b/pkg/googlesearch/search.go
@@ -37,8 +37,8 @@ type SearchInput struct {
 	// IncludeLinkText: Whether to include the scraped text of the search web page result.
 	IncludeLinkText *bool `json:"include_link_text,omitempty"`
 
-	// IncludeLinkHtml: Whether to include the scraped HTML of the search web page result.
-	IncludeLinkHtml *bool `json:"include_link_html,omitempty"`
+	// IncludeLinkHTML: Whether to include the scraped HTML of the search web page result.
+	IncludeLinkHTML *bool `json:"include_link_html,omitempty"`
 }
 
 type Result struct {
@@ -55,8 +55,8 @@ type Result struct {
 	// LinkText: The scraped text of the search web page result, in plain text.
 	LinkText string `json:"link_text"`
 
-	// LinkHtml: The full raw HTML of the search web page result.
-	LinkHtml string `json:"link_html"`
+	// LinkHTML: The full raw HTML of the search web page result.
+	LinkHTML string `json:"link_html"`
 }
 
 // SearchOutput defines the output of the search task
@@ -66,11 +66,11 @@ type SearchOutput struct {
 }
 
 // Scrape the search results if needed
-func scrapeSearchResults(searchResults *customsearch.Search, includeLinkText, includeLinkHtml bool) ([]*Result, error) {
+func scrapeSearchResults(searchResults *customsearch.Search, includeLinkText, includeLinkHTML bool) ([]*Result, error) {
 	results := []*Result{}
 	for _, item := range searchResults.Items {
-		linkText, linkHtml := "", ""
-		if includeLinkText || includeLinkHtml {
+		linkText, linkHTML := "", ""
+		if includeLinkText || includeLinkHTML {
 			// Make an HTTP GET request to the web page
 			client := &http.Client{Transport: &http.Transport{
 				DisableKeepAlives: true,
@@ -88,19 +88,19 @@ func scrapeSearchResults(searchResults *customsearch.Search, includeLinkText, in
 				fmt.Printf("Error parsing %s: %v", item.Link, err)
 			}
 
-			if includeLinkHtml {
-				linkHtml, err = util.ScrapeWebpageHTML(doc)
+			if includeLinkHTML {
+				linkHTML, err = util.ScrapeWebpageHTML(doc)
 				if err != nil {
 					log.Printf("Error scraping HTML from %s: %v", item.Link, err)
 				}
 			}
 
 			if includeLinkText {
-				linkHtml, err = util.ScrapeWebpageHTML(doc)
+				linkHTML, err = util.ScrapeWebpageHTML(doc)
 				if err != nil {
 					log.Printf("Error scraping HTML from %s: %v", item.Link, err)
 				}
-				linkText, err = util.ScrapeWebpageHTMLToMarkdown(linkHtml)
+				linkText, err = util.ScrapeWebpageHTMLToMarkdown(linkHTML)
 				if err != nil {
 					log.Printf("Error scraping text from %s: %v", item.Link, err)
 				}
@@ -113,7 +113,7 @@ func scrapeSearchResults(searchResults *customsearch.Search, includeLinkText, in
 			Link:     item.Link,
 			Snippet:  item.Snippet,
 			LinkText: linkText,
-			LinkHtml: linkHtml,
+			LinkHTML: linkHTML,
 		})
 	}
 	return results, nil
@@ -131,9 +131,9 @@ func search(cseListCall *customsearch.CseListCall, input SearchInput) (SearchOut
 		return output, fmt.Errorf("top_k must be between 1 and %d", MaxResults)
 	}
 
-	if input.IncludeLinkHtml == nil {
+	if input.IncludeLinkHTML == nil {
 		defaultValue := false
-		input.IncludeLinkHtml = &defaultValue
+		input.IncludeLinkHTML = &defaultValue
 	}
 	if input.IncludeLinkText == nil {
 		defaultValue := false
@@ -149,7 +149,7 @@ func search(cseListCall *customsearch.CseListCall, input SearchInput) (SearchOut
 		if err != nil {
 			return output, err
 		}
-		rs, err := scrapeSearchResults(searchResults, *input.IncludeLinkText, *input.IncludeLinkHtml)
+		rs, err := scrapeSearchResults(searchResults, *input.IncludeLinkText, *input.IncludeLinkHTML)
 		if err != nil {
 			return output, err
 		}

--- a/pkg/instill/connector_test.go
+++ b/pkg/instill/connector_test.go
@@ -32,7 +32,7 @@ func TestConnector_Test(t *testing.T) {
 			c.Check(r.URL.Path, qt.Equals, wantPath)
 
 			c.Check(r.Header.Get("Authorization"), qt.Equals, "Bearer "+apiKey)
-			c.Check(r.Header.Get("Instill-User-Uid"), qt.Equals, userID.String())
+			c.Check(r.Header.Get("Instill-User-UID"), qt.Equals, userID.String())
 
 			w.WriteHeader(http.StatusBadRequest)
 		})
@@ -62,7 +62,7 @@ func TestConnector_Test(t *testing.T) {
 			c.Check(r.URL.Path, qt.Equals, wantPath)
 
 			c.Check(r.Header.Get("Authorization"), qt.Equals, "Bearer "+apiKey)
-			c.Check(r.Header.Get("Instill-User-Uid"), qt.Equals, userID.String())
+			c.Check(r.Header.Get("Instill-User-UID"), qt.Equals, userID.String())
 		})
 
 		srv := httptest.NewServer(h)

--- a/pkg/instill/connector_test.go
+++ b/pkg/instill/connector_test.go
@@ -32,7 +32,7 @@ func TestConnector_Test(t *testing.T) {
 			c.Check(r.URL.Path, qt.Equals, wantPath)
 
 			c.Check(r.Header.Get("Authorization"), qt.Equals, "Bearer "+apiKey)
-			c.Check(r.Header.Get("Instill-User-UID"), qt.Equals, userID.String())
+			c.Check(r.Header.Get("Instill-User-Uid"), qt.Equals, userID.String())
 
 			w.WriteHeader(http.StatusBadRequest)
 		})
@@ -62,7 +62,7 @@ func TestConnector_Test(t *testing.T) {
 			c.Check(r.URL.Path, qt.Equals, wantPath)
 
 			c.Check(r.Header.Get("Authorization"), qt.Equals, "Bearer "+apiKey)
-			c.Check(r.Header.Get("Instill-User-UID"), qt.Equals, userID.String())
+			c.Check(r.Header.Get("Instill-User-Uid"), qt.Equals, userID.String())
 		})
 
 		srv := httptest.NewServer(h)

--- a/pkg/instill/image_classification.go
+++ b/pkg/instill/image_classification.go
@@ -47,7 +47,7 @@ func (e *Execution) executeImageClassification(grpcClient modelPB.ModelPublicSer
 		Name:       modelName,
 		TaskInputs: taskInputs,
 	}
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-Uid", getInstillUserUID(e.Config))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {

--- a/pkg/instill/image_classification.go
+++ b/pkg/instill/image_classification.go
@@ -12,7 +12,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (c *Execution) executeImageClassification(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *Execution) executeImageClassification(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
@@ -24,12 +24,12 @@ func (c *Execution) executeImageClassification(grpcClient modelPB.ModelPublicSer
 	taskInputs := []*modelPB.TaskInput{}
 	for _, input := range inputs {
 
-		inputJson, err := protojson.Marshal(input)
+		inputJSON, err := protojson.Marshal(input)
 		if err != nil {
 			return nil, err
 		}
 		classificationInput := &modelPB.ClassificationInput{}
-		err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(inputJson, classificationInput)
+		err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(inputJSON, classificationInput)
 		if err != nil {
 			return nil, err
 		}
@@ -47,7 +47,7 @@ func (c *Execution) executeImageClassification(grpcClient modelPB.ModelPublicSer
 		Name:       modelName,
 		TaskInputs: taskInputs,
 	}
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {
@@ -63,7 +63,7 @@ func (c *Execution) executeImageClassification(grpcClient modelPB.ModelPublicSer
 		if imgClassificationOp == nil {
 			return nil, fmt.Errorf("invalid output: %v for model: %s", imgClassificationOp, modelName)
 		}
-		outputJson, err := protojson.MarshalOptions{
+		outputJSON, err := protojson.MarshalOptions{
 			UseProtoNames:   true,
 			EmitUnpopulated: true,
 		}.Marshal(imgClassificationOp)
@@ -71,7 +71,7 @@ func (c *Execution) executeImageClassification(grpcClient modelPB.ModelPublicSer
 			return nil, err
 		}
 		output := &structpb.Struct{}
-		err = protojson.Unmarshal(outputJson, output)
+		err = protojson.Unmarshal(outputJSON, output)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/instill/image_to_image.go
+++ b/pkg/instill/image_to_image.go
@@ -12,7 +12,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (c *Execution) executeImageToImage(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *Execution) executeImageToImage(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
@@ -65,7 +65,7 @@ func (c *Execution) executeImageToImage(grpcClient modelPB.ModelPublicServiceCli
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
@@ -84,7 +84,7 @@ func (c *Execution) executeImageToImage(grpcClient modelPB.ModelPublicServiceCli
 			imageToImageOutput.Images[imageIdx] = fmt.Sprintf("data:image/jpeg;base64,%s", imageToImageOutput.Images[imageIdx])
 		}
 
-		outputJson, err := protojson.MarshalOptions{
+		outputJSON, err := protojson.MarshalOptions{
 			UseProtoNames:   true,
 			EmitUnpopulated: true,
 		}.Marshal(imageToImageOutput)
@@ -92,7 +92,7 @@ func (c *Execution) executeImageToImage(grpcClient modelPB.ModelPublicServiceCli
 			return nil, err
 		}
 		output := &structpb.Struct{}
-		err = protojson.Unmarshal(outputJson, output)
+		err = protojson.Unmarshal(outputJSON, output)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/instill/image_to_image.go
+++ b/pkg/instill/image_to_image.go
@@ -65,7 +65,7 @@ func (e *Execution) executeImageToImage(grpcClient modelPB.ModelPublicServiceCli
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-Uid", getInstillUserUID(e.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {

--- a/pkg/instill/instance_segmentation.go
+++ b/pkg/instill/instance_segmentation.go
@@ -12,7 +12,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (c *Execution) executeInstanceSegmentation(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *Execution) executeInstanceSegmentation(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
@@ -23,12 +23,12 @@ func (c *Execution) executeInstanceSegmentation(grpcClient modelPB.ModelPublicSe
 
 	taskInputs := []*modelPB.TaskInput{}
 	for _, input := range inputs {
-		inputJson, err := protojson.Marshal(input)
+		inputJSON, err := protojson.Marshal(input)
 		if err != nil {
 			return nil, err
 		}
 		segmentationInput := &modelPB.InstanceSegmentationInput{}
-		err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(inputJson, segmentationInput)
+		err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(inputJSON, segmentationInput)
 		if err != nil {
 			return nil, err
 		}
@@ -45,7 +45,7 @@ func (c *Execution) executeInstanceSegmentation(grpcClient modelPB.ModelPublicSe
 		Name:       modelName,
 		TaskInputs: taskInputs,
 	}
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {
@@ -62,7 +62,7 @@ func (c *Execution) executeInstanceSegmentation(grpcClient modelPB.ModelPublicSe
 		if instanceSegmentationOp == nil {
 			return nil, fmt.Errorf("invalid output: %v for model: %s", instanceSegmentationOp, modelName)
 		}
-		outputJson, err := protojson.MarshalOptions{
+		outputJSON, err := protojson.MarshalOptions{
 			UseProtoNames:   true,
 			EmitUnpopulated: true,
 		}.Marshal(instanceSegmentationOp)
@@ -70,7 +70,7 @@ func (c *Execution) executeInstanceSegmentation(grpcClient modelPB.ModelPublicSe
 			return nil, err
 		}
 		output := &structpb.Struct{}
-		err = protojson.Unmarshal(outputJson, output)
+		err = protojson.Unmarshal(outputJSON, output)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/instill/instance_segmentation.go
+++ b/pkg/instill/instance_segmentation.go
@@ -45,7 +45,7 @@ func (e *Execution) executeInstanceSegmentation(grpcClient modelPB.ModelPublicSe
 		Name:       modelName,
 		TaskInputs: taskInputs,
 	}
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-Uid", getInstillUserUID(e.Config))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {

--- a/pkg/instill/keypoint_detection.go
+++ b/pkg/instill/keypoint_detection.go
@@ -12,18 +12,18 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (c *Execution) executeKeyPointDetection(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *Execution) executeKeyPointDetection(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
 	taskInputs := []*modelPB.TaskInput{}
 	for _, input := range inputs {
-		inputJson, err := protojson.Marshal(input)
+		inputJSON, err := protojson.Marshal(input)
 		if err != nil {
 			return nil, err
 		}
 		keypointInput := &modelPB.KeypointInput{}
-		err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(inputJson, keypointInput)
+		err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(inputJSON, keypointInput)
 		if err != nil {
 			return nil, err
 		}
@@ -41,7 +41,7 @@ func (c *Execution) executeKeyPointDetection(grpcClient modelPB.ModelPublicServi
 		Name:       modelName,
 		TaskInputs: taskInputs,
 	}
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {
@@ -57,7 +57,7 @@ func (c *Execution) executeKeyPointDetection(grpcClient modelPB.ModelPublicServi
 		if keyPointOutput == nil {
 			return nil, fmt.Errorf("invalid output: %v for model: %s", keyPointOutput, modelName)
 		}
-		outputJson, err := protojson.MarshalOptions{
+		outputJSON, err := protojson.MarshalOptions{
 			UseProtoNames:   true,
 			EmitUnpopulated: true,
 		}.Marshal(keyPointOutput)
@@ -65,7 +65,7 @@ func (c *Execution) executeKeyPointDetection(grpcClient modelPB.ModelPublicServi
 			return nil, err
 		}
 		output := &structpb.Struct{}
-		err = protojson.Unmarshal(outputJson, output)
+		err = protojson.Unmarshal(outputJSON, output)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/instill/keypoint_detection.go
+++ b/pkg/instill/keypoint_detection.go
@@ -41,7 +41,7 @@ func (e *Execution) executeKeyPointDetection(grpcClient modelPB.ModelPublicServi
 		Name:       modelName,
 		TaskInputs: taskInputs,
 	}
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-Uid", getInstillUserUID(e.Config))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {

--- a/pkg/instill/llm_utils.go
+++ b/pkg/instill/llm_utils.go
@@ -29,7 +29,7 @@ type LLMInput struct {
 	ExtraParams *structpb.Struct
 }
 
-func (c *Execution) convertLLMInput(input *structpb.Struct) *LLMInput {
+func (e *Execution) convertLLMInput(input *structpb.Struct) *LLMInput {
 	llmInput := &LLMInput{
 		Prompt: input.GetFields()["prompt"].GetStringValue(),
 	}

--- a/pkg/instill/main.go
+++ b/pkg/instill/main.go
@@ -195,7 +195,7 @@ func newHTTPClient(config *structpb.Struct, logger *zap.Logger) *httpclient.Clie
 	}
 
 	if userID := getInstillUserUID(config); userID != "" {
-		c.SetHeader("Instill-User-UID", userID)
+		c.SetHeader("Instill-User-Uid", userID)
 	}
 
 	return c

--- a/pkg/instill/main.go
+++ b/pkg/instill/main.go
@@ -73,7 +73,7 @@ func getMode(config *structpb.Struct) string {
 func getAPIKey(config *structpb.Struct) string {
 	return config.GetFields()["api_token"].GetStringValue()
 }
-func getInstillUserUid(config *structpb.Struct) string {
+func getInstillUserUID(config *structpb.Struct) string {
 	return config.GetFields()["instill_user_uid"].GetStringValue()
 }
 
@@ -81,17 +81,17 @@ func getServerURL(config *structpb.Struct) string {
 	if getMode(config) == internalMode {
 		return config.GetFields()["instill_model_backend"].GetStringValue()
 	}
-	serverUrl := config.GetFields()["server_url"].GetStringValue()
-	if strings.HasPrefix(serverUrl, "https://") {
-		if len(strings.Split(serverUrl, ":")) == 2 {
-			serverUrl = serverUrl + ":443"
+	serverURL := config.GetFields()["server_url"].GetStringValue()
+	if strings.HasPrefix(serverURL, "https://") {
+		if len(strings.Split(serverURL, ":")) == 2 {
+			serverURL = serverURL + ":443"
 		}
-	} else if strings.HasPrefix(serverUrl, "http://") {
-		if len(strings.Split(serverUrl, ":")) == 2 {
-			serverUrl = serverUrl + ":80"
+	} else if strings.HasPrefix(serverURL, "http://") {
+		if len(strings.Split(serverURL, ":")) == 2 {
+			serverURL = serverURL + ":80"
 		}
 	}
-	return serverUrl
+	return serverURL
 }
 
 func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, error) {
@@ -194,8 +194,8 @@ func newHTTPClient(config *structpb.Struct, logger *zap.Logger) *httpclient.Clie
 		c.SetAuthToken(token)
 	}
 
-	if userID := getInstillUserUid(config); userID != "" {
-		c.SetHeader("Instill-User-Uid", userID)
+	if userID := getInstillUserUID(config); userID != "" {
+		c.SetHeader("Instill-User-UID", userID)
 	}
 
 	return c

--- a/pkg/instill/object_detection.go
+++ b/pkg/instill/object_detection.go
@@ -12,7 +12,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (c *Execution) executeObjectDetection(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *Execution) executeObjectDetection(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
@@ -23,13 +23,13 @@ func (c *Execution) executeObjectDetection(grpcClient modelPB.ModelPublicService
 
 	taskInputs := []*modelPB.TaskInput{}
 	for _, input := range inputs {
-		inputJson, err := protojson.Marshal(input)
+		inputJSON, err := protojson.Marshal(input)
 		if err != nil {
 			return nil, err
 		}
 
 		detectionInput := &modelPB.DetectionInput{}
-		err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(inputJson, detectionInput)
+		err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(inputJSON, detectionInput)
 		if err != nil {
 			return nil, err
 		}
@@ -48,7 +48,7 @@ func (c *Execution) executeObjectDetection(grpcClient modelPB.ModelPublicService
 		TaskInputs: taskInputs,
 	}
 
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {
@@ -66,7 +66,7 @@ func (c *Execution) executeObjectDetection(grpcClient modelPB.ModelPublicService
 		if objDetectionOutput == nil {
 			return nil, fmt.Errorf("invalid output: %v for model: %s", objDetectionOutput, modelName)
 		}
-		outputJson, err := protojson.MarshalOptions{
+		outputJSON, err := protojson.MarshalOptions{
 			UseProtoNames:   true,
 			EmitUnpopulated: true,
 		}.Marshal(objDetectionOutput)
@@ -74,7 +74,7 @@ func (c *Execution) executeObjectDetection(grpcClient modelPB.ModelPublicService
 			return nil, err
 		}
 		output := &structpb.Struct{}
-		err = protojson.Unmarshal(outputJson, output)
+		err = protojson.Unmarshal(outputJSON, output)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/instill/object_detection.go
+++ b/pkg/instill/object_detection.go
@@ -48,7 +48,7 @@ func (e *Execution) executeObjectDetection(grpcClient modelPB.ModelPublicService
 		TaskInputs: taskInputs,
 	}
 
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-Uid", getInstillUserUID(e.Config))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {

--- a/pkg/instill/ocr.go
+++ b/pkg/instill/ocr.go
@@ -11,7 +11,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (c *Execution) executeOCR(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *Execution) executeOCR(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
@@ -22,12 +22,12 @@ func (c *Execution) executeOCR(grpcClient modelPB.ModelPublicServiceClient, mode
 
 	outputs := []*structpb.Struct{}
 	for _, input := range inputs {
-		inputJson, err := protojson.Marshal(input)
+		inputJSON, err := protojson.Marshal(input)
 		if err != nil {
 			return nil, err
 		}
 		ocrInput := &modelPB.OcrInput{}
-		err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(inputJson, ocrInput)
+		err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(inputJSON, ocrInput)
 		if err != nil {
 			return nil, err
 		}
@@ -41,7 +41,7 @@ func (c *Execution) executeOCR(grpcClient modelPB.ModelPublicServiceClient, mode
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
@@ -56,7 +56,7 @@ func (c *Execution) executeOCR(grpcClient modelPB.ModelPublicServiceClient, mode
 		if ocrOutput == nil {
 			return nil, fmt.Errorf("invalid output: %v for model: %s", ocrOutput, modelName)
 		}
-		outputJson, err := protojson.MarshalOptions{
+		outputJSON, err := protojson.MarshalOptions{
 			UseProtoNames:   true,
 			EmitUnpopulated: true,
 		}.Marshal(ocrOutput)
@@ -64,7 +64,7 @@ func (c *Execution) executeOCR(grpcClient modelPB.ModelPublicServiceClient, mode
 			return nil, err
 		}
 		output := &structpb.Struct{}
-		err = protojson.Unmarshal(outputJson, output)
+		err = protojson.Unmarshal(outputJSON, output)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/instill/ocr.go
+++ b/pkg/instill/ocr.go
@@ -41,7 +41,7 @@ func (e *Execution) executeOCR(grpcClient modelPB.ModelPublicServiceClient, mode
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-Uid", getInstillUserUID(e.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {

--- a/pkg/instill/semantic_segmentation.go
+++ b/pkg/instill/semantic_segmentation.go
@@ -45,7 +45,7 @@ func (e *Execution) executeSemanticSegmentation(grpcClient modelPB.ModelPublicSe
 		Name:       modelName,
 		TaskInputs: taskInputs,
 	}
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-Uid", getInstillUserUID(e.Config))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {

--- a/pkg/instill/semantic_segmentation.go
+++ b/pkg/instill/semantic_segmentation.go
@@ -12,7 +12,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (c *Execution) executeSemanticSegmentation(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *Execution) executeSemanticSegmentation(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
@@ -21,12 +21,12 @@ func (c *Execution) executeSemanticSegmentation(grpcClient modelPB.ModelPublicSe
 	}
 	taskInputs := []*modelPB.TaskInput{}
 	for _, input := range inputs {
-		inputJson, err := protojson.Marshal(input)
+		inputJSON, err := protojson.Marshal(input)
 		if err != nil {
 			return nil, err
 		}
 		semanticSegmentationInput := &modelPB.SemanticSegmentationInput{}
-		err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(inputJson, semanticSegmentationInput)
+		err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(inputJSON, semanticSegmentationInput)
 		if err != nil {
 			return nil, err
 		}
@@ -45,7 +45,7 @@ func (c *Execution) executeSemanticSegmentation(grpcClient modelPB.ModelPublicSe
 		Name:       modelName,
 		TaskInputs: taskInputs,
 	}
-	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
+	md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	res, err := grpcClient.TriggerUserModel(ctx, &req)
 	if err != nil || res == nil {
@@ -62,7 +62,7 @@ func (c *Execution) executeSemanticSegmentation(grpcClient modelPB.ModelPublicSe
 		if semanticSegmentationOp == nil {
 			return nil, fmt.Errorf("invalid output: %v for model: %s", semanticSegmentationOp, modelName)
 		}
-		outputJson, err := protojson.MarshalOptions{
+		outputJSON, err := protojson.MarshalOptions{
 			UseProtoNames:   true,
 			EmitUnpopulated: true,
 		}.Marshal(semanticSegmentationOp)
@@ -70,7 +70,7 @@ func (c *Execution) executeSemanticSegmentation(grpcClient modelPB.ModelPublicSe
 			return nil, err
 		}
 		output := &structpb.Struct{}
-		err = protojson.Unmarshal(outputJson, output)
+		err = protojson.Unmarshal(outputJSON, output)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/instill/text_generation.go
+++ b/pkg/instill/text_generation.go
@@ -11,7 +11,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (c *Execution) executeTextGeneration(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *Execution) executeTextGeneration(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
@@ -24,7 +24,7 @@ func (c *Execution) executeTextGeneration(grpcClient modelPB.ModelPublicServiceC
 
 	for _, input := range inputs {
 
-		llmInput := c.convertLLMInput(input)
+		llmInput := e.convertLLMInput(input)
 		taskInput := &modelPB.TaskInput_TextGeneration{
 			TextGeneration: &modelPB.TextGenerationInput{
 				Prompt:        llmInput.Prompt,
@@ -44,7 +44,7 @@ func (c *Execution) executeTextGeneration(grpcClient modelPB.ModelPublicServiceC
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
@@ -59,7 +59,7 @@ func (c *Execution) executeTextGeneration(grpcClient modelPB.ModelPublicServiceC
 		if textGenOutput == nil {
 			return nil, fmt.Errorf("invalid output: %v for model: %s", textGenOutput, modelName)
 		}
-		outputJson, err := protojson.MarshalOptions{
+		outputJSON, err := protojson.MarshalOptions{
 			UseProtoNames:   true,
 			EmitUnpopulated: true,
 		}.Marshal(textGenOutput)
@@ -67,7 +67,7 @@ func (c *Execution) executeTextGeneration(grpcClient modelPB.ModelPublicServiceC
 			return nil, err
 		}
 		output := &structpb.Struct{}
-		err = protojson.Unmarshal(outputJson, output)
+		err = protojson.Unmarshal(outputJSON, output)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/instill/text_generation.go
+++ b/pkg/instill/text_generation.go
@@ -44,7 +44,7 @@ func (e *Execution) executeTextGeneration(grpcClient modelPB.ModelPublicServiceC
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-Uid", getInstillUserUID(e.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {

--- a/pkg/instill/text_generation_chat.go
+++ b/pkg/instill/text_generation_chat.go
@@ -11,7 +11,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (c *Execution) executeTextGenerationChat(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *Execution) executeTextGenerationChat(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
@@ -24,7 +24,7 @@ func (c *Execution) executeTextGenerationChat(grpcClient modelPB.ModelPublicServ
 	outputs := []*structpb.Struct{}
 
 	for _, input := range inputs {
-		llmInput := c.convertLLMInput(input)
+		llmInput := e.convertLLMInput(input)
 		taskInput := &modelPB.TaskInput_TextGenerationChat{
 			TextGenerationChat: &modelPB.TextGenerationChatInput{
 				Prompt:        llmInput.Prompt,
@@ -44,7 +44,7 @@ func (c *Execution) executeTextGenerationChat(grpcClient modelPB.ModelPublicServ
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
@@ -59,7 +59,7 @@ func (c *Execution) executeTextGenerationChat(grpcClient modelPB.ModelPublicServ
 		if textGenChatOutput == nil {
 			return nil, fmt.Errorf("invalid output: %v for model: %s", textGenChatOutput, modelName)
 		}
-		outputJson, err := protojson.MarshalOptions{
+		outputJSON, err := protojson.MarshalOptions{
 			UseProtoNames:   true,
 			EmitUnpopulated: true,
 		}.Marshal(textGenChatOutput)
@@ -67,7 +67,7 @@ func (c *Execution) executeTextGenerationChat(grpcClient modelPB.ModelPublicServ
 			return nil, err
 		}
 		output := &structpb.Struct{}
-		err = protojson.Unmarshal(outputJson, output)
+		err = protojson.Unmarshal(outputJSON, output)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/instill/text_generation_chat.go
+++ b/pkg/instill/text_generation_chat.go
@@ -44,7 +44,7 @@ func (e *Execution) executeTextGenerationChat(grpcClient modelPB.ModelPublicServ
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-Uid", getInstillUserUID(e.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {

--- a/pkg/instill/text_to_image.go
+++ b/pkg/instill/text_to_image.go
@@ -12,7 +12,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (c *Execution) executeTextToImage(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *Execution) executeTextToImage(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
@@ -56,7 +56,7 @@ func (c *Execution) executeTextToImage(grpcClient modelPB.ModelPublicServiceClie
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
@@ -77,7 +77,7 @@ func (c *Execution) executeTextToImage(grpcClient modelPB.ModelPublicServiceClie
 			return nil, fmt.Errorf("invalid output: %v for model: %s", textToImgOutput, modelName)
 		}
 
-		outputJson, err := protojson.MarshalOptions{
+		outputJSON, err := protojson.MarshalOptions{
 			UseProtoNames:   true,
 			EmitUnpopulated: true,
 		}.Marshal(textToImgOutput)
@@ -85,7 +85,7 @@ func (c *Execution) executeTextToImage(grpcClient modelPB.ModelPublicServiceClie
 			return nil, err
 		}
 		output := &structpb.Struct{}
-		err = protojson.Unmarshal(outputJson, output)
+		err = protojson.Unmarshal(outputJSON, output)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/instill/text_to_image.go
+++ b/pkg/instill/text_to_image.go
@@ -56,7 +56,7 @@ func (e *Execution) executeTextToImage(grpcClient modelPB.ModelPublicServiceClie
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-Uid", getInstillUserUID(e.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {

--- a/pkg/instill/unspecified.go
+++ b/pkg/instill/unspecified.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func (c *Execution) executeUnspecified(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *Execution) executeUnspecified(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}

--- a/pkg/instill/visual_question_answering.go
+++ b/pkg/instill/visual_question_answering.go
@@ -44,7 +44,7 @@ func (e *Execution) executeVisualQuestionAnswering(grpcClient modelPB.ModelPubli
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-Uid", getInstillUserUID(e.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {

--- a/pkg/instill/visual_question_answering.go
+++ b/pkg/instill/visual_question_answering.go
@@ -11,7 +11,7 @@ import (
 	modelPB "github.com/instill-ai/protogen-go/model/model/v1alpha"
 )
 
-func (c *Execution) executeVisualQuestionAnswering(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
+func (e *Execution) executeVisualQuestionAnswering(grpcClient modelPB.ModelPublicServiceClient, modelName string, inputs []*structpb.Struct) ([]*structpb.Struct, error) {
 	if len(inputs) <= 0 {
 		return nil, fmt.Errorf("invalid input: %v for model: %s", inputs, modelName)
 	}
@@ -24,7 +24,7 @@ func (c *Execution) executeVisualQuestionAnswering(grpcClient modelPB.ModelPubli
 
 	for _, input := range inputs {
 
-		llmInput := c.convertLLMInput(input)
+		llmInput := e.convertLLMInput(input)
 		taskInput := &modelPB.TaskInput_VisualQuestionAnswering{
 			VisualQuestionAnswering: &modelPB.VisualQuestionAnsweringInput{
 				Prompt:        llmInput.Prompt,
@@ -44,7 +44,7 @@ func (c *Execution) executeVisualQuestionAnswering(grpcClient modelPB.ModelPubli
 			Name:       modelName,
 			TaskInputs: []*modelPB.TaskInput{{Input: taskInput}},
 		}
-		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(c.Config)), "Instill-User-Uid", getInstillUserUid(c.Config))
+		md := metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", getAPIKey(e.Config)), "Instill-User-UID", getInstillUserUID(e.Config))
 		ctx := metadata.NewOutgoingContext(context.Background(), md)
 		res, err := grpcClient.TriggerUserModel(ctx, &req)
 		if err != nil || res == nil {
@@ -59,7 +59,7 @@ func (c *Execution) executeVisualQuestionAnswering(grpcClient modelPB.ModelPubli
 		if visualQuestionAnsweringOutput == nil {
 			return nil, fmt.Errorf("invalid output: %v for model: %s", visualQuestionAnsweringOutput, modelName)
 		}
-		outputJson, err := protojson.MarshalOptions{
+		outputJSON, err := protojson.MarshalOptions{
 			UseProtoNames:   true,
 			EmitUnpopulated: true,
 		}.Marshal(visualQuestionAnsweringOutput)
@@ -67,7 +67,7 @@ func (c *Execution) executeVisualQuestionAnswering(grpcClient modelPB.ModelPubli
 			return nil, err
 		}
 		output := &structpb.Struct{}
-		err = protojson.Unmarshal(outputJson, output)
+		err = protojson.Unmarshal(outputJSON, output)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -79,14 +79,14 @@ func (c *Connector) CreateExecution(defUID uuid.UUID, task string, config *struc
 	return c.connectorUIDMap[defUID].CreateExecution(defUID, task, config, logger)
 }
 
-func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
-	return c.connectorUIDMap[defUid].Test(defUid, config, logger)
+func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+	return c.connectorUIDMap[defUID].Test(defUID, config, logger)
 }
 
 func (c *Connector) GetConnectorDefinitionByID(defID string, resourceConfig *structpb.Struct, componentConfig *structpb.Struct) (*pipelinePB.ConnectorDefinition, error) {
 	return c.connectorIDMap[defID].GetConnectorDefinitionByID(defID, resourceConfig, componentConfig)
 }
 
-func (c *Connector) GetConnectorDefinitionByUID(defUid uuid.UUID, resourceConfig *structpb.Struct, componentConfig *structpb.Struct) (*pipelinePB.ConnectorDefinition, error) {
-	return c.connectorUIDMap[defUid].GetConnectorDefinitionByUID(defUid, resourceConfig, componentConfig)
+func (c *Connector) GetConnectorDefinitionByUID(defUID uuid.UUID, resourceConfig *structpb.Struct, componentConfig *structpb.Struct) (*pipelinePB.ConnectorDefinition, error) {
+	return c.connectorUIDMap[defUID].GetConnectorDefinitionByUID(defUID, resourceConfig, componentConfig)
 }

--- a/pkg/numbers/main.go
+++ b/pkg/numbers/main.go
@@ -24,9 +24,9 @@ import (
 	pipelinePB "github.com/instill-ai/protogen-go/vdp/pipeline/v1beta"
 )
 
-const ApiUrlPin = "https://api.numbersprotocol.io/api/v3/assets/"
-const ApiUrlCommit = "https://eo883tj75azolos.m.pipedream.net"
-const ApiUrlMe = "https://api.numbersprotocol.io/api/v3/auth/users/me"
+const urlPin = "https://api.numbersprotocol.io/api/v3/assets/"
+const urlCommit = "https://eo883tj75azolos.m.pipedream.net"
+const urlUserMe = "https://api.numbersprotocol.io/api/v3/auth/users/me"
 
 var once sync.Once
 var connector base.IConnector
@@ -58,11 +58,11 @@ type CommitCustom struct {
 	License           *CommitCustomLicense `json:"license,omitempty"`
 	Metadata          *struct {
 		Pipeline *struct {
-			Uid    *string     `json:"uid,omitempty"`
+			UID    *string     `json:"uid,omitempty"`
 			Recipe interface{} `json:"recipe,omitempty"`
 		} `json:"pipeline,omitempty"`
 		Owner *struct {
-			Uid *string `json:"uid,omitempty"`
+			UID *string `json:"uid,omitempty"`
 		} `json:"owner,omitempty"`
 	} `json:"instillMetadata,omitempty"`
 }
@@ -93,11 +93,11 @@ type Input struct {
 		} `json:"license,omitempty"`
 		Metadata *struct {
 			Pipeline *struct {
-				Uid    *string     `json:"uid,omitempty"`
+				UID    *string     `json:"uid,omitempty"`
 				Recipe interface{} `json:"recipe,omitempty"`
 			} `json:"pipeline,omitempty"`
 			Owner *struct {
-				Uid *string `json:"uid,omitempty"`
+				UID *string `json:"uid,omitempty"`
 			} `json:"owner,omitempty"`
 		} `json:"metadata,omitempty"`
 	} `json:"custom,omitempty"`
@@ -128,7 +128,7 @@ func getToken(config *structpb.Struct) string {
 	return fmt.Sprintf("token %s", config.GetFields()["capture_token"].GetStringValue())
 }
 
-func (con *Execution) pinFile(data []byte) (string, string, error) {
+func (e *Execution) pinFile(data []byte) (string, string, error) {
 
 	var b bytes.Buffer
 
@@ -154,12 +154,12 @@ func (con *Execution) pinFile(data []byte) (string, string, error) {
 	w.Close()
 	sha256hash := fmt.Sprintf("%x", h.Sum(nil))
 
-	req, err := http.NewRequest("POST", ApiUrlPin, &b)
+	req, err := http.NewRequest("POST", urlPin, &b)
 	if err != nil {
 		return "", "", err
 	}
 	req.Header.Set("Content-Type", w.FormDataContentType())
-	req.Header.Set("Authorization", getToken(con.Config))
+	req.Header.Set("Authorization", getToken(e.Config))
 
 	tr := &http.Transport{
 		DisableKeepAlives: true,
@@ -195,19 +195,19 @@ func (con *Execution) pinFile(data []byte) (string, string, error) {
 	}
 }
 
-func (con *Execution) commit(commit Commit) (string, string, error) {
+func (e *Execution) commit(commit Commit) (string, string, error) {
 
 	marshalled, err := json.Marshal(commit)
 	if err != nil {
 		return "", "", err
 	}
 
-	req, err := http.NewRequest("POST", ApiUrlCommit, bytes.NewReader(marshalled))
+	req, err := http.NewRequest("POST", urlCommit, bytes.NewReader(marshalled))
 	if err != nil {
 		return "", "", err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", getToken(con.Config))
+	req.Header.Set("Authorization", getToken(e.Config))
 
 	tr := &http.Transport{
 		DisableKeepAlives: true,
@@ -337,9 +337,9 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 
 }
 
-func (con *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 
-	req, err := http.NewRequest("GET", ApiUrlMe, nil)
+	req, err := http.NewRequest("GET", urlUserMe, nil)
 	if err != nil {
 		return pipelinePB.Connector_STATE_ERROR, nil
 	}

--- a/pkg/openai/main.go
+++ b/pkg/openai/main.go
@@ -139,7 +139,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 					return nil, err
 				}
 				url := fmt.Sprintf("data:%s;base64,%s", mimetype.Detect(b).String(), base.TrimBase64Mime(image))
-				userContents = append(userContents, Content{Type: "image_url", ImageUrl: &ImageUrl{Url: url}})
+				userContents = append(userContents, Content{Type: "image_url", ImageURL: &ImageURL{URL: url}})
 			}
 			messages = append(messages, MultiModalMessage{Role: "user", Content: userContents})
 

--- a/pkg/openai/text_generation.go
+++ b/pkg/openai/text_generation.go
@@ -55,13 +55,13 @@ type Message struct {
 	Content string `json:"content"`
 }
 
-type ImageUrl struct {
-	Url string `json:"url"`
+type ImageURL struct {
+	URL string `json:"url"`
 }
 type Content struct {
 	Type     string    `json:"type"`
 	Text     *string   `json:"text,omitempty"`
-	ImageUrl *ImageUrl `json:"image_url,omitempty"`
+	ImageURL *ImageURL `json:"image_url,omitempty"`
 }
 
 type TextCompletionResp struct {

--- a/pkg/pinecone/main.go
+++ b/pkg/pinecone/main.go
@@ -140,7 +140,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 	//TODO: change this
 	return pipelinePB.Connector_STATE_CONNECTED, nil
 }

--- a/pkg/redis/chat_history.go
+++ b/pkg/redis/chat_history.go
@@ -29,8 +29,8 @@ type MultiModalMessage struct {
 type MultiModalContent struct {
 	Type     string  `json:"type"`
 	Text     *string `json:"text,omitempty"`
-	ImageUrl *struct {
-		Url string `json:"url"`
+	ImageURL *struct {
+		URL string `json:"url"`
 	} `json:"image_url,omitempty"`
 }
 

--- a/pkg/redis/client.go
+++ b/pkg/redis/client.go
@@ -50,7 +50,7 @@ func (e *VerifyFullSSL) GetConfig() (*tls.Config, error) {
 	// Load client's certificate and private key
 	clientCert, err := tls.X509KeyPair([]byte(e.ClientCert), []byte(e.ClientKey))
 	if err != nil {
-		return nil, fmt.Errorf("Failed to load client certificate and key: %v", err)
+		return nil, fmt.Errorf("failed to load client certificate and key: %v", err)
 	}
 
 	// Setup TLS config
@@ -105,7 +105,7 @@ func getSSLMode(config *structpb.Struct) (SSLModeConfig, error) {
 	case string(VerifyFullSSLMode):
 		sslModeConfig = &VerifyFullSSL{}
 	default:
-		return nil, fmt.Errorf("Invalid SSL mode: %s", mode)
+		return nil, fmt.Errorf("invalid SSL mode: %s", mode)
 	}
 
 	err := base.ConvertFromStructpb(sslMode, sslModeConfig)

--- a/pkg/redis/main.go
+++ b/pkg/redis/main.go
@@ -113,7 +113,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 	client, err := NewClient(config)
 	if err != nil {
 		return pipelinePB.Connector_STATE_ERROR, err

--- a/pkg/restapi/client.go
+++ b/pkg/restapi/client.go
@@ -7,7 +7,7 @@ import (
 )
 
 type TaskInput struct {
-	EndpointUrl string                 `json:"endpoint_url"`
+	EndpointURL string                 `json:"endpoint_url"`
 	Body        map[string]interface{} `json:"body,omitempty"`
 }
 

--- a/pkg/restapi/connector_test.go
+++ b/pkg/restapi/connector_test.go
@@ -79,7 +79,7 @@ func TestConnector_Execute(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 
 		pbIn, err := base.ConvertToStructpb(TaskInput{
-			EndpointUrl: srv.URL + path,
+			EndpointURL: srv.URL + path,
 			Body:        reqBody,
 		})
 		c.Assert(err, qt.IsNil)
@@ -109,7 +109,7 @@ func TestConnector_Execute(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 
 		pbIn, err := base.ConvertToStructpb(TaskInput{
-			EndpointUrl: srv.URL + path,
+			EndpointURL: srv.URL + path,
 			Body:        reqBody,
 		})
 
@@ -141,7 +141,7 @@ func TestConnector_Execute(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 
 		pbIn, err := base.ConvertToStructpb(TaskInput{
-			EndpointUrl: srv.URL + path,
+			EndpointURL: srv.URL + path,
 			Body:        reqBody,
 		})
 		c.Assert(err, qt.IsNil)

--- a/pkg/restapi/main.go
+++ b/pkg/restapi/main.go
@@ -147,7 +147,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 			req.SetBody(taskIn.Body)
 		}
 
-		resp, err := req.Execute(method, taskIn.EndpointUrl)
+		resp, err := req.Execute(method, taskIn.EndpointURL)
 		if err != nil {
 			return nil, err
 		}
@@ -165,7 +165,7 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 	// we don't need to validate the connection since no url setting here
 	return pipelinePB.Connector_STATE_CONNECTED, nil
 }

--- a/pkg/website/main.go
+++ b/pkg/website/main.go
@@ -86,6 +86,6 @@ func (e *Execution) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, erro
 	return outputs, nil
 }
 
-func (c *Connector) Test(defUid uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
+func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.Logger) (pipelinePB.Connector_State, error) {
 	return pipelinePB.Connector_STATE_CONNECTED, nil
 }

--- a/pkg/website/scrape_website.go
+++ b/pkg/website/scrape_website.go
@@ -16,7 +16,7 @@ type PageInfo struct {
 	Link     string `json:"link"`
 	Title    string `json:"title"`
 	LinkText string `json:"link_text"`
-	LinkHtml string `json:"link_html"`
+	LinkHTML string `json:"link_html"`
 }
 
 // ScrapeWebsiteInput defines the input of the scrape website task
@@ -29,8 +29,8 @@ type ScrapeWebsiteInput struct {
 	MaxK int `json:"max_k"`
 	// IncludeLinkText: Whether to include the scraped text of the scraped web page.
 	IncludeLinkText *bool `json:"include_link_text"`
-	// IncludeLinkHtml: Whether to include the scraped HTML of the scraped web page.
-	IncludeLinkHtml *bool `json:"include_link_html"`
+	// IncludeLinkHTML: Whether to include the scraped HTML of the scraped web page.
+	IncludeLinkHTML *bool `json:"include_link_html"`
 }
 
 // ScrapeWebsiteOutput defines the output of the scrape website task
@@ -96,9 +96,9 @@ func getHTMLPageDoc(url string) (*goquery.Document, error) {
 func Scrape(input ScrapeWebsiteInput) (ScrapeWebsiteOutput, error) {
 	output := ScrapeWebsiteOutput{}
 
-	if input.IncludeLinkHtml == nil {
+	if input.IncludeLinkHTML == nil {
 		b := false
-		input.IncludeLinkHtml = &b
+		input.IncludeLinkHTML = &b
 	}
 	if input.IncludeLinkText == nil {
 		b := false
@@ -154,15 +154,15 @@ func Scrape(input ScrapeWebsiteInput) (ScrapeWebsiteOutput, error) {
 			page.Title = title
 			page.Link = strippedURL.String()
 
-			if *input.IncludeLinkHtml || *input.IncludeLinkText {
+			if *input.IncludeLinkHTML || *input.IncludeLinkText {
 				html, err := util.ScrapeWebpageHTML(doc)
 				if err != nil {
 					fmt.Printf("Error scraping HTML from %s: %v", strippedURL.String(), err)
 					return
 				}
 
-				if *input.IncludeLinkHtml {
-					page.LinkHtml = html
+				if *input.IncludeLinkHTML {
+					page.LinkHTML = html
 				}
 
 				if *input.IncludeLinkText {


### PR DESCRIPTION
Because

- We want to standardize the naming convention on variable name with initialisms

This commit

- Enable stylecheck in golangci-lint
- Update variable name
- Add golangci-lint Github Action
- Remove JSON auto-formatter since it will break the readability