### PR TITLE
feat(openai): change default value for `response_format`

### DIFF
--- a/pkg/openai/v0/config/tasks.json
+++ b/pkg/openai/v0/config/tasks.json
@@ -311,6 +311,7 @@
               "instillAcceptFormats": [
                 "string"
               ],
+              "example": "text",
               "instillShortDescription": "Setting to `json_object` enables JSON mode. ",
               "instillUIOrder": 0,
               "instillUpstreamTypes": [


### PR DESCRIPTION
Because

- The majority of the use cases involve returning response in `text` rather than `json_object`.

This commit

- Changes default value for `response_format`
