### PR TITLE
chore(restapi): update `output_body_schema` description

### DIFF
--- a/pkg/restapi/config/tasks.json
+++ b/pkg/restapi/config/tasks.json
@@ -37,13 +37,13 @@
           "type": "string"
         },
         "output_body_schema": {
-          "description": "The request body",
+          "description": "The JSON schema of output body",
           "instillAcceptFormats": [
             "string"
           ],
           "instillUIMultiline": true,
           "instillMultiline": true,
-          "instillShortDescription": "The request body",
+          "instillShortDescription": "The JSON schema of output body",
           "instillUIOrder": 1,
           "instillUpstreamTypes": [
             "reference",


### PR DESCRIPTION
Because

- The description of `output_body_schema` was wrong.

This commit

- Update `output_body_schema` description
