### PR TITLE
chore: add release_stage field to definitions

### DIFF
--- a/pkg/airbyte/v0/config/definitions.json
+++ b/pkg/airbyte/v0/config/definitions.json
@@ -11929,6 +11929,7 @@
       "airbyte-devmate-cloud": "ghcr.io/devmate-cloud/streamr-airbyte-connectors:0.0.1"
     },
     "version": "0.1.0-alpha",
-    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/airbyte/v0"
+    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/airbyte/v0",
+    "release_stage": "RELEASE_STAGE_ALPHA"
   }
 ]

--- a/pkg/archetypeai/v0/config/definitions.json
+++ b/pkg/archetypeai/v0/config/definitions.json
@@ -39,6 +39,7 @@
     "vendor": "Archetype AI",
     "vendor_attributes": {},
     "version": "0.1.0-alpha",
-    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/archetypeai/v0"
+    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/archetypeai/v0",
+    "release_stage": "RELEASE_STAGE_ALPHA"
   }
 ]

--- a/pkg/bigquery/v0/config/definitions.json
+++ b/pkg/bigquery/v0/config/definitions.json
@@ -59,6 +59,7 @@
     "vendor": "Google",
     "vendor_attributes": {},
     "version": "0.1.0-alpha",
-    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/bigquery/v0"
+    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/bigquery/v0",
+    "release_stage": "RELEASE_STAGE_ALPHA"
   }
 ]

--- a/pkg/googlecloudstorage/v0/config/definitions.json
+++ b/pkg/googlecloudstorage/v0/config/definitions.json
@@ -46,6 +46,7 @@
     "vendor": "Google",
     "vendor_attributes": {},
     "version": "0.1.0-alpha",
-    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/googlecloudstorage/v0"
+    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/googlecloudstorage/v0",
+    "release_stage": "RELEASE_STAGE_ALPHA"
   }
 ]

--- a/pkg/googlesearch/v0/config/definitions.json
+++ b/pkg/googlesearch/v0/config/definitions.json
@@ -45,6 +45,7 @@
     "vendor": "Google",
     "vendor_attributes": {},
     "version": "0.1.0-alpha",
-    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/googlesearch/v0"
+    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/googlesearch/v0",
+    "release_stage": "RELEASE_STAGE_ALPHA"
   }
 ]

--- a/pkg/huggingface/v0/config/definitions.json
+++ b/pkg/huggingface/v0/config/definitions.json
@@ -71,6 +71,7 @@
     "vendor": "Hugging Face",
     "vendor_attributes": {},
     "version": "0.1.0-alpha",
-    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/huggingface/v0"
+    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/huggingface/v0",
+    "release_stage": "RELEASE_STAGE_ALPHA"
   }
 ]

--- a/pkg/instill/v0/config/definitions.json
+++ b/pkg/instill/v0/config/definitions.json
@@ -71,6 +71,7 @@
     "vendor": "Instill",
     "vendor_attributes": {},
     "version": "0.1.0-alpha",
-    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/instill/v0"
+    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/instill/v0",
+    "release_stage": "RELEASE_STAGE_ALPHA"
   }
 ]

--- a/pkg/numbers/v0/config/definitions.json
+++ b/pkg/numbers/v0/config/definitions.json
@@ -37,6 +37,7 @@
     "vendor": "Numbers Protocol",
     "vendor_attributes": {},
     "version": "0.1.0-alpha",
-    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/numbers/v0"
+    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/numbers/v0",
+    "release_stage": "RELEASE_STAGE_ALPHA"
   }
 ]

--- a/pkg/openai/v0/config/definitions.json
+++ b/pkg/openai/v0/config/definitions.json
@@ -46,6 +46,7 @@
     "vendor": "OpenAI",
     "vendor_attributes": {},
     "version": "0.1.0-alpha",
-    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/openai/v0"
+    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/openai/v0",
+    "release_stage": "RELEASE_STAGE_ALPHA"
   }
 ]

--- a/pkg/pinecone/v0/config/definitions.json
+++ b/pkg/pinecone/v0/config/definitions.json
@@ -46,6 +46,7 @@
     "vendor": "Pinecone",
     "vendor_attributes": {},
     "version": "0.1.0-alpha",
-    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/pinecone/v0"
+    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/pinecone/v0",
+    "release_stage": "RELEASE_STAGE_ALPHA"
   }
 ]

--- a/pkg/redis/v0/config/definitions.json
+++ b/pkg/redis/v0/config/definitions.json
@@ -157,6 +157,7 @@
     "vendor": "Redis Labs",
     "vendor_attributes": {},
     "version": "0.1.0-alpha",
-    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/redis/v0"
+    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/redis/v0",
+    "release_stage": "RELEASE_STAGE_ALPHA"
   }
 ]

--- a/pkg/restapi/v0/config/definitions.json
+++ b/pkg/restapi/v0/config/definitions.json
@@ -162,6 +162,7 @@
     "vendor": "",
     "vendor_attributes": {},
     "version": "0.1.0-alpha",
-    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/restapi/v0"
+    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/restapi/v0",
+    "release_stage": "RELEASE_STAGE_ALPHA"
   }
 ]

--- a/pkg/stabilityai/v0/config/definitions.json
+++ b/pkg/stabilityai/v0/config/definitions.json
@@ -38,6 +38,7 @@
     "vendor": "Stability AI",
     "vendor_attributes": {},
     "version": "0.1.0-alpha",
-    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/stabilityai/v0"
+    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/stabilityai/v0",
+    "release_stage": "RELEASE_STAGE_ALPHA"
   }
 ]

--- a/pkg/website/v0/config/definitions.json
+++ b/pkg/website/v0/config/definitions.json
@@ -26,6 +26,7 @@
     "vendor": "",
     "vendor_attributes": {},
     "version": "0.1.0-alpha",
-    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/website/v0"
+    "source_url": "https://github.com/instill-ai/connector/blob/main/pkg/website/v0",
+    "release_stage": "RELEASE_STAGE_ALPHA"
   }
 ]


### PR DESCRIPTION
Because

- With https://github.com/instill-ai/pipeline-backend/pull/414 the `release_stage` property will be displayed and filtered by in the component definition lists.

This commit

- Adds the release property for the existing connectors

## Next steps ⏭️ 

- This field, along with others, will be documented so it is clear how to set it in new contributions.
- In the console connector and operator lists, unimplemented components will be hidden.
