### PR TITLE
feat(instill): mark `prompt_images` as required in TASK_VISUAL_QUESTION_ANSWERING

### DIFF
--- a/pkg/instill/config/tasks.json
+++ b/pkg/instill/config/tasks.json
@@ -605,6 +605,180 @@
     }
   },
   "TASK_VISUAL_QUESTION_ANSWERING": {
-    "$ref": "#/TASK_TEXT_GENERATION"
+    "input": {
+      "description": "Input",
+      "instillEditOnNodeFields": [
+        "prompt",
+        "prompt_images",
+        "model_name"
+      ],
+      "instillUIOrder": 0,
+      "properties": {
+        "chat_history": {
+          "description": "Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: : {\"role\": \"The message role, i.e. 'system', 'user' or 'assistant'\", \"content\": \"message content\"}.",
+          "instillAcceptFormats": [
+            "structured/chat_messages"
+          ],
+          "instillShortDescription": "Incorporate external chat history, specifically previous messages within the conversation. Please note that System Message will be ignored and will not have any effect when this field is populated. Each message should adhere to the format: : {\"role\": \"The message role, i.e. 'system', 'user' or 'assistant'\", \"content\": \"message content\"}.",
+          "instillUIOrder": 4,
+          "instillUpstreamTypes": [
+            "reference"
+          ],
+          "items": {
+            "$ref": "#/$defs/chat_message"
+          },
+          "title": "Chat history",
+          "type": "array"
+        },
+        "extra_params": {
+          "$ref": "#/$defs/extra_params"
+        },
+        "max_new_tokens": {
+          "default": 50,
+          "description": "The maximum number of tokens for model to generate",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUIOrder": 6,
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "title": "Max new tokens",
+          "type": "integer"
+        },
+        "model_name": {
+          "description": "The Instill Model model to be used.",
+          "instillAcceptFormats": [
+            "string"
+          ],
+          "instillUIOrder": 0,
+          "instillUpstreamTypes": [
+            "value",
+            "reference",
+            "template"
+          ],
+          "title": "Model Name",
+          "type": "string"
+        },
+        "prompt": {
+          "description": "The prompt text",
+          "instillAcceptFormats": [
+            "string"
+          ],
+          "instillUIMultiline": true,
+          "instillUIOrder": 2,
+          "instillUpstreamTypes": [
+            "value",
+            "reference",
+            "template"
+          ],
+          "title": "Prompt",
+          "type": "string"
+        },
+        "prompt_images": {
+          "description": "The prompt images",
+          "instillAcceptFormats": [
+            "array:image/*"
+          ],
+          "instillUIOrder": 3,
+          "instillUpstreamTypes": [
+            "reference"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "title": "Prompt Images",
+          "type": "array"
+        },
+        "seed": {
+          "description": "The seed",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUIOrder": 4,
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "title": "Seed",
+          "type": "integer"
+        },
+        "system_message": {
+          "default": "You are a helpful assistant.",
+          "description": "The system message helps set the behavior of the assistant. For example, you can modify the personality of the assistant or provide specific instructions about how it should behave throughout the conversation. By default, the model\u2019s behavior is using a generic message as \"You are a helpful assistant.\"",
+          "instillAcceptFormats": [
+            "string"
+          ],
+          "instillShortDescription": "The system message helps set the behavior of the assistant",
+          "instillUIMultiline": true,
+          "instillUIOrder": 2,
+          "instillUpstreamTypes": [
+            "value",
+            "reference",
+            "template"
+          ],
+          "title": "System message",
+          "type": "string"
+        },
+        "temperature": {
+          "default": 0.7,
+          "description": "The temperature for sampling",
+          "instillAcceptFormats": [
+            "number"
+          ],
+          "instillUIOrder": 5,
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "title": "Temperature",
+          "type": "number"
+        },
+        "top_k": {
+          "default": 10,
+          "description": "Top k for sampling",
+          "instillAcceptFormats": [
+            "integer"
+          ],
+          "instillUIOrder": 5,
+          "instillUpstreamTypes": [
+            "value",
+            "reference"
+          ],
+          "title": "Top K",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "prompt",
+        "prompt_images",
+        "model_name"
+      ],
+      "title": "Input",
+      "type": "object"
+    },
+    "output": {
+      "description": "Output",
+      "instillEditOnNodeFields": [
+        "text"
+      ],
+      "instillUIOrder": 0,
+      "properties": {
+        "text": {
+          "description": "Text",
+          "instillFormat": "string",
+          "instillUIMultiline": true,
+          "instillUIOrder": 0,
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "title": "Output",
+      "type": "object"
+    }
   }
 }


### PR DESCRIPTION
Because

- `prompt_images` should be marked as required for TASK_VISUAL_QUESTION_ANSWERING

This commit

- mark `prompt_images` as required in TASK_VISUAL_QUESTION_ANSWERING
