### PR TITLE
chore(bigquery,gcs): add `instillUIMultiline` for `json_key`

### DIFF
--- a/pkg/bigquery/config/definitions.json
+++ b/pkg/bigquery/config/definitions.json
@@ -24,6 +24,7 @@
             "description": "Contents of the JSON key file with access to the bucket.",
             "instillCredentialField": true,
             "instillUIOrder": 0,
+            "instillUIMultiline": true,
             "title": "JSON Key File contents",
             "type": "string"
           },

--- a/pkg/googlecloudstorage/config/definitions.json
+++ b/pkg/googlecloudstorage/config/definitions.json
@@ -25,6 +25,7 @@
             "description": "Contents of the JSON key file with access to the bucket.",
             "instillCredentialField": true,
             "instillUIOrder": 1,
+            "instillUIMultiline": true,
             "title": "JSON Key File contents",
             "type": "string"
           }

--- a/pkg/openai/config/tasks.json
+++ b/pkg/openai/config/tasks.json
@@ -385,7 +385,6 @@
           "instillUIOrder": 0,
           "items": {
             "instillFormat": "string",
-            "instillMultiline": true,
             "instillUIMultiline": true,
             "type": "string"
           },

--- a/pkg/restapi/config/tasks.json
+++ b/pkg/restapi/config/tasks.json
@@ -42,7 +42,6 @@
             "string"
           ],
           "instillUIMultiline": true,
-          "instillMultiline": true,
           "instillShortDescription": "The JSON schema of output body",
           "instillUIOrder": 1,
           "instillUpstreamTypes": [
@@ -90,7 +89,6 @@
             "value"
           ],
           "instillUIMultiline": true,
-          "instillMultiline": true,
           "order": 1,
           "required": [],
           "title": "Body",


### PR DESCRIPTION
Because

- We want to use multi-line text field to show `json_key` field.

This commit

- Add `instillUIMultiline` for `json_key`
- Remove deprecated `instillMultiline`
