### PR TITLE
feat(restapi): use `instillFormat: semi-structured/json` for request and response body

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/gocolly/colly/v2 v2.1.0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/h2non/filetype v1.1.3
-	github.com/instill-ai/component v0.10.0-beta.0.20240206082535-b067f9cbaa98
+	github.com/instill-ai/component v0.10.0-beta.0.20240212093359-3dbaa03ff708
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240206062817-a862071d8ece
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/redis/go-redis/v9 v9.3.0

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
-github.com/instill-ai/component v0.10.0-beta.0.20240206082535-b067f9cbaa98 h1:3B9NVpATwjMuOXA3YXDcofZXZscaezxZir4D1NbGQFw=
-github.com/instill-ai/component v0.10.0-beta.0.20240206082535-b067f9cbaa98/go.mod h1:THyROt2dqqge2lDc+PVzm/+LueG4dBtxpLzSjl+T83A=
+github.com/instill-ai/component v0.10.0-beta.0.20240212093359-3dbaa03ff708 h1:DFVCYd2GOQ9dYl9RfzJHMuQ+Ga7R/cfHPwp6LvEKfQI=
+github.com/instill-ai/component v0.10.0-beta.0.20240212093359-3dbaa03ff708/go.mod h1:THyROt2dqqge2lDc+PVzm/+LueG4dBtxpLzSjl+T83A=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240206062817-a862071d8ece h1:Zs8zy+ZgLe8bWRh9E48JaPTB+iS2E7f27OiD0Jjjld8=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240206062817-a862071d8ece/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=

--- a/pkg/restapi/v0/client.go
+++ b/pkg/restapi/v0/client.go
@@ -7,14 +7,14 @@ import (
 )
 
 type TaskInput struct {
-	EndpointURL string                 `json:"endpoint_url"`
-	Body        map[string]interface{} `json:"body,omitempty"`
+	EndpointURL string      `json:"endpoint_url"`
+	Body        interface{} `json:"body,omitempty"`
 }
 
 type TaskOutput struct {
-	StatusCode int                    `json:"status_code"`
-	Body       map[string]interface{} `json:"body"`
-	Header     map[string][]string    `json:"header"`
+	StatusCode int                 `json:"status_code"`
+	Body       interface{}         `json:"body"`
+	Header     map[string][]string `json:"header"`
 }
 
 func newClient(config *structpb.Struct, logger *zap.Logger) (*httpclient.Client, error) {

--- a/pkg/restapi/v0/config/tasks.json
+++ b/pkg/restapi/v0/config/tasks.json
@@ -10,7 +10,7 @@
         "body": {
           "description": "The request body",
           "instillAcceptFormats": [
-            "semi-structured/object"
+            "semi-structured/json"
           ],
           "instillShortDescription": "The request body",
           "instillUIOrder": 1,
@@ -19,8 +19,7 @@
           ],
           "order": 1,
           "required": [],
-          "title": "Body",
-          "type": "object"
+          "title": "Body"
         },
         "endpoint_url": {
           "description": "The API endpoint url",
@@ -107,11 +106,10 @@
       "properties": {
         "body": {
           "description": "The body of the response",
-          "instillFormat": "semi-structured/object",
+          "instillFormat": "semi-structured/json",
           "instillUIOrder": 1,
           "required": [],
-          "title": "Body",
-          "type": "object"
+          "title": "Body"
         },
         "header": {
           "description": "The HTTP header of the response",


### PR DESCRIPTION
Because

- Originally, we used `object` for the request and response body in the RestAPI connector. However, an "array of objects" is also a valid body. We should allow for both.

This commit

- Uses `instillFormat: semi-structured/json` for the request and response body.