### PR TITLE
feat: accept videos in Archetype upload task 

### DIFF
--- a/pkg/archetypeai/config/tasks.json
+++ b/pkg/archetypeai/config/tasks.json
@@ -166,6 +166,7 @@
           "description": "The file to upload. Accepted formats are JPEG and PNG for images or MP4 for videos",
           "type": "string",
           "instillAcceptFormats": [
+            "video/*",
             "image/*"
           ],
           "instillUIOrder": 0,


### PR DESCRIPTION
Because

- Video upload fails on archetype upload task

This commit

- Accept `video/files` on upload task
