### PR TITLE
fix: add missing `array:` instillFormat in connector output

### DIFF
--- a/pkg/huggingface/v0/config/tasks.json
+++ b/pkg/huggingface/v0/config/tasks.json
@@ -335,6 +335,7 @@
             "generated_responses": {
               "description": "List of strings. The last outputs from the model in the conversation, after the model has run.",
               "instillUIOrder": 0,
+              "instillFormat": "array:string",
               "items": {
                 "instillFormat": "string",
                 "instillUIMultiline": true,
@@ -346,6 +347,7 @@
             "past_user_inputs": {
               "description": "List of strings. The last inputs from the user in the conversation, after the model has run.",
               "instillUIOrder": 1,
+              "instillFormat": "array:string",
               "items": {
                 "instillFormat": "string",
                 "instillUIMultiline": true,
@@ -925,6 +927,7 @@
         "scores": {
           "description": "The associated similarity score for each of the given strings",
           "instillUIOrder": 0,
+          "instillFormat": "array:number",
           "items": {
             "instillFormat": "number",
             "type": "number"
@@ -1223,6 +1226,7 @@
         "cells": {
           "description": "a list of coordinates of the cells contents",
           "instillUIOrder": 2,
+          "instillFormat": "array:string",
           "items": {
             "instillFormat": "string",
             "instillUIMultiline": true,
@@ -1239,6 +1243,7 @@
               "instillFormat": "integer",
               "type": "integer"
             },
+            "instillFormat": "array:integer",
             "type": "array"
           },
           "title": "Coordinates",
@@ -1829,6 +1834,7 @@
         "labels": {
           "description": "The list of strings for labels that you sent (in order)",
           "instillUIOrder": 1,
+          "instillFormat": "array:string",
           "items": {
             "instillFormat": "string",
             "type": "string"
@@ -1839,6 +1845,7 @@
         "scores": {
           "description": "a list of floats that correspond the the probability of label, in the same order as labels.",
           "instillUIOrder": 0,
+          "instillFormat": "array:number",
           "items": {
             "instillFormat": "number",
             "type": "number"

--- a/pkg/instill/v0/config/tasks.json
+++ b/pkg/instill/v0/config/tasks.json
@@ -235,6 +235,7 @@
         "images": {
           "description": "Images",
           "instillUIOrder": 0,
+          "instillFormat": "array:image/jpeg",
           "items": {
             "instillFormat": "image/jpeg",
             "type": "string"
@@ -599,6 +600,7 @@
         "images": {
           "description": "Images",
           "instillUIOrder": 0,
+          "instillFormat": "array:image/jpeg",
           "items": {
             "instillFormat": "image/jpeg",
             "type": "string"

--- a/pkg/numbers/v0/config/tasks.json
+++ b/pkg/numbers/v0/config/tasks.json
@@ -178,6 +178,7 @@
           "description": "Asset Urls",
           "instillEnableCopyButton": true,
           "instillUIOrder": 0,
+          "instillFormat": "array:string",
           "items": {
             "instillEnableCopyButton": true,
             "instillFormat": "string",

--- a/pkg/openai/v0/config/tasks.json
+++ b/pkg/openai/v0/config/tasks.json
@@ -383,6 +383,7 @@
       "properties": {
         "texts": {
           "instillUIOrder": 0,
+          "instillFormat": "array:string",
           "items": {
             "instillFormat": "string",
             "instillUIMultiline": true,

--- a/pkg/pinecone/v0/config/tasks.json
+++ b/pkg/pinecone/v0/config/tasks.json
@@ -162,9 +162,11 @@
               "values": {
                 "description": "Vector data values",
                 "instillUIOrder": 2,
+                "instillFormat": "array:number",
                 "items": {
                   "description": "Each float value represents one dimension",
-                  "type": "number"
+                  "type": "number",
+                  "instillFormat": "number"
                 },
                 "title": "Values",
                 "type": "array"

--- a/pkg/stabilityai/v0/config/tasks.json
+++ b/pkg/stabilityai/v0/config/tasks.json
@@ -438,6 +438,7 @@
         "images": {
           "description": "Generated images",
           "instillUIOrder": 0,
+          "instillFormat": "array:image/png",
           "items": {
             "instillFormat": "image/png",
             "type": "string"
@@ -448,6 +449,7 @@
         "seeds": {
           "description": "Seeds of generated images",
           "instillUIOrder": 1,
+          "instillFormat": "array:number",
           "items": {
             "$ref": "stabilityai.json#/components/schemas/Image/properties/seed",
             "instillFormat": "number"


### PR DESCRIPTION
Because

- The console can't display the correct `array` label due to the lack of an array-type `instillFormat`.

This commit

- Adds the missing array-type `instillFormat` in the connector output definition.