### PR TITLE
feat: adopt the new GetConnectorDefinition function interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,8 @@ require (
 	github.com/gocolly/colly/v2 v2.1.0
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/h2non/filetype v1.1.3
-	github.com/instill-ai/component v0.12.0-beta.0.20240304105959-85bbc223c1df
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240304063945-0080cc53de5e
+	github.com/instill-ai/component v0.12.0-beta.0.20240307023544-7c27d15e4e01
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240306151355-4398dad0ba73
 	github.com/instill-ai/x v0.4.0-alpha
 	github.com/redis/go-redis/v9 v9.3.0
 	go.uber.org/zap v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -145,10 +145,10 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
 github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
-github.com/instill-ai/component v0.12.0-beta.0.20240304105959-85bbc223c1df h1:T8xczmtdyZXrHW7mVwNXTi/WaBYgPw8wUE1Pm+ptkuc=
-github.com/instill-ai/component v0.12.0-beta.0.20240304105959-85bbc223c1df/go.mod h1:mvySqiBVNAy5wpDZnPdUZ/P1Iaj2BZJmi328hRMS818=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240304063945-0080cc53de5e h1:fHbGDWVbaFFSrqRmy5cKDlBT/8nlsfS5m5LIo3P7Q70=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240304063945-0080cc53de5e/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
+github.com/instill-ai/component v0.12.0-beta.0.20240307023544-7c27d15e4e01 h1:sfbQZD/vun9+UUusZqtCWMpWxvdc7rAD/UsibNrRpZg=
+github.com/instill-ai/component v0.12.0-beta.0.20240307023544-7c27d15e4e01/go.mod h1:Zr3ej9EbkCe+lgSyzKhaqq8+mq84LGGP2F3OWOr/l3c=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240306151355-4398dad0ba73 h1:3YT3WV9F1eltn5x3AhtOuRDO2zY3Aud6nk/som9YQvs=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240306151355-4398dad0ba73/go.mod h1:jhEL0SauySMoPLVvx105DWyThju9sYTbsXIySVCArmM=
 github.com/instill-ai/x v0.4.0-alpha h1:zQV2VLbSHjMv6gyBN/2mwwrvWk0/mJM6ZKS12AzjfQg=
 github.com/instill-ai/x v0.4.0-alpha/go.mod h1:L6jmDPrUou6XskaLXZuK/gDeitdoPa9yE8ONKt1ZwCw=
 github.com/jawher/mow.cli v1.1.0/go.mod h1:aNaQlc7ozF3vw6IJ2dHjp2ZFiA4ozMIYY6PyuRJwlUg=

--- a/pkg/instill/v0/main.go
+++ b/pkg/instill/v0/main.go
@@ -196,13 +196,13 @@ func (c *Connector) Test(_ uuid.UUID, config *structpb.Struct, logger *zap.Logge
 	return pipelinePB.Connector_STATE_CONNECTED, nil
 }
 
-func (c *Connector) GetConnectorDefinitionByID(defID string, resourceConfig *structpb.Struct, componentConfig *structpb.Struct) (*pipelinePB.ConnectorDefinition, error) {
-	def, err := c.Connector.GetConnectorDefinitionByID(defID, resourceConfig, componentConfig)
+func (c *Connector) GetConnectorDefinitionByID(defID string, resourceConfig *structpb.Struct, component *pipelinePB.ConnectorComponent) (*pipelinePB.ConnectorDefinition, error) {
+	def, err := c.Connector.GetConnectorDefinitionByID(defID, resourceConfig, component)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.GetConnectorDefinitionByUID(uuid.FromStringOrNil(def.Uid), resourceConfig, componentConfig)
+	return c.GetConnectorDefinitionByUID(uuid.FromStringOrNil(def.Uid), resourceConfig, component)
 }
 
 type ModelsResp struct {
@@ -213,8 +213,8 @@ type ModelsResp struct {
 }
 
 // Generate the model_name enum based on the task
-func (c *Connector) GetConnectorDefinitionByUID(defUID uuid.UUID, resourceConfig *structpb.Struct, componentConfig *structpb.Struct) (*pipelinePB.ConnectorDefinition, error) {
-	oriDef, err := c.Connector.GetConnectorDefinitionByUID(defUID, resourceConfig, componentConfig)
+func (c *Connector) GetConnectorDefinitionByUID(defUID uuid.UUID, resourceConfig *structpb.Struct, component *pipelinePB.ConnectorComponent) (*pipelinePB.ConnectorDefinition, error) {
+	oriDef, err := c.Connector.GetConnectorDefinitionByUID(defUID, resourceConfig, component)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -85,10 +85,10 @@ func (c *Connector) Test(defUID uuid.UUID, config *structpb.Struct, logger *zap.
 	return c.connectorUIDMap[defUID].Test(defUID, config, logger)
 }
 
-func (c *Connector) GetConnectorDefinitionByID(defID string, resourceConfig *structpb.Struct, componentConfig *structpb.Struct) (*pipelinePB.ConnectorDefinition, error) {
-	return c.connectorIDMap[defID].GetConnectorDefinitionByID(defID, resourceConfig, componentConfig)
+func (c *Connector) GetConnectorDefinitionByID(defID string, resourceConfig *structpb.Struct, component *pipelinePB.ConnectorComponent) (*pipelinePB.ConnectorDefinition, error) {
+	return c.connectorIDMap[defID].GetConnectorDefinitionByID(defID, resourceConfig, component)
 }
 
-func (c *Connector) GetConnectorDefinitionByUID(defUID uuid.UUID, resourceConfig *structpb.Struct, componentConfig *structpb.Struct) (*pipelinePB.ConnectorDefinition, error) {
-	return c.connectorUIDMap[defUID].GetConnectorDefinitionByUID(defUID, resourceConfig, componentConfig)
+func (c *Connector) GetConnectorDefinitionByUID(defUID uuid.UUID, resourceConfig *structpb.Struct, component *pipelinePB.ConnectorComponent) (*pipelinePB.ConnectorDefinition, error) {
+	return c.connectorUIDMap[defUID].GetConnectorDefinitionByUID(defUID, resourceConfig, component)
 }


### PR DESCRIPTION
Because

- Related to https://github.com/instill-ai/component/pull/64, we simplifies `openapi_specification` into `data_specification` by preserving only the input and output JSON schema and removing the nested structure of the OpenAPI spec. We need to adopt this change.

This commit

- Adopts the new GetConnectorDefinition function interface.