### PR TITLE
chore(openai): add missing title in TASK_TEXT_TO_IMAGE

### DIFF
--- a/pkg/openai/v0/config/tasks.json
+++ b/pkg/openai/v0/config/tasks.json
@@ -504,11 +504,13 @@
             "description": "Generated result",
             "properties": {
               "image": {
+                "title": "Generated Image",
                 "description": "Generated image",
                 "instillFormat": "image/webp",
                 "type": "string"
               },
               "revised_prompt": {
+                "title": "Revised Prompt",
                 "description": "Revised prompt",
                 "instillFormat": "string",
                 "instillUIMultiline": true,


### PR DESCRIPTION
Because

- Some titles in TASK_TEXT_TO_IMAGE was missing.

This commit

- Adds missing title in TASK_TEXT_TO_IMAGE.
